### PR TITLE
Adds more e2e BasicSearchTests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SQL_SA_PASSWORD: ${{ secrets.SQL_SA_PASSWORD || 'YourStrong!Passw0rd' }}
+
 jobs:
-  build-and-test:
-    name: Build and Test
+  build-and-unit-tests:
+    name: Build and Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,23 +27,108 @@ jobs:
           fetch-depth: 0  # Full history for GitVersion
           submodules: recursive
 
-      - name: Build and test solution
+      - name: Build and run unit tests (exclude E2E)
         id: build
         uses: ./.github/actions/dotnet-build-and-test
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
           solution-file: 'All.sln'
           build-configuration: 'Release'
+          test-filter: 'FullyQualifiedName!~E2ETests'
 
       - name: Store version for later jobs
         run: |
           echo "VERSION=${{ steps.build.outputs.version }}" >> $GITHUB_ENV
           echo "ASSEMBLY_VERSION=${{ steps.build.outputs.assembly-version }}" >> $GITHUB_ENV
 
+  e2e-tests-sql:
+    name: E2E Tests (SQL Server)
+    runs-on: ubuntu-latest
+    # Run in parallel with unit tests for faster CI (both do their own build)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Start SQL Server container
+        run: |
+          echo "Starting SQL Server and Azurite containers..."
+          docker compose -f docker-compose.test.yml up -d --wait || {
+            echo "❌ Container startup failed. Checking logs..."
+            docker compose -f docker-compose.test.yml logs
+            docker ps -a
+            exit 1
+          }
+          echo "✅ SQL Server and Azurite started and healthy"
+        env:
+          SQL_SA_PASSWORD: ${{ env.SQL_SA_PASSWORD }}
+
+      - name: Verify SQL Server connection
+        run: |
+          docker exec ignixa-test-sql /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -C -U sa -P "${{ env.SQL_SA_PASSWORD }}" \
+            -Q "SELECT @@VERSION" -b
+        timeout-minutes: 2
+
+      - name: Restore dependencies
+        run: dotnet restore All.sln
+
+      - name: Build solution
+        run: dotnet build All.sln --configuration Release --no-restore
+
+      - name: Run E2E tests
+        run: |
+          dotnet test All.sln \
+            --configuration Release \
+            --no-build \
+            --filter "FullyQualifiedName~E2ETests" \
+            --logger "trx;LogFileName=e2e-test-results.trx" \
+            --verbosity normal
+        env:
+          TEST_SQL_CONNECTION_STRING: "Server=localhost,1433;Database=FhirTest;User Id=sa;Password=${{ env.SQL_SA_PASSWORD }};TrustServerCertificate=true;Encrypt=false"
+
+      - name: Upload E2E test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: '**/e2e-test-results.trx'
+          retention-days: 30
+
+      - name: Publish E2E test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: '**/e2e-test-results.trx'
+          check_name: 'E2E Test Results'
+          comment_mode: 'off'
+
+      - name: Capture SQL Server logs on failure
+        if: failure()
+        run: |
+          echo "=== SQL Server Logs ==="
+          docker logs ignixa-test-sql
+          echo "=== SQL Server Error Logs ==="
+          docker exec ignixa-test-sql cat /var/opt/mssql/log/errorlog || true
+
+      - name: Cleanup SQL Server container
+        if: always()
+        run: |
+          docker compose -f docker-compose.test.yml down -v
+          echo "✅ SQL Server container stopped and removed"
+
   check-code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
-    needs: [ build-and-test ]
+    needs: [ build-and-unit-tests ]
     continue-on-error: true
 
     steps:
@@ -93,7 +181,7 @@ jobs:
   build-and-push-container:
     name: Build and Push Container
     runs-on: ubuntu-latest
-    needs: [ build-and-test, check-docker-changes ]
+    needs: [ build-and-unit-tests, check-docker-changes ]
     if: success() && needs.check-docker-changes.outputs.should-build == 'true'
     permissions:
       contents: read
@@ -165,10 +253,11 @@ jobs:
   notify-success:
     name: Notify Success
     runs-on: ubuntu-latest
-    needs: [ build-and-test, check-docker-changes, build-and-push-container ]
+    needs: [ build-and-unit-tests, e2e-tests-sql, check-docker-changes, build-and-push-container ]
     if: |
       always() &&
-      needs.build-and-test.result == 'success' &&
+      needs.build-and-unit-tests.result == 'success' &&
+      needs.e2e-tests-sql.result == 'success' &&
       (needs.build-and-push-container.result == 'success' ||
        needs.build-and-push-container.result == 'skipped')
 
@@ -180,15 +269,20 @@ jobs:
           else
             echo "✅ CI pipeline completed successfully"
           fi
+          echo "Unit tests: ✅"
+          echo "E2E tests: ✅"
 
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
-    needs: [ build-and-test, check-docker-changes, build-and-push-container ]
+    needs: [ build-and-unit-tests, e2e-tests-sql, check-docker-changes, build-and-push-container ]
     if: failure()
 
     steps:
       - name: Create failure status
         run: |
           echo "❌ CI pipeline failed"
+          echo "Unit tests: ${{ needs.build-and-unit-tests.result }}"
+          echo "E2E tests: ${{ needs.e2e-tests-sql.result }}"
+          echo "Docker build: ${{ needs.build-and-push-container.result }}"
           exit 1

--- a/src/Application/Ignixa.Api/Endpoints/CompartmentEndpoints.cs
+++ b/src/Application/Ignixa.Api/Endpoints/CompartmentEndpoints.cs
@@ -227,8 +227,9 @@ public static class CompartmentEndpoints
         var tenantConfig = fhirContext.TenantConfiguration;
 
         // Get version-specific search options builder
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirSpec = FhirSpecificationExtensions.FromVersionString(tenantConfig.FhirVersion);
-        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec);
+        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec, fhirContext.TenantId);
 
         // Parse query parameters
         var queryParameters = queryParser.Parse(context.Request.Query);

--- a/src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs
+++ b/src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs
@@ -580,8 +580,10 @@ public static class FhirEndpoints
         var tenantConfig = fhirContext.TenantConfiguration;
 
         // Get version-specific search options builder and schema provider
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
+        // This ensures query parsing uses the same parameters as indexing
         var fhirSpec = FhirSpecificationExtensions.FromVersionString(tenantConfig.FhirVersion);
-        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec);
+        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec, tenantId);
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
 
         // Parse query parameters
@@ -664,8 +666,9 @@ public static class FhirEndpoints
         }
 
         var tenantConfig = fhirContext.TenantConfiguration;
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirSpec = FhirSpecificationExtensions.FromVersionString(tenantConfig.FhirVersion);
-        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec);
+        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec, tenantId);
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
         var searchOptions = searchOptionsBuilder.Build(resourceType, queryParameters, schemaProvider);
 
