### PR TITLE
rename blob settings

### DIFF
--- a/src/Ignixa.Api/appsettings.json
+++ b/src/Ignixa.Api/appsettings.json
@@ -12,19 +12,13 @@
     "BaseDirectory": "fhir-data"
   },
   "BlobStorage": {
-    "_Comment": "Provider selection: 'Local' for filesystem, 'Azure' for Azure Blob Storage. Override in production with 'Azure'.",
-    "Provider": "Local"
-  },
-  "LocalFileBlobStorage": {
-    "_Comment": "Local filesystem blob storage (used when Provider = 'Local')",
-    "RootDirectory": "fhir-exports"
-  },
-  "AzureBlobStorage": {
-    "_Comment": "Azure Blob Storage configuration (used when Provider = 'Azure'). Set connection string via environment variable or Azure Key Vault in production.",
-    "ConnectionString": "",
+    "_Comment": "Unified blob storage configuration. Provider: 'Local' for filesystem, 'Azure' for Azure Blob Storage. Environment variable overrides: BlobStorage__Provider, BlobStorage__UseManagedIdentity, etc.",
+    "Provider": "Local",
+    "RootDirectory": "fhir-exports",
     "ContainerName": "fhirstorage",
     "UseManagedIdentity": true,
-    "StorageAccountUri": "https://yourAccount.blob.core.windows.net"
+    "StorageAccountUri": "https://yourAccount.blob.core.windows.net",
+    "ConnectionString": ""
   },
   "DurableTask": {
     "_Comment": "DurableTask orchestration backend: 'FileSystem' for dev, 'AzureStorage' for cloud",

--- a/src/Ignixa.DataLayer.BlobStorage/Infrastructure/AzureBlobStorageClient.cs
+++ b/src/Ignixa.DataLayer.BlobStorage/Infrastructure/AzureBlobStorageClient.cs
@@ -192,34 +192,3 @@ public partial class AzureBlobStorageClient : IBlobStorageClient
     }
 }
 
-/// <summary>
-/// Configuration options for <see cref="AzureBlobStorageClient"/>.
-/// </summary>
-public class AzureBlobStorageOptions
-{
-    /// <summary>
-    /// Connection string for Azure Blob Storage.
-    /// Can use "UseDevelopmentStorage=true" for Azurite emulator locally.
-    /// Example: "UseDevelopmentStorage=true" or "DefaultEndpointsProtocol=https;AccountName=xxx;AccountKey=xxx;EndpointSuffix=core.windows.net"
-    /// </summary>
-    public string? ConnectionString { get; set; }
-
-    /// <summary>
-    /// Azure Blob Storage container name where resources are stored.
-    /// Example: "fhir-storage" or "fhir-exports"
-    /// </summary>
-    public string? ContainerName { get; set; }
-
-    /// <summary>
-    /// Whether to use Managed Identity for authentication (Azure AD).
-    /// If true, ConnectionString is ignored and Managed Identity is used.
-    /// Default: false (uses ConnectionString)
-    /// </summary>
-    public bool UseManagedIdentity { get; set; }
-
-    /// <summary>
-    /// Azure storage account URI for Managed Identity auth.
-    /// Example: "https://myaccount.blob.core.windows.net"
-    /// </summary>
-    public string? StorageAccountUri { get; set; }
-}

--- a/src/Ignixa.DataLayer.BlobStorage/Infrastructure/BlobClientFactory.cs
+++ b/src/Ignixa.DataLayer.BlobStorage/Infrastructure/BlobClientFactory.cs
@@ -55,7 +55,7 @@ public class BlobClientFactory
         _logger.LogInformation("Creating local file-based blob storage client");
 
         var options = new LocalFileBlobStorageOptions();
-        _configuration.GetSection("LocalFileBlobStorage").Bind(options);
+        _configuration.GetSection("BlobStorage").Bind(options);
 
         var logger = _serviceProvider.GetRequiredService<ILogger<LocalFileBlobClient>>();
         return new LocalFileBlobClient(Microsoft.Extensions.Options.Options.Create(options), logger);
@@ -69,11 +69,11 @@ public class BlobClientFactory
         _logger.LogInformation("Creating Azure Blob Storage client");
 
         var options = new AzureBlobStorageOptions();
-        _configuration.GetSection("AzureBlobStorage").Bind(options);
+        _configuration.GetSection("BlobStorage").Bind(options);
 
         if (string.IsNullOrEmpty(options.ContainerName))
         {
-            throw new InvalidOperationException("AzureBlobStorage:ContainerName is required when using Azure provider");
+            throw new InvalidOperationException("BlobStorage:ContainerName is required when using Azure provider");
         }
 
         BlobServiceClient blobServiceClient;
