### PR TITLE
Fixes date sorting

### DIFF
--- a/src/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleSerializer.cs
+++ b/src/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleSerializer.cs
@@ -753,9 +753,34 @@ public static class StreamingBundleSerializer
         // Parse query string
         var parsedQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(queryWithoutPrefix);
 
+        // Build set of unsupported parameter keys (including special handling for _sort=fieldName)
+        var unsupportedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unsupportedSortFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var unsupported in unsupportedParams)
+        {
+            if (unsupported.StartsWith("_sort=", StringComparison.OrdinalIgnoreCase))
+            {
+                // Track unsupported sort fields (e.g., "invalidField" from "_sort=invalidField")
+                string fieldName = unsupported.Substring("_sort=".Length);
+                unsupportedSortFields.Add(fieldName);
+            }
+            else
+            {
+                // Regular unsupported parameter key (e.g., "_sort" or "name")
+                unsupportedKeys.Add(unsupported);
+            }
+        }
+
+        // If any sort field is unsupported, the entire _sort parameter is unsupported
+        if (unsupportedSortFields.Count > 0)
+        {
+            unsupportedKeys.Add("_sort");
+        }
+
         // Filter out unsupported parameters
         var filteredQuery = parsedQuery
-            .Where(kvp => !unsupportedParams.Contains(kvp.Key, StringComparer.OrdinalIgnoreCase))
+            .Where(kvp => !unsupportedKeys.Contains(kvp.Key))
             .SelectMany(kvp => kvp.Value.Select(v => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(v ?? string.Empty)}"));
 
         string result = string.Join("&", filteredQuery);

--- a/src/Ignixa.DataLayer.SqlEntityFramework/Search/SqlEntityFrameworkSearchService.cs
+++ b/src/Ignixa.DataLayer.SqlEntityFramework/Search/SqlEntityFrameworkSearchService.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ignixa.DataLayer.SqlEntityFramework.Compression;
 using Ignixa.DataLayer.SqlEntityFramework.Entities;
+using Ignixa.DataLayer.SqlEntityFramework.Indexing;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Models;
 using Ignixa.Search.Expressions;
@@ -29,6 +30,7 @@ public class SqlEntityFrameworkSearchService : ISearchService
     private readonly IterateProcessor _iterateProcessor;
     private readonly GzipResourceCompressor _compressor;
     private readonly ILogger<SqlEntityFrameworkSearchService> _logger;
+    private readonly SearchIndexReferenceDataCache _cache;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlEntityFrameworkSearchService"/> class.
@@ -40,6 +42,7 @@ public class SqlEntityFrameworkSearchService : ISearchService
     /// <param name="revIncludeProcessor">The revinclude processor for _revinclude.</param>
     /// <param name="iterateProcessor">The iterate processor for :iterate modifier.</param>
     /// <param name="compressor">The resource compressor for decompressing RawResource bytes.</param>
+    /// <param name="cache">The search index reference data cache for looking up SearchParamIds.</param>
     /// <param name="logger">Logger instance.</param>
     public SqlEntityFrameworkSearchService(
         FhirDbContext context,
@@ -49,6 +52,7 @@ public class SqlEntityFrameworkSearchService : ISearchService
         RevIncludeProcessor revIncludeProcessor,
         IterateProcessor iterateProcessor,
         GzipResourceCompressor compressor,
+        SearchIndexReferenceDataCache cache,
         ILogger<SqlEntityFrameworkSearchService> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
@@ -58,6 +62,7 @@ public class SqlEntityFrameworkSearchService : ISearchService
         _revIncludeProcessor = revIncludeProcessor ?? throw new ArgumentNullException(nameof(revIncludeProcessor));
         _iterateProcessor = iterateProcessor ?? throw new ArgumentNullException(nameof(iterateProcessor));
         _compressor = compressor ?? throw new ArgumentNullException(nameof(compressor));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -398,8 +403,13 @@ public class SqlEntityFrameworkSearchService : ISearchService
         if (sortOptions == null || sortOptions.Count == 0)
         {
             // Default sort: by ResourceSurrogateId ascending (oldest first)
+            _logger.LogDebug("No sort options provided, using default sort by ResourceSurrogateId");
             return query.OrderBy(r => r.ResourceSurrogateId);
         }
+
+        _logger.LogDebug("Applying {Count} sort expression(s): {Sorts}",
+            sortOptions.Count,
+            string.Join(", ", sortOptions.Select(s => $"{s.Parameter.Code} ({s.SortOrder})")));
 
         // Apply primary sort
         var firstSort = sortOptions[0];
@@ -410,6 +420,13 @@ public class SqlEntityFrameworkSearchService : ISearchService
         {
             orderedQuery = ApplyThenBy(orderedQuery, sortOptions[i]);
         }
+
+        // CRITICAL: Always add final sort by ResourceSurrogateId for deterministic ordering
+        // This ensures:
+        // 1. Resources with NULL values for the sort parameter have consistent positioning
+        // 2. Pagination with continuation tokens is stable (same query = same order)
+        // 3. Multiple resources with identical sort values are ordered predictably
+        orderedQuery = orderedQuery.ThenBy(r => r.ResourceSurrogateId);
 
         return orderedQuery;
     }
@@ -444,7 +461,9 @@ public class SqlEntityFrameworkSearchService : ISearchService
         {
             case SearchParamType.String:
                 // LEFT JOIN with StringSearchParam, use MIN/MAX aggregation for multi-value parameters
-                // Nulls (resources without this parameter) sort last
+                // NOTE: SQL Server default behavior - NULLs sort FIRST in ascending, LAST in descending
+                // Resources without this parameter will appear at beginning (ASC) or end (DESC)
+                // Final ThenBy(ResourceSurrogateId) ensures deterministic ordering for NULL values
                 return isDescending
                     ? query.OrderByDescending(r =>
                         _context.StringSearchParams
@@ -840,5 +859,30 @@ public class SqlEntityFrameworkSearchService : ISearchService
             .FirstOrDefaultAsync(rt => rt.Name == resourceType, ct);
 
         return entity?.ResourceTypeId;
+    }
+
+    /// <summary>
+    /// Gets the SearchParamId for a given search parameter URL.
+    /// This is a synchronous wrapper around the async cache lookup.
+    /// IMPORTANT: This method is called inside EF Core LINQ expressions, which means we CANNOT use async/await
+    /// (LINQ to SQL requires synchronous expressions). We use .GetAwaiter().GetResult() to block synchronously.
+    /// The cache has an in-memory dictionary, so this is typically fast (only first call may hit database).
+    /// </summary>
+    /// <param name="url">The search parameter URL (e.g., "http://hl7.org/fhir/SearchParameter/Patient-birthdate").</param>
+    /// <returns>The SearchParamId (short).</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the search parameter is not found in the database.</exception>
+#pragma warning disable CA2012 // Use ValueTasks correctly - Must block synchronously in EF LINQ expression context
+    private short GetSearchParamIdFromUrl(string url)
+    {
+        var result = _cache.GetSearchParamIdAsync(url).GetAwaiter().GetResult();
+#pragma warning restore CA2012
+
+        if (result == null)
+        {
+            _logger.LogError("Search parameter not found for URL: {Url}. Ensure search parameters are loaded in database.", url);
+            throw new InvalidOperationException($"Search parameter not found for URL: {url}");
+        }
+
+        return result.Value;
     }
 }

--- a/src/Ignixa.DataLayer.SqlEntityFramework/SqlEntityFrameworkRepositoryFactory.cs
+++ b/src/Ignixa.DataLayer.SqlEntityFramework/SqlEntityFrameworkRepositoryFactory.cs
@@ -343,6 +343,7 @@ public class SqlEntityFrameworkRepositoryFactory : IFhirRepositoryFactory, ISear
                 revIncludeProcessor,
                 iterateProcessor,
                 compressor,
+                searchIndexCache,
                 _loggerFactory.CreateLogger<Search.SqlEntityFrameworkSearchService>());
         };
 