@@ -1427,8 +1430,9 @@ public static class FhirEndpoints
         var tenantConfig = fhirContext.TenantConfiguration;
 
         // Get version-specific search options builder and schema provider
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirSpec = FhirSpecificationExtensions.FromVersionString(tenantConfig.FhirVersion);
-        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec);
+        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec, tenantId);
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
 
         // Parse query parameters
@@ -1510,8 +1514,9 @@ public static class FhirEndpoints
         }
 
         var tenantConfig = fhirContext.TenantConfiguration;
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirSpec = FhirSpecificationExtensions.FromVersionString(tenantConfig.FhirVersion);
-        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec);
+        var searchOptionsBuilder = searchOptionsBuilderFactory.Create(fhirSpec, tenantId);
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
         var searchOptions = searchOptionsBuilder.Build(null, queryParameters, schemaProvider);
 

--- a/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/SearchAndWriteChunkActivity.cs
+++ b/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/SearchAndWriteChunkActivity.cs
@@ -86,7 +86,8 @@ public class SearchAndWriteChunkActivity : AsyncTaskActivity<SearchAndWriteChunk
                 var parameters = queryParser.Parse(input.TypeFilter);
 
                 // Build SearchOptions using the factory with tenant's FHIR version
-                var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion);
+                // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
+                var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion, input.TenantId);
                 searchOptions = searchOptionsBuilder.Build(input.ResourceType, parameters);
 
                 // Override MaxItemCount for chunked export (ignore client's _count parameter)

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs
@@ -83,8 +83,9 @@ public class ConditionalCreateHandler : IRequestHandler<ConditionalCreateCommand
         }
 
         // 2. Get FHIR version from context
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirVersion = context.FhirVersion;
-        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion);
+        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion, context.TenantId);
 
         // 3. Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalDelete/ConditionalDeleteHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalDelete/ConditionalDeleteHandler.cs
@@ -53,8 +53,9 @@ public class ConditionalDeleteHandler : IRequestHandler<ConditionalDeleteCommand
         var queryParameters = _queryParser.Parse(request.SearchCriteria);
 
         // Step 2: Get FHIR version from context
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirVersion = context.FhirVersion;
-        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion);
+        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion, context.TenantId);
 
         // Step 3: Build search options with appropriate max count
         int maxItemCount = isSingleMode ? 2 : (request.Count!.Value + 1);

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalPatch/ConditionalPatchHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalPatch/ConditionalPatchHandler.cs
@@ -63,8 +63,9 @@ public class ConditionalPatchHandler : IRequestHandler<ConditionalPatchCommand, 
         var queryParameters = _queryParser.Parse(request.SearchCriteria);
 
         // Step 2: Get FHIR version from context
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirVersion = context.FhirVersion;
-        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion);
+        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion, context.TenantId);
 
         // Step 3: Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalUpdate/ConditionalUpdateHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalUpdate/ConditionalUpdateHandler.cs
@@ -68,8 +68,9 @@ public class ConditionalUpdateHandler : IRequestHandler<ConditionalUpdateCommand
         var queryParameters = _queryParser.Parse(request.SearchCriteria);
 
         // 2. Get FHIR version from context
+        // CRITICAL: Pass tenantId to use tenant-specific search parameters (e.g., US Core)
         var fhirVersion = context.FhirVersion;
-        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion);
+        var searchOptionsBuilder = _searchOptionsBuilderFactory.Create(fhirVersion, context.TenantId);
 
         // 3. Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);

--- a/src/Application/Ignixa.Application/Features/Resource/SearchResourcesHandler.cs
+++ b/src/Application/Ignixa.Application/Features/Resource/SearchResourcesHandler.cs
@@ -73,6 +73,22 @@ public class SearchResourcesHandler : IRequestHandler<SearchResourcesQuery, Sear
             string.Join(",", partition.PartitionIds),
             partition.Mode);
 
+        // Handle _summary=count - return only total, no resources
+        if (request.SearchOptions.Summary == SummaryType.Count)
+        {
+            _logger.LogDebug("Summary=Count requested, returning only total count");
+
+            int totalCount = await _executionStrategy.CountAsync(partition, request.SearchOptions, cancellationToken);
+            _logger.LogDebug("Count query returned {TotalCount}", totalCount);
+
+            return new SearchResourcesResult(
+                Resources: EmptyAsyncEnumerable(),
+                Total: totalCount,
+                ContinuationToken: null,
+                HasMore: false,
+                SearchOptions: request.SearchOptions);
+        }
+
         // 2. Request pageSize + 1 results to detect if there are more (count-as-render pattern)
         //    The serializer will render only pageSize items and use the +1 to detect hasMore
         var searchOptionsWithExtra = new SearchOptions
@@ -86,7 +102,8 @@ public class SearchResourcesHandler : IRequestHandler<SearchResourcesQuery, Sear
             Total = request.SearchOptions.Total,
             Summary = request.SearchOptions.Summary,
             UnsupportedParams = request.SearchOptions.UnsupportedParams,
-            ResourceType = request.SearchOptions.ResourceType
+            ResourceType = request.SearchOptions.ResourceType,
+            ResourceTypes = request.SearchOptions.ResourceTypes
         };
 
         _logger.LogDebug(
@@ -130,5 +147,11 @@ public class SearchResourcesHandler : IRequestHandler<SearchResourcesQuery, Sear
             SearchOptions: request.SearchOptions); // Original pageSize, not +1
 
         return result;
+    }
+
+    private static async IAsyncEnumerable<SearchEntryResult> EmptyAsyncEnumerable()
+    {
+        await Task.CompletedTask;
+        yield break;
     }
 }