@@ -88,7 +88,7 @@ public class BlobClientFactory
         {
             if (string.IsNullOrEmpty(options.StorageAccountUri))
             {
-                throw new InvalidOperationException("AzureBlobStorage:StorageAccountUri is required when using Managed Identity");
+                throw new InvalidOperationException("BlobStorage:StorageAccountUri is required when using Managed Identity");
             }
 
             _logger.LogDebug("Using Managed Identity for Azure Blob Storage authentication");
@@ -122,7 +122,7 @@ public class BlobClientFactory
         {
             if (string.IsNullOrEmpty(options.ConnectionString))
             {
-                throw new InvalidOperationException("AzureBlobStorage:ConnectionString is required when UseManagedIdentity is false");
+                throw new InvalidOperationException("BlobStorage:ConnectionString is required when UseManagedIdentity is false");
             }
 
             _logger.LogDebug("Using connection string for Azure Blob Storage authentication");
@@ -157,14 +157,14 @@ public class BlobClientFactory
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        // Register configuration options
+        // Register configuration options from unified BlobStorage section
         services.Configure<LocalFileBlobStorageOptions>(options =>
         {
-            configuration.GetSection("LocalFileBlobStorage").Bind(options);
+            configuration.GetSection("BlobStorage").Bind(options);
         });
         services.Configure<AzureBlobStorageOptions>(options =>
         {
-            configuration.GetSection("AzureBlobStorage").Bind(options);
+            configuration.GetSection("BlobStorage").Bind(options);
         });
 
         // Register factory
@@ -180,4 +180,69 @@ public class BlobClientFactory
 
         return services;
     }
+}
+
+/// <summary>
+/// Configuration options for Azure Blob Storage client.
+/// Supports both connection string and Managed Identity authentication.
+/// </summary>
+public class AzureBlobStorageOptions
+{
+    /// <summary>
+    /// Connection string for Azure Blob Storage.
+    /// Can use "UseDevelopmentStorage=true" for Azurite emulator locally.
+    /// Example: "UseDevelopmentStorage=true" or "DefaultEndpointsProtocol=https;AccountName=xxx;AccountKey=xxx;EndpointSuffix=core.windows.net"
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Azure Blob Storage container name where resources are stored.
+    /// Example: "fhir-storage" or "fhir-exports"
+    /// </summary>
+    public string? ContainerName { get; set; }
+
+    /// <summary>
+    /// Whether to use Managed Identity for authentication (Azure AD).
+    /// If true, ConnectionString is ignored and Managed Identity is used.
+    /// Default: false (uses ConnectionString)
+    /// </summary>
+    public bool UseManagedIdentity { get; set; }
+
+    /// <summary>
+    /// Azure storage account URI for Managed Identity auth.
+    /// Example: "https://myaccount.blob.core.windows.net"
+    /// </summary>
+    public string? StorageAccountUri { get; set; }
+}
+
+/// <summary>
+/// Configuration options for local file-based blob storage client.
+/// </summary>
+public class LocalFileBlobStorageOptions
+{
+    /// <summary>
+    /// Root directory where blobs are stored.
+    /// Example: "C:/FhirData/exports" or "/var/fhir/exports"
+    /// </summary>
+    public string? RootDirectory { get; set; }
+
+    /// <summary>
+    /// Azure Blob Storage container name (unused for local storage, kept for compatibility with unified BlobStorage config).
+    /// </summary>
+    public string? ContainerName { get; set; }
+
+    /// <summary>
+    /// Whether to use Managed Identity (unused for local storage, kept for compatibility with unified BlobStorage config).
+    /// </summary>
+    public bool UseManagedIdentity { get; set; }
+
+    /// <summary>
+    /// Storage account URI (unused for local storage, kept for compatibility with unified BlobStorage config).
+    /// </summary>
+    public string? StorageAccountUri { get; set; }
+
+    /// <summary>
+    /// Connection string (unused for local storage, kept for compatibility with unified BlobStorage config).
+    /// </summary>
+    public string? ConnectionString { get; set; }
 }

--- a/src/Ignixa.DataLayer.BlobStorage/Infrastructure/LocalFileBlobClient.cs
+++ b/src/Ignixa.DataLayer.BlobStorage/Infrastructure/LocalFileBlobClient.cs
@@ -205,14 +205,3 @@ public partial class LocalFileBlobClient : IBlobStorageClient
     }
 }
 
-/// <summary>
-/// Configuration options for <see cref="LocalFileBlobClient"/>.
-/// </summary>
-public class LocalFileBlobStorageOptions
-{
-    /// <summary>
-    /// Root directory where blobs are stored.
-    /// Example: "C:/FhirData/exports" or "/var/fhir/exports"
-    /// </summary>
-    public string? RootDirectory { get; set; }
-}


### PR DESCRIPTION
This pull request refactors the blob storage configuration to unify the settings for both local and Azure providers under a single `BlobStorage` section in `appsettings.json`. It also updates the codebase to use this unified configuration, simplifying the setup and improving maintainability. Additionally, the configuration option classes have been moved and expanded to support compatibility with the new unified approach.

**Configuration unification and code updates:**

* Combined the separate `LocalFileBlobStorage` and `AzureBlobStorage` sections in `appsettings.json` into a single `BlobStorage` section, consolidating all relevant settings and comments.
* Updated configuration binding in `BlobClientFactory.cs` to use the unified `BlobStorage` section for both local and Azure blob storage client creation, replacing references to the old separate sections. [[1]](diffhunk://#diff-7769f00ea972ae244166f4adb51c0c8469d33cf6b084cdc21971c9056cd40535L58-R58) [[2]](diffhunk://#diff-7769f00ea972ae244166f4adb51c0c8469d33cf6b084cdc21971c9056cd40535L72-R76) [[3]](diffhunk://#diff-7769f00ea972ae244166f4adb51c0c8469d33cf6b084cdc21971c9056cd40535L91-R91) [[4]](diffhunk://#diff-7769f00ea972ae244166f4adb51c0c8469d33cf6b084cdc21971c9056cd40535L125-R125) [[5]](diffhunk://#diff-7769f00ea972ae244166f4adb51c0c8469d33cf6b084cdc21971c9056cd40535L160-R167)

**Configuration option class refactoring:**

* Moved and expanded `AzureBlobStorageOptions` and `LocalFileBlobStorageOptions` classes to support all unified configuration properties, including compatibility fields for both providers.
* Removed the old configuration option classes from their previous locations in the Azure and local blob client files. [[1]](diffhunk://#diff-42d6b17b44457a99fa1b5c4eb09f9fe2bbe4484ac92be0c8d70ebc43a5bdc793L195-L225) [[2]](diffhunk://#diff-b9153de3d88fc5678dac4847c212b91ed0cee5a5a589376d1121fb3da71ffdf7L208-L218)