### PR TITLE
Deploy sql bicep with aad admin

### DIFF
--- a/deploy/azure/modules/sql-server.bicep
+++ b/deploy/azure/modules/sql-server.bicep
@@ -12,35 +12,36 @@ param location string = resourceGroup().location
 @description('Environment name')
 param environment string = 'production'
 
-@description('SQL Server admin password (placeholder - Azure AD-only auth is used instead)')
-@minLength(8)
-@maxLength(128)
-@secure()
-param sqlAdminPassword string = newGuid()
+@description('User-Assigned Managed Identity principal ID (for SQL AAD admin) - REQUIRED for Entra-only auth')
+param sqlAdminPrincipalId string
 
-@description('User-Assigned Managed Identity principal ID (for SQL AAD admin)')
-param sqlAdminPrincipalId string = ''
-
-@description('User-Assigned Managed Identity name (for SQL AAD admin)')
-param sqlAdminName string = ''
+@description('User-Assigned Managed Identity name (for SQL AAD admin) - REQUIRED for Entra-only auth')
+param sqlAdminName string
 
 @description('Azure AD tenant ID')
 param tenantId string = subscription().tenantId
 
-// Create Azure SQL Server with System-Assigned Managed Identity
-// Uses Azure AD-only authentication (no local SQL logins)
-resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+// Create Azure SQL Server with Entra-only authentication enabled at creation time
+// This satisfies Azure Policy: "Azure SQL Database should have Microsoft Entra-only authentication enabled during creation"
+resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
   name: sqlServerName
   location: location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
-    administratorLogin: 'azureAdmin' // Placeholder, not used with AD-only auth
-    administratorLoginPassword: sqlAdminPassword // Placeholder, not used with AD-only auth
     version: '12.0'
     publicNetworkAccess: 'Enabled'
     minimalTlsVersion: '1.2'
+    // Entra-only authentication configured at creation time (required by policy)
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      principalType: 'Application'
+      login: sqlAdminName
+      sid: sqlAdminPrincipalId
+      tenantId: tenantId
+      azureADOnlyAuthentication: true
+    }
   }
   tags: {
     environment: environment
@@ -58,30 +59,8 @@ resource sqlFirewallRule 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
   }
 }
 
-// Configure User-Assigned Managed Identity as SQL Server admin (required for AAD-only authentication)
-resource sqlAadAdmin 'Microsoft.Sql/servers/administrators@2021-11-01' = if (!empty(sqlAdminPrincipalId) && !empty(sqlAdminName)) {
-  parent: sqlServer
-  name: 'ActiveDirectory'
-  properties: {
-    administratorType: 'ActiveDirectory'
-    login: sqlAdminName
-    sid: sqlAdminPrincipalId
-    tenantId: tenantId
-  }
-}
-
-// Enable Azure AD-only authentication (no local SQL logins)
-// NOTE: This depends on sqlAadAdmin being configured first
-resource sqlAzureAdOnlyAuth 'Microsoft.Sql/servers/azureADOnlyAuthentications@2021-11-01' = if (!empty(sqlAdminPrincipalId)) {
-  parent: sqlServer
-  name: 'Default'
-  properties: {
-    azureADOnlyAuthentication: true
-  }
-  dependsOn: [
-    sqlAadAdmin
-  ]
-}
+// NOTE: AAD admin and Entra-only auth are now configured inline on the SQL Server resource
+// to satisfy the Azure Policy requiring Entra-only auth during creation
 
 // Output SQL Server details
 output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName


### PR DESCRIPTION
This pull request updates the `sql-server.bicep` module to improve how Microsoft Entra-only (formerly Azure AD-only) authentication is configured for Azure SQL Servers. The main change is to set up Entra-only authentication and the admin identity directly during the SQL Server resource creation, which ensures compliance with Azure Policy requirements and simplifies the deployment.

Authentication and admin configuration improvements:

* The SQL Server resource now uses the `2023-05-01-preview` API version and configures Entra-only authentication and the admin identity inline during creation, eliminating the need for separate resources for admin assignment and authentication.
* Parameters for admin principal ID and name (`sqlAdminPrincipalId` and `sqlAdminName`) are now required and no longer have default values, reflecting that these are mandatory for Entra-only authentication.

Code simplification and policy compliance:

* Removed the separate `sqlAadAdmin` and `sqlAzureAdOnlyAuth` resources, as these are now handled directly in the main SQL Server resource. This change also ensures that the deployment satisfies the Azure Policy requiring Entra-only authentication at creation time.