--- a/src/Application/Ignixa.Application/Features/Search/SearchOptionsBuilderFactory.cs
+++ b/src/Application/Ignixa.Application/Features/Search/SearchOptionsBuilderFactory.cs
@@ -24,6 +24,7 @@ public sealed class SearchOptionsBuilderFactory : ISearchOptionsBuilderFactory, 
 {
     private readonly IFhirVersionContext _versionContext;
     private readonly ConcurrentDictionary<(TenantContext Tenant, FhirVersion Version), ISearchOptionsBuilder> _builderCache = new();
+    private readonly ConcurrentDictionary<(TenantContext Tenant, FhirVersion Version, int? TenantId), ISearchOptionsBuilder> _tenantBuilderCache = new();
     private readonly SemaphoreSlim _creationLock = new(1, 1);
     private bool _disposed;
 
@@ -36,27 +37,42 @@ public sealed class SearchOptionsBuilderFactory : ISearchOptionsBuilderFactory, 
     /// <inheritdoc/>
     public ISearchOptionsBuilder Create(FhirVersion fhirVersion)
     {
-        // Phase 1: Single-tenant mode - always use default tenant
-        // Phase 2+: Extract tenant from HttpContext and create tenant-specific builders
-        return CreateForTenant(TenantContext.Default, fhirVersion);
+        // Uses base search parameter definitions only (no tenant-specific IG parameters)
+        return CreateForTenant(TenantContext.Default, fhirVersion, tenantId: null);
+    }
+
+    /// <inheritdoc/>
+    public ISearchOptionsBuilder Create(FhirVersion fhirVersion, int? tenantId)
+    {
+        // Uses tenant-specific search parameter definitions including IG parameters
+        return CreateForTenant(TenantContext.Default, fhirVersion, tenantId);
     }
 
     /// <summary>
     /// Creates a SearchOptionsBuilder for the specified tenant and FHIR version.
-    /// Internal method for future multi-tenant support.
+    /// Internal method for multi-tenant support with IG-specific search parameters.
     /// </summary>
     /// <param name="tenant">The tenant context.</param>
     /// <param name="fhirVersion">The FHIR version.</param>
+    /// <param name="tenantId">The tenant ID for IG-specific search parameters (null uses base definitions only).</param>
     private ISearchOptionsBuilder CreateForTenant(
         TenantContext tenant,
-        FhirVersion fhirVersion)
+        FhirVersion fhirVersion,
+        int? tenantId)
     {
-        var cacheKey = (tenant, fhirVersion);
+        // Include tenantId in cache key to separate tenant-specific builders
+        var cacheKey = (tenant, fhirVersion, tenantId);
 
-        // Fast path: check cache
-        if (_builderCache.TryGetValue(cacheKey, out var cachedBuilder))
+        // Fast path: check cache (use TryGetValue on extension for tuple key)
+        if (_builderCache.TryGetValue((tenant, fhirVersion), out var cachedBuilder) && !tenantId.HasValue)
         {
             return cachedBuilder;
+        }
+
+        // Check tenant-specific cache
+        if (tenantId.HasValue && _tenantBuilderCache.TryGetValue(cacheKey, out var tenantCachedBuilder))
+        {
+            return tenantCachedBuilder;
         }
 
         // Slow path: create new builder with version-specific dependencies
@@ -64,14 +80,24 @@ public sealed class SearchOptionsBuilderFactory : ISearchOptionsBuilderFactory, 
         try
         {
             // Double-check after acquiring lock
-            if (_builderCache.TryGetValue(cacheKey, out cachedBuilder))
+            if (!tenantId.HasValue && _builderCache.TryGetValue((tenant, fhirVersion), out cachedBuilder))
             {
                 return cachedBuilder;
             }
 
+            if (tenantId.HasValue && _tenantBuilderCache.TryGetValue(cacheKey, out tenantCachedBuilder))
+            {
+                return tenantCachedBuilder;
+            }
+
             // Get version-specific components from context (cached and reused)
             var schemaProvider = _versionContext.GetBaseSchemaProvider(fhirVersion);
-            var searchParamDefinitionManager = _versionContext.GetSearchParameterDefinitionManager(fhirVersion);
+
+            // CRITICAL: Use tenant-specific search parameter manager when tenantId is provided
+            // This ensures query parsing uses the same search parameters as indexing (including US Core)
+            var searchParamDefinitionManager = tenantId.HasValue
+                ? _versionContext.GetSearchParameterDefinitionManager(fhirVersion, tenantId)
+                : _versionContext.GetSearchParameterDefinitionManager(fhirVersion);
 
             // Create resolver delegate for SearchParameterDefinitionManager
             ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver resolver =
@@ -92,10 +118,16 @@ public sealed class SearchOptionsBuilderFactory : ISearchOptionsBuilderFactory, 
             // Create version-specific SearchOptionsBuilder
             var builder = new SearchOptionsBuilder(expressionParser, searchParamDefinitionManager);
 
-            // Cache and return
-            // Phase 2+: This cache will hold separate builders for (tenant, version) pairs
-            // allowing custom search parameters per tenant
-            _builderCache.TryAdd(cacheKey, builder);
+            // Cache and return - use appropriate cache based on tenant ID
+            if (tenantId.HasValue)
+            {
+                _tenantBuilderCache.TryAdd(cacheKey, builder);
+            }
+            else
+            {
+                _builderCache.TryAdd((tenant, fhirVersion), builder);
+            }
+
             return builder;
         }
         finally

--- a/src/Core/Ignixa.Search/Models/SearchOptions.cs
+++ b/src/Core/Ignixa.Search/Models/SearchOptions.cs
@@ -76,6 +76,12 @@ public class SearchOptions
     public string ResourceType { get; set; }
 
     /// <summary>
+    /// Gets or sets the resource types to filter by (from _type parameter).
+    /// Used in system-level search to filter results to specific resource types.
+    /// </summary>
+    public IReadOnlyList<string> ResourceTypes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// Optional: When set, filters results to resources within this surrogate ID range.
     /// Used for parallel export operations to partition work across multiple workers.
     /// When both are set, filters to resources where: StartSurrogateId <= SurrogateId <= EndSurrogateId

--- a/src/Core/Ignixa.Search/Parsing/ISearchOptionsBuilderFactory.cs
+++ b/src/Core/Ignixa.Search/Parsing/ISearchOptionsBuilderFactory.cs
@@ -15,8 +15,19 @@ public interface ISearchOptionsBuilderFactory
 {
     /// <summary>
     /// Creates a SearchOptionsBuilder for the specified FHIR version.
+    /// Uses base search parameter definitions only (no tenant-specific IG parameters).
     /// </summary>
     /// <param name="fhirVersion">The FHIR version specification.</param>
     /// <returns>A SearchOptionsBuilder configured for the specified version.</returns>
     ISearchOptionsBuilder Create(FhirVersion fhirVersion);
+
+    /// <summary>
+    /// Creates a SearchOptionsBuilder for the specified FHIR version and tenant.
+    /// Uses tenant-specific search parameter definitions including IG parameters (e.g., US Core).
+    /// IMPORTANT: Use this overload for SQL Server searches to ensure query parameters match indexed values.
+    /// </summary>
+    /// <param name="fhirVersion">The FHIR version specification.</param>
+    /// <param name="tenantId">The tenant ID (null uses base definitions only).</param>
+    /// <returns>A SearchOptionsBuilder configured for the specified version and tenant.</returns>
+    ISearchOptionsBuilder Create(FhirVersion fhirVersion, int? tenantId);
 }

--- a/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
+++ b/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
@@ -69,6 +69,7 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
         var revIncludeParameters = new List<string>();
         var elementsParameters = new List<string>();
         var unsupportedParameters = new List<string>();
+        var typeFilterParameters = new List<string>();
 
         // For system-wide search (resourceType is null), use "Resource" as base type
         // This allows searching with common parameters like _tag, _profile, _security, _id, _lastUpdated
@@ -129,6 +130,15 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
 
                     case ParameterCategory.Elements:
                         elementsParameters.Add(param.Value);
+                        break;
+
+                    case ParameterCategory.Type:
+                        // _type parameter for system-level search (filter by resource type)
+                        // Value can be comma-separated: _type=Patient,Observation
+                        typeFilterParameters.AddRange(
+                            param.Value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(t => t.Trim())
+                                .Where(t => !string.IsNullOrEmpty(t)));
                         break;
 
                     case ParameterCategory.Search:
@@ -238,7 +248,13 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
             }
         }
 