--- a/src/Ignixa.Search/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Ignixa.Search/Definition/SearchParameterDefinitionManager.cs
@@ -67,7 +67,7 @@ public class SearchParameterDefinitionManager : ISearchParameterDefinitionManage
                 {
                     continue;
                 }
-                
+
                 var applicableTypes = ExpandBaseResourceTypes(param.BaseResourceTypes, resourceTypes);
                 foreach (var resourceType in applicableTypes)
                 {

--- a/src/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
+++ b/src/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
@@ -7,6 +7,7 @@
 
 using EnsureThat;
 using Ignixa.Domain.Constants;
+using Ignixa.Search.Definition;
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Expressions.Parsers;
 using Ignixa.Search.Indexing;
@@ -24,15 +25,21 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
     private const int MaxAllowedItemCount = 1000;
 
     private readonly IExpressionParser _expressionParser;
+    private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchOptionsBuilder"/> class.
     /// </summary>
     /// <param name="expressionParser">The expression parser for building search expressions.</param>
-    public SearchOptionsBuilder(IExpressionParser expressionParser)
+    /// <param name="searchParameterDefinitionManager">The search parameter definition manager for looking up parameter metadata.</param>
+    public SearchOptionsBuilder(
+        IExpressionParser expressionParser,
+        ISearchParameterDefinitionManager searchParameterDefinitionManager)
     {
         EnsureArg.IsNotNull(expressionParser, nameof(expressionParser));
+        EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
         _expressionParser = expressionParser;
+        _searchParameterDefinitionManager = searchParameterDefinitionManager;
     }
 
     /// <summary>
@@ -148,7 +155,7 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
         // STEP 3: Parse sorting
         if (sortParameters.Count > 0)
         {
-            options.Sort = ParseSortParameters(resourceTypes, sortParameters);
+            options.Sort = ParseSortParameters(resourceTypes, sortParameters, unsupportedParameters);
         }
 
         // STEP 4: Parse includes
@@ -226,7 +233,10 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
         };
     }
 