-        // STEP 7: Record unsupported parameters and create Bundle issues
+        // STEP 7: Set resource type filter (_type parameter)
+        if (typeFilterParameters.Count > 0)
+        {
+            options.ResourceTypes = typeFilterParameters;
+        }
+
+        // STEP 8: Record unsupported parameters and create Bundle issues
         options.UnsupportedParams = unsupportedParameters;
         foreach (var param in unsupportedParameters)
         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchExpressionQueryBuilder.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchExpressionQueryBuilder.cs
@@ -247,7 +247,7 @@ public class SearchExpressionQueryBuilder
         return baseQuery.Where(r => !matchingResourceIds.Contains(r.ResourceSurrogateId));
     }
 
-    private Task<IQueryable<ResourceEntity>> ApplyMissingSearchParameterExpressionAsync(
+    private async Task<IQueryable<ResourceEntity>> ApplyMissingSearchParameterExpressionAsync(
         IQueryable<ResourceEntity> baseQuery,
         short? resourceTypeId,
         MissingSearchParameterExpression expression,
@@ -262,66 +262,85 @@ public class SearchExpressionQueryBuilder
         if (searchParamInfo == null)
         {
             _logger.LogWarning("Missing search parameter expression has no parameter info");
-            return Task.FromResult(baseQuery.Where(r => false)); // Return empty
+            return baseQuery.Where(r => false); // Return empty
         }
 
+        // Look up the SearchParamId for this specific search parameter
+        short? searchParamId = await _parameterQueryGenerator.GetSearchParamIdAsync(searchParamInfo);
+        if (!searchParamId.HasValue)
+        {
+            _logger.LogWarning("Could not find SearchParamId for parameter {Code}", searchParamInfo.Code);
+            return baseQuery.Where(r => false); // Return empty
+        }
+
+        _logger.LogDebug("Found SearchParamId {SearchParamId} for parameter {Code}", searchParamId.Value, searchParamInfo.Code);
+
         // Query the appropriate search parameter table based on parameter type
+        // IMPORTANT: Filter by both ResourceTypeId AND SearchParamId to find resources
+        // that have this specific parameter indexed
         IQueryable<long> resourcesWithParameter;
 
         switch (searchParamInfo.Type)
         {
             case SearchParamType.String:
                 resourcesWithParameter = _context.StringSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Token:
                 resourcesWithParameter = _context.TokenSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Reference:
                 resourcesWithParameter = _context.ReferenceSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Number:
                 resourcesWithParameter = _context.NumberSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Date:
                 resourcesWithParameter = _context.DateTimeSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Quantity:
                 resourcesWithParameter = _context.QuantitySearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             case SearchParamType.Uri:
                 resourcesWithParameter = _context.UriSearchParams
-                    .Where(sp => sp.ResourceTypeId == resourceTypeId)
+                    .Where(sp => (!resourceTypeId.HasValue || sp.ResourceTypeId == resourceTypeId.Value)
+                        && sp.SearchParamId == searchParamId.Value)
                     .Select(sp => sp.ResourceSurrogateId)
                     .Distinct();
                 break;
 
             default:
                 _logger.LogWarning("Unsupported search parameter type for missing modifier: {Type}", searchParamInfo.Type);
-                return Task.FromResult(baseQuery.Where(r => false)); // Return empty
+                return baseQuery.Where(r => false); // Return empty
         }
 
         IQueryable<ResourceEntity> result;
@@ -336,7 +355,7 @@ public class SearchExpressionQueryBuilder
             result = baseQuery.Where(r => resourcesWithParameter.Contains(r.ResourceSurrogateId));
         }
 
-        return Task.FromResult(result);
+        return result;
     }
 
     private static IQueryable<long> CombineWithAnd(List<IQueryable<long>> queries)

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
@@ -45,6 +45,16 @@ public class SearchParameterQueryGenerator
     }
 
     /// <summary>
+    /// Gets the SearchParamId for a search parameter from the cache.
+    /// </summary>
+    /// <param name="searchParamInfo">The search parameter info.</param>
+    /// <returns>The SearchParamId, or null if not found.</returns>
+    public ValueTask<short?> GetSearchParamIdAsync(SearchParameterInfo searchParamInfo)
+    {
+        return _cache.GetSearchParamIdAsync(searchParamInfo);
+    }
+
+    /// <summary>
     /// Generates a query for a search parameter expression, returning matching resource surrogate IDs.
     /// </summary>
     /// <param name="resourceTypeId">The resource type identifier, or null for system-wide search across all types.</param>

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SqlEntityFrameworkSearchService.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SqlEntityFrameworkSearchService.cs
@@ -225,9 +225,37 @@ public class SqlEntityFrameworkSearchService : ISearchService
         {
             _logger.LogDebug("System-wide count query - no resource type filter");
 
-            // Base query without resource type filter
-            var multiTypeBaseQuery = _context.Resources
-                .Where(r => !r.IsHistory && !r.IsDeleted);
+            IQueryable<ResourceEntity> multiTypeBaseQuery;
+
+            // Handle _type parameter filtering for system-wide search
+            if (options.ResourceTypes.Count > 0)
+            {
+                var resourceTypeNames = options.ResourceTypes.ToList();
+                var typeIds = await _context.ResourceTypes
+                    .Where(rt => resourceTypeNames.Contains(rt.Name))
+                    .Select(rt => rt.ResourceTypeId)
+                    .ToListAsync(ct);
+
+                if (typeIds.Count == 0)
+                {
+                    // No valid types found, return 0
+                    return 0;
+                }
+
+                multiTypeBaseQuery = _context.Resources
+                    .Where(r => typeIds.Contains(r.ResourceTypeId)
+                        && !r.IsHistory
+                        && !r.IsDeleted);
+
+                _logger.LogDebug("Applied _type filter for count: {Types} -> TypeIds: {TypeIds}",
+                    string.Join(",", resourceTypeNames), string.Join(",", typeIds));
+            }
+            else
+            {
+                // Base query without resource type filter
+                multiTypeBaseQuery = _context.Resources
+                    .Where(r => !r.IsHistory && !r.IsDeleted);
+            }
 
             // Apply search expression filters
             if (options.Expression != null)
@@ -459,6 +487,32 @@ public class SqlEntityFrameworkSearchService : ISearchService
                         && !r.IsHistory
                         && !r.IsDeleted);
             }
+            else if (options.ResourceTypes.Count > 0)
+            {
+                // Multi-type search with _type filter: filter by specified resource types
+                // Get ResourceTypeIds for the specified types
+                var resourceTypeNames = options.ResourceTypes.ToList();
+                var typeIds = await _context.ResourceTypes
+                    .Where(rt => resourceTypeNames.Contains(rt.Name))
+                    .Select(rt => rt.ResourceTypeId)
+                    .ToListAsync(ct);
+
+                if (typeIds.Count == 0)
+                {
+                    // No valid types found, return empty query
+                    baseQuery = _context.Resources.Where(r => false);
+                }
+                else
+                {
+                    baseQuery = _context.Resources
+                        .Where(r => typeIds.Contains(r.ResourceTypeId)
+                            && !r.IsHistory
+                            && !r.IsDeleted);
+                }
+
+                _logger.LogDebug("Applied _type filter: {Types} -> TypeIds: {TypeIds}",
+                    string.Join(",", resourceTypeNames), string.Join(",", typeIds));
+            }
             else
             {
                 // Multi-type search: no resource type filter
@@ -474,12 +528,11 @@ public class SqlEntityFrameworkSearchService : ISearchService
             {
                 _logger.LogDebug("Applying search expression filters");
 
-                // For multi-type searches, we pass a dummy resourceTypeId (not used by expressions like CompartmentSearchExpression)
-                var typeIdForExpression = resourceTypeId ?? 1; // Use 1 as dummy value for multi-type
-
+                // For multi-type searches, pass null to skip resource type filtering in search parameter queries
+                // The base query already filters by resource types via _type parameter or no filter at all
                 filteredQuery = await _queryBuilder.ApplySearchExpressionAsync(
                     baseQuery,
-                    typeIdForExpression,
+                    resourceTypeId, // null for multi-type searches
                     options.Expression,
                     ct);
             }

--- a/test/Ignixa.Api.E2ETests/BasicSearchTests.cs
+++ b/test/Ignixa.Api.E2ETests/BasicSearchTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Text.Json.Nodes;
 using FluentAssertions;
 using Ignixa.Api.E2ETests.Fixtures;
 using Ignixa.Api.E2ETests.Infrastructure;
@@ -10,6 +11,8 @@ using Ignixa.FhirFakes.Builders.Profiles;
 using Ignixa.FhirFakes.Population;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
 
 namespace Ignixa.Api.E2ETests;
 
@@ -50,7 +53,7 @@ public class BasicSearchTests : CapabilityDrivenTestBase
         });
     }
 
-    [Fact(Skip = "Todo")]
+    [Fact]
     public async Task GivenPatients_WhenSearchedByFamily_ThenReturnsMatching()
     {
         // Capability check
@@ -85,7 +88,7 @@ public class BasicSearchTests : CapabilityDrivenTestBase
         results.Should().HaveCount(2);
     }
 
-    [Fact(Skip = "Todo")]
+    [Fact]
     public async Task GivenPatients_WhenSearchedByFamilyAndGiven_ThenReturnsMatching()
     {
         // Capability check - multiple parameters
@@ -123,7 +126,7 @@ public class BasicSearchTests : CapabilityDrivenTestBase
         results.Should().HaveCount(1);
     }
 
-    [Fact(Skip = "TODO")]
+    [Fact]
     public async Task GivenPatients_WhenSearchedByGender_ThenReturnsMatching()
     {
         // Capability check
@@ -224,7 +227,7 @@ public class BasicSearchTests : CapabilityDrivenTestBase
         results.Should().HaveCount(1);
     }
 
-    [Fact(Skip = "Todo")]
+    [Fact]
     public async Task GivenInternationalPatients_WhenSearchedByCountry_ThenFiltersCorrectly()
     {
         // Capability check
@@ -241,7 +244,8 @@ public class BasicSearchTests : CapabilityDrivenTestBase
         await Harness.CreateResourcesAsync([patient1, patient2, patient3]);
 
         // Act - Search for patients in Australia (only Melbourne patient)
-        var results = await Harness.SearchAsync("Patient", $"address-country=Australia&_tag={tag}");
+        // Note: Country is stored as ISO 2-letter code (AU) per CityDemographics, not full name
+        var results = await Harness.SearchAsync("Patient", $"address-country=AU&_tag={tag}");
 
         // Assert
         results.Should().HaveCount(1);
@@ -312,4 +316,470 @@ public class BasicSearchTests : CapabilityDrivenTestBase
             patient.MutableNode["extension"].Should().NotBeNull("Patient should have race/ethnicity extensions");
         });
     }