-    private IReadOnlyList<SortExpression> ParseSortParameters(string[] resourceTypes, List<string> sortParameters)
+    private IReadOnlyList<SortExpression> ParseSortParameters(
+        string[] resourceTypes,
+        List<string> sortParameters,
+        List<string> unsupportedParameters)
     {
         var sortExpressions = new List<SortExpression>();
 
@@ -251,22 +261,30 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
 
                 try
                 {
-                    // Parse the field as a search parameter to get the SearchParameterInfo
-                    Expression fieldExpression = _expressionParser.Parse(resourceTypes, fieldName, "dummy");
-
-                    if (fieldExpression is SearchParameterExpression searchParamExpr)
+                    // Look up the search parameter directly (no need to parse a value for sorting)
+                    // For sorting, we only need the SearchParameterInfo metadata, not a parsed value expression
+                    if (!_searchParameterDefinitionManager.TryGetSearchParameter(resourceTypes[0], fieldName, out SearchParameterInfo searchParameter))
                     {
-                        sortExpressions.Add(new SortExpression(searchParamExpr.Parameter, sortOrder));
+                        // Field is not a valid search parameter - record the unsupported field
+                        System.Diagnostics.Debug.WriteLine($"Sort field '{fieldName}' is not supported for resource type: {resourceTypes[0]}");
+                        unsupportedParameters.Add($"_sort={fieldName}");
+                        continue;
                     }
+
+                    sortExpressions.Add(new SortExpression(searchParameter, sortOrder));
+                    System.Diagnostics.Debug.WriteLine($"✅ Added sort expression: {searchParameter.Code} ({searchParameter.Type}) {sortOrder}");
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Skip invalid sort parameters
+                    // Log other exceptions for debugging, add to unsupported, then skip
+                    System.Diagnostics.Debug.WriteLine($"Failed to parse sort field '{fieldName}': {ex.GetType().Name} - {ex.Message}");
+                    unsupportedParameters.Add($"_sort={fieldName}");
                     continue;
                 }
             }
         }
 
+        System.Diagnostics.Debug.WriteLine($"ParseSortParameters returning {sortExpressions.Count} sort expression(s)");
         return sortExpressions;
     }
 

--- a/src/Ignixa.Search/Parsing/SearchOptionsBuilderFactory.cs
+++ b/src/Ignixa.Search/Parsing/SearchOptionsBuilderFactory.cs
@@ -92,7 +92,7 @@ public sealed class SearchOptionsBuilderFactory : ISearchOptionsBuilderFactory, 
                 schemaProvider);
 
             // Create version-specific SearchOptionsBuilder
-            var builder = new SearchOptionsBuilder(expressionParser);
+            var builder = new SearchOptionsBuilder(expressionParser, searchParamDefinitionManager);
 
             // Cache and return
             // Phase 2+: This cache will hold separate builders for (tenant, version) pairs


### PR DESCRIPTION
This pull request introduces several improvements to search parameter handling and sorting logic in the Ignixa application. The main changes focus on more robust filtering of unsupported search parameters, improved sort expression validation, deterministic sorting in database queries, and better dependency management for search parameter metadata. These updates enhance both correctness and maintainability of search-related code.

**Search parameter filtering and sort validation:**
- Improved filtering of unsupported query parameters, especially handling `_sort=fieldName` by identifying unsupported sort fields and ensuring the entire `_sort` parameter is excluded if any sort field is unsupported. (`StreamingBundleSerializer.cs`)
- Enhanced sort expression parsing to validate sort fields against available search parameters, recording unsupported fields in the `unsupportedParameters` list. Invalid sort fields are now properly ignored, and debug logging is added for easier troubleshooting. (`SearchOptionsBuilder.cs`)

**Sorting logic and deterministic ordering:**
- Updated sorting logic in `SqlEntityFrameworkSearchService` to always append a final sort by `ResourceSurrogateId`, ensuring deterministic ordering for resources with identical or NULL sort values, which is critical for stable pagination and predictable results. [[1]](diffhunk://#diff-7b0e108941122d7bbae0c7b3d101a5fe4fdc5402c500ab20dd7395a6ab5e35b6R424-R430) [[2]](diffhunk://#diff-7b0e108941122d7bbae0c7b3d101a5fe4fdc5402c500ab20dd7395a6ab5e35b6L447-R466)
- Added debug logging to sorting operations to aid in diagnosing sort behavior and defaults.

**Dependency and cache management:**
- Refactored constructors and dependencies to inject `SearchIndexReferenceDataCache` and `ISearchParameterDefinitionManager`, enabling efficient lookup of search parameter metadata and IDs. This improves performance and reliability of search parameter resolution. (`SqlEntityFrameworkSearchService.cs`, `SearchOptionsBuilder.cs`, and related factory code) [[1]](diffhunk://#diff-7b0e108941122d7bbae0c7b3d101a5fe4fdc5402c500ab20dd7395a6ab5e35b6R33) [[2]](diffhunk://#diff-7b0e108941122d7bbae0c7b3d101a5fe4fdc5402c500ab20dd7395a6ab5e35b6R55) [[3]](diffhunk://#diff-7b0e108941122d7bbae0c7b3d101a5fe4fdc5402c500ab20dd7395a6ab5e35b6R65) [[4]](diffhunk://#diff-23caaa6f255d453ee9fe524c1fef15cc3b8d9cc58c6a5fa831b888312a34e3a8L95-R95) [[5]](diffhunk://#diff-b0ef8bfe93875c95dc90137dd6aea04be18064a545aee5dae0d6c38384e82b8eR346) [[6]](diffhunk://#diff-6204c4ca5d7af014e9603044bc9b9e36de96f0828238092453cc5a688ab23931R28-R42)

**New utility for search parameter ID lookup:**
- Added a synchronous wrapper method for search parameter ID lookup using the cache, with error handling and logging for missing parameters. This is necessary for use within EF Core LINQ expressions. (`SqlEntityFrameworkSearchService.cs`)