+
+    #region Ported Tests - Phase 1: Core Search Functionality
+
+    /// <summary>
+    /// Tests AND logic with multiple search parameters.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 42-53)
+    /// </summary>
+    [Fact]
+    public async Task GivenResourceWithVariousValues_WhenSearchedWithMultipleParams_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
+    {
+        // Capability check - multiple parameters
+        RequireSearchParameters("Patient", "address-city", "family");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+
+        var patient1 = CreatePatient()
+            .FromSeattle()
+            .WithFamilyName("Robinson")
+            .WithTag(tag)
+            .Build();
+
+        var patient2 = CreatePatient()
+            .FromCity(KnownCities.LosAngeles)  // Portland not in KnownCities, using LA as different city
+            .WithFamilyName("Williamas")
+            .WithTag(tag)
+            .Build();
+
+        var patient3 = CreatePatient()
+            .FromSeattle()
+            .WithFamilyName("Jones")
+            .WithTag(tag)
+            .Build();
+
+        await Harness.CreateResourcesAsync([patient1, patient2, patient3]);
+
+        // Act - AND logic: city=Seattle AND family=Jones
+        var results = await Harness.SearchAsync("Patient", $"address-city=Seattle&family=Jones&_tag={tag}");
+
+        // Assert - Only patient3 matches both criteria
+        results.Should().HaveCount(1);
+        var matchedPatient = results[0];
+        matchedPatient.MutableNode["name"]?[0]?["family"]?.GetValue<string>().Should().Be("Jones");
+    }
+
+    /// <summary>
+    /// Tests basic resource type filtering.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 76-89)
+    /// </summary>
+    [Fact]
+    public async Task GivenVariousTypesOfResources_WhenSearchedByResourceType_ThenOnlyResourcesMatchingTheResourceTypeShouldBeReturned()
+    {
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+        var faker = Harness.CreateFaker().WithTag(tag);
+
+        // Create various resource types
+        var patient1 = CreatePatient().FromSeattle().WithTag(tag).Build();
+        var patient2 = CreatePatient().FromCity(KnownCities.Boston).WithTag(tag).Build();
+        var patient3 = CreatePatient().FromCity(KnownCities.Chicago).WithTag(tag).Build();
+
+        // Create an Observation (uses faker which respects the tag)
+        var observation = faker.Generate("Observation");
+        // Create an Organization
+        var organization = faker.Generate("Organization");
+
+        await Harness.CreateResourcesAsync([patient1, patient2, patient3, observation, organization]);
+
+        // Act - Search for Patient resources with our tag
+        var results = await Harness.SearchAsync("Patient", $"_tag={tag}");
+
+        // Assert - Should return only Patient resources
+        results.Should().HaveCount(3);
+        results.Should().AllSatisfy(r => r.ResourceType.Should().Be("Patient"));
+    }
+
+    /// <summary>
+    /// Tests the :missing modifier for finding resources with or without a specific parameter.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 93-123)
+    /// </summary>
+    [Fact]
+    public async Task GivenResourcesWithVariousValues_WhenSearchedWithTheMissingModifier_ThenOnlyTheResourcesWithMissingOrPresentParametersAreReturned()
+    {
+        // Capability check
+        RequireSearchParameter("Patient", "gender");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+
+        // Patient with gender specified
+        var patientWithGender = CreatePatient()
+            .FromSeattle()
+            .WithGender(g => g.Female)
+            .WithTag(tag)
+            .Build();
+
+        // Patient without gender (need to remove gender after building)
+        var patientWithoutGender = CreatePatient()
+            .FromCity(KnownCities.Boston)
+            .WithTag(tag)
+            .Build();
+        patientWithoutGender.MutableNode.Remove("gender");
+
+        await Harness.CreateResourcesAsync([patientWithGender, patientWithoutGender]);
+
+        // Act & Assert - Search for patients with gender missing
+        var missingResults = await Harness.SearchAsync("Patient", $"gender:missing=true&_tag={tag}");
+        missingResults.Should().HaveCount(1);
+
+        // Act & Assert - Search for patients with gender present
+        var presentResults = await Harness.SearchAsync("Patient", $"gender:missing=false&_tag={tag}");
+        presentResults.Should().HaveCount(1);
+        presentResults[0].MutableNode["gender"]?.GetValue<string>().Should().Be("female");
+    }
+
+    /// <summary>
+    /// Tests reference parameter searches combined with _id.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 127-142)
+    /// </summary>
+    [Fact]
+    public async Task GivenResourcesWithReference_WhenSearchedWithReferenceAndIdParameter_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
+    {
+        // Capability check
+        RequireSearchParameter("Patient", "organization");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+
+        // Create two patients with different organization references
+        var patient1 = CreatePatient()
+            .FromSeattle()
+            .WithGender(g => g.Female)
+            .WithTag(tag)
+            .Build();
+        patient1.MutableNode["managingOrganization"] = new JsonObject
+        {
+            ["reference"] = "Organization/123"
+        };
+
+        var patient2 = CreatePatient()
+            .FromCity(KnownCities.Boston)
+            .WithGender(g => g.Female)
+            .WithTag(tag)
+            .Build();
+        patient2.MutableNode["managingOrganization"] = new JsonObject
+        {
+            ["reference"] = "Organization/234"
+        };
+
+        var createdResources = await Harness.CreateResourcesAsync([patient1, patient2]);
+        var patient1Id = createdResources[0].Id;
+
+        // Act - Search with matching reference
+        var matchingResults = await Harness.SearchAsync("Patient", $"_id={patient1Id}&organization=Organization/123");
+        matchingResults.Should().HaveCount(1);
+
+        // Act - Search with non-matching reference
+        var nonMatchingResults = await Harness.SearchAsync("Patient", $"_id={patient1Id}&organization=Organization/234");
+        nonMatchingResults.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Tests the _type parameter for cross-resource-type searches.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 375-402)
+    /// </summary>
+    [Fact]
+    public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypes_ThenOnlyResourcesMatchingTypeParameterShouldBeReturned()
+    {
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+        var faker = Harness.CreateFaker().WithTag(tag);
+
+        // Create various resource types
+        var patient1 = CreatePatient().FromSeattle().WithTag(tag).Build();
+        var patient2 = CreatePatient().FromCity(KnownCities.Boston).WithTag(tag).Build();
+        var patient3 = CreatePatient().FromCity(KnownCities.Chicago).WithTag(tag).Build();
+
+        var observation = faker.Generate("Observation");
+        var organization = faker.Generate("Organization");
+
+        await Harness.CreateResourcesAsync([patient1, patient2, patient3, observation, organization]);
+
+        // Act - System-level search with _type=Patient
+        var bundle = await Harness.SearchSystemAsync($"_type=Patient&_tag={tag}");
+
+        // Assert - Should return only Patient resources
+        var resources = bundle.Entry
+            .Where(e => e.Resource is not null)
+            .Select(e => e.Resource!)
+            .ToArray();
+
+        resources.Should().HaveCount(3);
+        resources.Should().AllSatisfy(r => r.ResourceType.Should().Be("Patient"));
+    }
+
+    #endregion
+
+    #region Ported Tests - Phase 2: Pagination & Counting
+
+    /// <summary>
+    /// Tests that _count parameter limits the number of resources returned per page.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 572-624)
+    /// </summary>
+    [Fact]
+    public async Task GivenResources_WhenSearchedWithCount_ThenNumberOfResourcesReturnedShouldNotExceedCount()
+    {
+        // Arrange
+        const int numberOfResources = 5;
+        const int count = 2;
+        var tag = Guid.NewGuid().ToString();
+
+        var patients = Enumerable.Range(0, numberOfResources)
+            .Select(_ => CreatePatient().FromSeattle().WithTag(tag).Build())
+            .ToArray();
+
+        await Harness.CreateResourcesAsync(patients);
+
+        // Act - Search with _count=2
+        var bundle = await Harness.SearchBundleAsync("Patient", $"_count={count}&_tag={tag}");
+
+        // Assert - First page should have at most 'count' entries
+        bundle.Entry.Count.Should().BeLessOrEqualTo(count);
+        bundle.Entry.Count.Should().BeGreaterThan(0);
+
+        // Follow next links to collect all results
+        var allResources = bundle.Entry
+            .Where(e => e.Resource is not null)
+            .Select(e => e.Resource!)
+            .ToList();
+
+        var nextLink = bundle.Link.FirstOrDefault(l => l.Relation == "next")?.Url;
+        var iterations = 1;
+
+        while (!string.IsNullOrEmpty(nextLink) && iterations < 10)
+        {
+            var nextBundle = await Harness.GetBundleAsync(nextLink);
+            nextBundle.Entry.Count.Should().BeLessOrEqualTo(count);
+
+            allResources.AddRange(
+                nextBundle.Entry
+                    .Where(e => e.Resource is not null)
+                    .Select(e => e.Resource!));
+
+            nextLink = nextBundle.Link.FirstOrDefault(l => l.Relation == "next")?.Url;
+            iterations++;
+        }
+
+        // Assert - All resources should be retrieved across pages
+        allResources.Should().HaveCount(numberOfResources);
+    }
+
+    /// <summary>
+    /// Tests that next link is populated when more results exist than the count.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 628-666)
+    /// </summary>
+    [Fact]
+    public async Task GivenMoreSearchResultsThanCount_WhenSearched_ThenNextLinkUrlShouldBePopulated()
+    {
+        // Arrange
+        const int numberOfResources = 10;
+        const int count = 2;
+        var tag = Guid.NewGuid().ToString();
+
+        var patients = Enumerable.Range(0, numberOfResources)
+            .Select(_ => CreatePatient().FromSeattle().WithTag(tag).Build())
+            .ToArray();
+
+        await Harness.CreateResourcesAsync(patients);
+
+        // Act - Search with _count=2
+        var bundle = await Harness.SearchBundleAsync("Patient", $"_count={count}&_tag={tag}");
+
+        // Assert - Should have next link since we have more results
+        var nextLink = bundle.Link.FirstOrDefault(l => l.Relation == "next");
+        nextLink.Should().NotBeNull("There should be a next link when results exceed count");
+        nextLink!.Url.Should().NotBeNullOrEmpty();
+
+        // Follow all pages and collect resources
+        var allResources = bundle.Entry
+            .Where(e => e.Resource is not null)
+            .Select(e => e.Resource!)
+            .ToList();
+
+        var currentNextLink = nextLink.Url;
+        var iterations = 1;
+
+        while (!string.IsNullOrEmpty(currentNextLink) && iterations < 10)
+        {
+            var nextBundle = await Harness.GetBundleAsync(currentNextLink);
+            allResources.AddRange(
+                nextBundle.Entry
+                    .Where(e => e.Resource is not null)
+                    .Select(e => e.Resource!));
+
+            currentNextLink = nextBundle.Link.FirstOrDefault(l => l.Relation == "next")?.Url;
+            iterations++;
+        }
+
+        // All resources should be retrieved
+        allResources.Should().HaveCount(numberOfResources);
+    }
+
+    /// <summary>
+    /// Tests _summary=count returns total without resources.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 719-740)
+    /// </summary>
+    [Fact]
+    public async Task GivenListOfResources_WhenSearchedWithCountSummary_ThenTotalCountShouldBeReturned()
+    {
+        // Arrange
+        const int numberOfResources = 5;
+        var tag = Guid.NewGuid().ToString();
+
+        var patients = Enumerable.Range(0, numberOfResources)
+            .Select(_ => CreatePatient().FromSeattle().WithTag(tag).Build())
+            .ToArray();
+
+        await Harness.CreateResourcesAsync(patients);
+
+        // Act - Search with _summary=count
+        var bundle = await Harness.SearchBundleAsync("Patient", $"_tag={tag}&_summary=count");
+
+        // Assert
+        bundle.Should().NotBeNull();
+        bundle.Total.Should().Be(numberOfResources);
+        bundle.Entry.Should().BeEmpty("_summary=count should not return any entries");
+    }
+
+    #endregion
+
+    #region Ported Tests - Phase 3: Advanced Features
+
+    /// <summary>
+    /// Tests _total=accurate returns accurate total count.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 872-893)
+    /// </summary>
+    [Fact]
+    public async Task GivenListOfResources_WhenSearchedWithTotalTypeAccurate_ThenTotalCountShouldBeIncludedInReturnedBundle()
+    {
+        // Arrange
+        const int numberOfResources = 5;
+        var tag = Guid.NewGuid().ToString();
+
+        var patients = Enumerable.Range(0, numberOfResources)
+            .Select(_ => CreatePatient().FromSeattle().WithTag(tag).Build())
+            .ToArray();
+
+        await Harness.CreateResourcesAsync(patients);
+
+        // Act - Search with _total=accurate
+        var bundle = await Harness.SearchBundleAsync("Patient", $"_tag={tag}&_total=accurate");
+
+        // Assert
+        bundle.Should().NotBeNull();
+        bundle.Entry.Should().NotBeEmpty();
+        bundle.Total.Should().Be(numberOfResources);
+    }
+
+    /// <summary>
+    /// Tests _total=none does not return total count.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 897-918)
+    /// </summary>
+    [Fact]
+    public async Task GivenListOfResources_WhenSearchedWithTotalTypeNone_ThenTotalCountShouldNotBeIncludedInReturnedBundle()
+    {
+        // Arrange
+        const int numberOfResources = 5;
+        var tag = Guid.NewGuid().ToString();
+
+        var patients = Enumerable.Range(0, numberOfResources)
+            .Select(_ => CreatePatient().FromSeattle().WithTag(tag).Build())
+            .ToArray();
+
+        await Harness.CreateResourcesAsync(patients);
+
+        // Act - Search with _total=none
+        var bundle = await Harness.SearchBundleAsync("Patient", $"_tag={tag}&_total=none");
+
+        // Assert
+        bundle.Should().NotBeNull();
+        bundle.Entry.Should().NotBeEmpty();
+        bundle.Total.Should().BeNull("_total=none should not include total count");
+    }
+
+    /// <summary>
+    /// Tests that only the current version of a resource is returned when searching.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 693-715)
+    /// </summary>
+    [Fact]
+    public async Task GivenResourceWithHistory_WhenSearchedWithParams_ThenOnlyCurrentVersionShouldBeReturned()
+    {
+        // Capability check
+        RequireSearchParameter("Observation", "code");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+
+        // Create an observation with a specific code
+        var scenario = CreateScenario()
+            .WithTag(tag)
+            .WithPatient(p => p.FromSeattle())
+            .AddEncounter("Test visit")
+            .AddObservation(VitalSigns.HeartRate, 72m, "beats/minute", "/min")
+            .Build();
+
+        var createdResources = await Harness.CreateResourcesAsync(scenario.AllResources.ToArray());
+
+        // Find the created observation
+        var observation = createdResources.FirstOrDefault(r => r.ResourceType == "Observation")
+            ?? throw new InvalidOperationException("No observation was created");
+
+        // Act - Update the observation with a new value
+        var valueQuantity = observation.MutableNode["valueQuantity"] as JsonObject
+            ?? throw new InvalidOperationException("Observation does not have valueQuantity");
+
+        valueQuantity["value"] = JsonValue.Create(85m); // Update heart rate from 72 to 85
+
+        var updatedObservation = await Harness.UpdateResourceAsync(observation);
+
+        // Search for observations by code
+        var searchResults = await Harness.SearchAsync("Observation", $"code=8867-4&_tag={tag}");
+
+        // Assert
+        searchResults.Should().HaveCount(1, "only the current version should be returned, not historical versions");
+
+        var returnedObservation = searchResults.First();
+        var returnedValue = returnedObservation.MutableNode["valueQuantity"]?["value"]?.GetValue<decimal>();
+
+        returnedValue.Should().Be(85m, "the returned observation should have the updated value");
+        returnedObservation.Id.Should().Be(observation.Id, "the returned observation should have the same ID");
+    }
+
+    /// <summary>
+    /// Tests case-insensitive city search.
+    /// Ported from: Microsoft.Health.Fhir.Tests.E2E.Rest.Search.BasicSearchTests (line 55-72)
+    /// </summary>
+    [Fact]
+    public async Task GivenResourceWithVariousValues_WhenSearchedWithCityParam_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
+    {
+        // Capability check
+        RequireSearchParameter("Patient", "address-city");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+
+        // Create patients with various city values (testing case-insensitivity)
+        var patient1 = CreatePatient().FromSeattle().WithFamilyName("Robinson").WithTag(tag).Build();  // Seattle
+        var patient2 = CreatePatient().FromCity(KnownCities.LosAngeles).WithFamilyName("Williamas").WithTag(tag).Build();  // Los Angeles
+        var patient3 = CreatePatient().FromSeattle().WithFamilyName("Skouras").WithTag(tag).Build();   // Seattle
+        var patient4 = CreatePatient().FromCity(KnownCities.NewYork).WithFamilyName("Cook").WithTag(tag).Build();  // New York
+
+        await Harness.CreateResourcesAsync([patient1, patient2, patient3, patient4]);
+
+        // Act - Search for Seattle (case-insensitive)
+        var results = await Harness.SearchAsync("Patient", $"address-city=Seattle&_tag={tag}");
+
+        // Assert - Should match both Seattle patients
+        results.Should().HaveCount(2);
+        results.Should().AllSatisfy(r =>
+        {
+            var city = r.MutableNode["address"]?[0]?["city"]?.GetValue<string>();
+            city.Should().BeEquivalentTo("Seattle", "City search should be case-insensitive");
+        });
+    }
+
+    #endregion
 }

--- a/test/Ignixa.Api.E2ETests/Infrastructure/SearchTestHarness.cs
+++ b/test/Ignixa.Api.E2ETests/Infrastructure/SearchTestHarness.cs
@@ -90,6 +90,34 @@ public sealed class SearchTestHarness
     }
 
     /// <summary>
+    /// Updates a resource on the server using PUT.
+    /// </summary>
+    public async Task<ResourceJsonNode> UpdateResourceAsync(ResourceJsonNode resource, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var resourceType = resource.ResourceType;
+        var resourceId = resource.Id;
+
+        if (string.IsNullOrEmpty(resourceId))
+        {
+            throw new ArgumentException("Resource must have an ID for update", nameof(resource));
+        }
+
+        var json = resource.MutableNode.ToJsonString();
+
+        var response = await _client.PutAsync(
+            $"/{resourceType}/{resourceId}",
+            new StringContent(json, System.Text.Encoding.UTF8, "application/fhir+json"),
+            cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSourceNodeFactory.Parse<ResourceJsonNode>(responseJson);
+    }
+
+    /// <summary>
     /// Creates multiple resources on the server using a FHIR batch bundle for better performance.
     /// </summary>
     public async Task<ResourceJsonNode[]> CreateResourcesAsync(ResourceJsonNode[] resources, CancellationToken cancellationToken = default)
@@ -165,5 +193,54 @@ public sealed class SearchTestHarness
             .Where(e => e.Resource is not null)
             .Select(e => e.Resource!)
             .ToArray();
+    }
+
+    /// <summary>
+    /// Executes a search and returns the full Bundle (for pagination/total tests).
+    /// </summary>
+    public async Task<BundleJsonNode> SearchBundleAsync(string resourceType, string queryString, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resourceType);
+
+        var url = string.IsNullOrEmpty(queryString)
+            ? $"/{resourceType}"
+            : $"/{resourceType}?{queryString}";
+
+        var response = await _client.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSourceNodeFactory.Parse<BundleJsonNode>(responseJson);
+    }
+
+    /// <summary>
+    /// Executes a system-level search (no resource type) and returns the full Bundle.
+    /// Used for cross-resource-type searches with _type parameter.
+    /// </summary>
+    public async Task<BundleJsonNode> SearchSystemAsync(string queryString, CancellationToken cancellationToken = default)
+    {
+        var url = string.IsNullOrEmpty(queryString)
+            ? "/"
+            : $"/?{queryString}";
+
+        var response = await _client.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSourceNodeFactory.Parse<BundleJsonNode>(responseJson);
+    }
+
+    /// <summary>
+    /// Executes a search via GET request to a URL (for following next links).
+    /// </summary>
+    public async Task<BundleJsonNode> GetBundleAsync(string url, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        var response = await _client.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSourceNodeFactory.Parse<BundleJsonNode>(responseJson);
     }
 }


### PR DESCRIPTION
This pull request introduces tenant-aware search parameter handling across the application and refactors the CI pipeline to split unit and E2E tests, improving both correctness and CI speed. The main change is passing `tenantId` to the `SearchOptionsBuilderFactory.Create` method wherever search options are built, ensuring that tenant-specific search parameters (such as US Core) are used consistently for query parsing and resource indexing. The CI workflow now runs unit tests and E2E tests separately and in parallel, with improved logging and artifact handling.

**Tenant-aware search parameter handling:**

* Updated all usages of `SearchOptionsBuilderFactory.Create` in API endpoints, background operations, and conditional operation handlers to pass `tenantId`, ensuring tenant-specific search parameters are used for search and indexing. [[1]](diffhunk://#diff-c305e1345d447d0a6db78da1dd98fffac24e3ef0c07769f5607d01d1eedc2e91R230-R232) [[2]](diffhunk://#diff-3b5c4eb97d2cc87ca9a318a77d6e383a166fe64ff1ae85a7bb663b599b86cf4cR583-R586) [[3]](diffhunk://#diff-3b5c4eb97d2cc87ca9a318a77d6e383a166fe64ff1ae85a7bb663b599b86cf4cR669-R671) [[4]](diffhunk://#diff-3b5c4eb97d2cc87ca9a318a77d6e383a166fe64ff1ae85a7bb663b599b86cf4cR1433-R1435) [[5]](diffhunk://#diff-3b5c4eb97d2cc87ca9a318a77d6e383a166fe64ff1ae85a7bb663b599b86cf4cR1517-R1519) [[6]](diffhunk://#diff-d170aa0be7a0cb8fa27a9bba1dc4b5eead136397fe9b67946e802decd4802088L89-R90) [[7]](diffhunk://#diff-26d79cd60f7730ce862b70777bc71b8d7c9e327ea50999f277912cf23ecb6d10R86-R88) [[8]](diffhunk://#diff-618ef1e5b45732a81bf7e88b9a3dc7b7d45cede521d2ef6716b574f9ba1f67fbR56-R58) [[9]](diffhunk://#diff-c2008eb5445beafe9de3a6755e9fcc204381a873625e2a3a7a27275b809c7acfR66-R68) [[10]](diffhunk://#diff-d5513a72adb5d2ae7eb542e6c5af515ce972646348598e1b9a28a752576a389cR71-R73)

* Added a new cache to `SearchOptionsBuilderFactory` to support tenant-specific builders.

**CI workflow improvements:**

* Refactored `.github/workflows/ci.yml` to split the build-and-test job into `build-and-unit-tests` and a new parallel `e2e-tests-sql` job, with dedicated steps for SQL Server container setup, E2E test execution, result publishing, and improved error handling/logging. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR11-R16) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R131)

* Updated job dependencies and notification logic to account for the new split between unit and E2E tests, ensuring both must pass for CI success. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL96-R184) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL168-R260) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR272-R287)

**Search resource handler enhancements:**

* Added support for `_summary=count` searches in `SearchResourcesHandler`, returning only the total count when requested. [[1]](diffhunk://#diff-89f6c0158e4a9f21404acbc08e48cc084fd55c0ac32d024dccc51763b1518433R76-R91) [[2]](diffhunk://#diff-89f6c0158e4a9f21404acbc08e48cc084fd55c0ac32d024dccc51763b1518433R151-R156)

* Included `ResourceTypes` in the search options result for improved downstream handling.