### PR TITLE
Builds in the common case resolver for fhirpath

### DIFF
--- a/src/Core/Ignixa.FhirPath/Evaluation/Functions/FhirSpecificFunctions.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/Functions/FhirSpecificFunctions.cs
@@ -60,56 +60,40 @@ internal static class FhirSpecificFunctions
 
     /// <summary>
     /// resolve() - Takes a Reference element and resolves it to the actual resource.
-    /// Returns empty if the reference cannot be resolved or if ElementResolver is not configured.
+    /// Returns LazyResolvedElement that parses reference for type checks without DB lookup.
     /// Per FHIR spec: resolve() returns empty on failure (does not throw).
     /// </summary>
     public static IEnumerable<IElement> Resolve(
         IEnumerable<IElement> focus,
         EvaluationContext context)
     {
-        // resolve() : collection
-        // Takes a Reference element and resolves it to the actual resource.
-        // Returns empty if the reference cannot be resolved or if ElementResolver is not configured.
-        // Per FHIR spec: resolve() returns empty on failure (does not throw).
-
         var results = new List<IElement>();
 
-        if (context is not FhirEvaluationContext fhirContext || fhirContext.ElementResolver == null)
+        Func<string, IElement?>? fullResolver = null;
+        if (context is FhirEvaluationContext fhirContext && fhirContext.ElementResolver != null)
         {
-            // No resolver available - return empty (this is expected during indexing)
-            return results;
+            fullResolver = fhirContext.ElementResolver;
         }
 
         foreach (var element in focus)
         {
-            // resolve() only works on Reference types
             if (element.InstanceType != "Reference" && element.InstanceType != "ResourceReference")
             {
-                // Not a reference - skip
                 continue;
             }
 
-            // Extract the reference string (e.g., "Patient/123" or "http://example.org/fhir/Patient/123")
             var referenceValue = element.Scalar("reference") as string;
             if (string.IsNullOrEmpty(referenceValue))
             {
-                // No reference value - skip
                 continue;
             }
 
-            // Call the ElementResolver to resolve the reference
             try
             {
-                var resolved = fhirContext.ElementResolver(referenceValue);
-                if (resolved != null)
-                {
-                    results.Add(resolved);
-                }
-                // If resolved is null, the reference couldn't be resolved - skip silently
+                results.Add(new LazyResolvedElement(referenceValue, fullResolver));
             }
             catch
             {
-                // If resolution fails, skip silently (FHIR spec: resolve() returns empty on failure)
                 continue;
             }
         }

--- a/src/Core/Ignixa.FhirPath/Evaluation/LazyResolvedElement.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/LazyResolvedElement.cs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * LazyResolvedElement provides lightweight parsing for resolve() function.
+ * Parses reference strings ("Patient/123") for type checks without DB lookup.
+ * Triggers optional ElementResolver delegate only when accessing properties beyond id/resourceType.
+ */
+
+using System.Text.RegularExpressions;
+using Ignixa.Abstractions;
+using Ignixa.FhirPath.Evaluation.Functions;
+
+namespace Ignixa.FhirPath.Evaluation;
+
+/// <summary>
+/// Lazy implementation of IElement for resolve() function.
+/// Parses reference strings for lightweight type checks, triggers full resolution only when needed.
+/// </summary>
+internal class LazyResolvedElement : IElement
+{
+    private static readonly Regex ReferenceRegex = new(
+        @"(?:(?<baseUrl>.+)/)?(?<resourceType>[A-Z][a-zA-Z]+)/(?<resourceId>[A-Za-z0-9\-\.]{1,64})(?:/_history/[A-Za-z0-9\-\.]{1,64})?",
+        RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+    private readonly string _reference;
+    private readonly Func<string, IElement?>? _fullResolver;
+    private IElement? _fullElement;
+    private bool _resolverInvoked;
+    private string? _resourceType;
+    private string? _resourceId;
+    private bool _parsed;
+
+    public LazyResolvedElement(string reference, Func<string, IElement?>? fullResolver = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reference);
+        _reference = reference;
+        _fullResolver = fullResolver;
+    }
+
+    public string Name => string.Empty;
+
+    public string InstanceType
+    {
+        get
+        {
+            EnsureParsed();
+            return _resourceType ?? "Resource";
+        }
+    }
+
+    public object? Value => null;
+
+    public string Location => _reference;
+
+    public IType? Type => null;
+
+    public IReadOnlyList<IElement> Children(string? name = null)
+    {
+        if (name == "id")
+        {
+            EnsureParsed();
+            if (_resourceId != null)
+            {
+                return [new PrimitiveElement(_resourceId, "id")];
+            }
+            return [];
+        }
+
+        if (name == "resourceType")
+        {
+            EnsureParsed();
+            if (_resourceType != null)
+            {
+                return [new PrimitiveElement(_resourceType, "code")];
+            }
+            return [];
+        }
+
+        if (name == null)
+        {
+            var fullElement = GetFullElement();
+            return fullElement?.Children(null) ?? [];
+        }
+
+        var element = GetFullElement();
+        return element?.Children(name) ?? [];
+    }
+
+    public T? Meta<T>() where T : class => null;
+
+    private void EnsureParsed()
+    {
+        if (_parsed) return;
+
+        var match = ReferenceRegex.Match(_reference);
+        if (match.Success)
+        {
+            _resourceType = match.Groups["resourceType"].Value;
+            _resourceId = match.Groups["resourceId"].Value;
+        }
+
+        _parsed = true;
+    }
+
+    private IElement? GetFullElement()
+    {
+        if (_resolverInvoked)
+        {
+            return _fullElement;
+        }
+
+        _resolverInvoked = true;
+
+        if (_fullResolver != null)
+        {
+            _fullElement = _fullResolver(_reference);
+        }
+
+        return _fullElement;
+    }
+
+    private class PrimitiveElement(object value, string instanceType) : IElement
+    {
+        public string Name => string.Empty;
+        public string InstanceType => instanceType;
+        public object Value => value;
+        public string Location => string.Empty;
+        public IType? Type => null;
+        public IReadOnlyList<IElement> Children(string? name = null) => [];
+        public T? Meta<T>() where T : class => null;
+    }
+}

--- a/src/Core/Ignixa.Search/Indexing/ElementSearchIndexer.cs
+++ b/src/Core/Ignixa.Search/Indexing/ElementSearchIndexer.cs
@@ -24,7 +24,6 @@ public partial class ElementSearchIndexer : ISearchIndexer
 {
     private readonly IElementToSearchValueConverterManager _fhirElementTypeConverterManager;
     private readonly ILogger<ElementSearchIndexer> _logger;
-    private readonly IReferenceToElementResolver _referenceToElementResolver;
     private readonly ISupportedSearchParameterDefinitionManager _searchParameterDefinitionManager;
     private readonly ConcurrentDictionary<string, List<string>> _targetTypesLookup = new();
 
@@ -33,22 +32,18 @@ public partial class ElementSearchIndexer : ISearchIndexer
     /// </summary>
     /// <param name="searchParameterDefinitionManager">The search parameter definition manager.</param>
     /// <param name="fhirElementTypeConverterManager">The FHIR element type converter manager.</param>
-    /// <param name="referenceToElementResolver">Used for parsing reference strings</param>
     /// <param name="logger">The logger.</param>
     public ElementSearchIndexer(
         ISupportedSearchParameterDefinitionManager searchParameterDefinitionManager,
         IElementToSearchValueConverterManager fhirElementTypeConverterManager,
-        IReferenceToElementResolver referenceToElementResolver,
         ILogger<ElementSearchIndexer> logger)
     {
         EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
         EnsureArg.IsNotNull(fhirElementTypeConverterManager, nameof(fhirElementTypeConverterManager));
-        EnsureArg.IsNotNull(referenceToElementResolver, nameof(referenceToElementResolver));
         EnsureArg.IsNotNull(logger, nameof(logger));
 
         _searchParameterDefinitionManager = searchParameterDefinitionManager;
         _fhirElementTypeConverterManager = fhirElementTypeConverterManager;
-        _referenceToElementResolver = referenceToElementResolver;
         _logger = logger;
     }
 
@@ -59,13 +54,10 @@ public partial class ElementSearchIndexer : ISearchIndexer
 
         var entries = new List<SearchIndexEntry>();
 
-        var context = new FhirEvaluationContext();
-
-        // Our FhirEvaluationContext uses IElement directly - no need for ToPocoNode()
-        context.ElementResolver = str => _referenceToElementResolver.Resolve(str);
-
-        // This allows resolving %resource FhirPath to provided value
-        context.Resource = resource;
+        var context = new FhirEvaluationContext
+        {
+            Resource = resource
+        };
 
         IEnumerable<SearchParameterInfo> searchParameters = _searchParameterDefinitionManager.GetSearchParameters(resource.InstanceType);
 

--- a/src/Core/Ignixa.Search/Indexing/SearchIndexerFactory.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchIndexerFactory.cs
@@ -20,27 +20,22 @@ public static class SearchIndexerFactory
         ILoggerFactory loggerProvider,
         ISearchParameterDefinitionManager searchParameterDefinitionManager = null)
     {
-        // If no manager provided, create new instance (backward compatibility)
         var definitionManager = searchParameterDefinitionManager
             ?? new SearchParameterDefinitionManager(fhirSchemaProvider, loggerProvider.CreateLogger<SearchParameterDefinitionManager>());
 
         var referenceParser = new ReferenceSearchValueParser(fhirSchemaProvider);
-        var elementResolver = new LightweightReferenceToElementResolver(referenceParser, fhirSchemaProvider);
         var codesystems = new CodeSystemResolver(fhirSchemaProvider.Version);
 
         IElementToSearchValueConverter[] converters = typeof(ElementSearchIndexer)
             .Assembly
             .ExportedTypes
             .Where(x => typeof(IElementToSearchValueConverter).IsAssignableFrom(x) && !x.IsAbstract && !x.IsGenericType)
-            .Select(x => (IElementToSearchValueConverter)CreateTypeWithArguments(x, fhirSchemaProvider, referenceParser, elementResolver, codesystems, fhirSchemaProvider.Version))
+            .Select(x => (IElementToSearchValueConverter)CreateTypeWithArguments(x, fhirSchemaProvider, referenceParser, codesystems, fhirSchemaProvider.Version))
             .ToArray();
-
-        // Manager is now initialized synchronously in constructor with pre-generated search parameters
 
         return new ElementSearchIndexer(
             new SupportedSearchParameterDefinitionManager(definitionManager),
             new FhirElementToSearchValueConverterManager(converters),
-            elementResolver,
             loggerProvider.CreateLogger<ElementSearchIndexer>());
     }
 

--- a/test/Ignixa.FhirPath.Tests/Evaluation/LazyResolvedElementTests.cs
+++ b/test/Ignixa.FhirPath.Tests/Evaluation/LazyResolvedElementTests.cs
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Unit tests for LazyResolvedElement - lazy resolution architecture for resolve() function.
+ */
+
+using Ignixa.Abstractions;
+using Ignixa.FhirPath.Evaluation;
+using Ignixa.FhirPath.Evaluation.Functions;
+using Shouldly;
+
+namespace Ignixa.FhirPath.Tests.Evaluation;
+
+public class LazyResolvedElementTests
+{
+    [Fact]
+    public void GivenRelativeReference_WhenGettingInstanceType_ThenParsesResourceTypeWithoutResolver()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenAbsoluteReference_WhenGettingInstanceType_ThenParsesResourceTypeWithoutResolver()
+    {
+        var element = new LazyResolvedElement("http://example.org/fhir/Patient/123");
+
+        element.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenRelativeReference_WhenAccessingIdChild_ThenReturnsIdWithoutResolver()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        var children = element.Children("id");
+
+        children.ShouldNotBeEmpty();
+        children.Count.ShouldBe(1);
+        children[0].Value.ShouldBe("123");
+        children[0].InstanceType.ShouldBe("id");
+    }
+
+    [Fact]
+    public void GivenAbsoluteReference_WhenAccessingIdChild_ThenReturnsIdWithoutResolver()
+    {
+        var element = new LazyResolvedElement("http://example.org/fhir/Patient/456");
+
+        var children = element.Children("id");
+
+        children.ShouldNotBeEmpty();
+        children.Count.ShouldBe(1);
+        children[0].Value.ShouldBe("456");
+    }
+
+    [Fact]
+    public void GivenRelativeReference_WhenAccessingResourceTypeChild_ThenReturnsResourceTypeWithoutResolver()
+    {
+        var element = new LazyResolvedElement("Observation/789");
+
+        var children = element.Children("resourceType");
+
+        children.ShouldNotBeEmpty();
+        children.Count.ShouldBe(1);
+        children[0].Value.ShouldBe("Observation");
+        children[0].InstanceType.ShouldBe("code");
+    }
+
+    [Fact]
+    public void GivenReferenceWithHistoryVersion_WhenAccessingId_ThenReturnsIdWithoutVersion()
+    {
+        var element = new LazyResolvedElement("Patient/123/_history/2");
+
+        var children = element.Children("id");
+
+        children.ShouldNotBeEmpty();
+        children[0].Value.ShouldBe("123");
+    }
+
+    [Fact]
+    public void GivenNoResolver_WhenAccessingOtherProperty_ThenReturnsEmpty()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        var children = element.Children("name");
+
+        children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenResolver_WhenAccessingOtherProperty_ThenInvokesResolver()
+    {
+        var resolverInvoked = false;
+        IElement? mockPatient = new MockElement("Patient", "123");
+
+        var element = new LazyResolvedElement("Patient/123", reference =>
+        {
+            resolverInvoked = true;
+            reference.ShouldBe("Patient/123");
+            return mockPatient;
+        });
+
+        var children = element.Children("name");
+
+        resolverInvoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenResolver_WhenAccessingMultipleProperties_ThenInvokesResolverOnlyOnce()
+    {
+        var resolverCallCount = 0;
+        IElement mockPatient = new MockElement("Patient", "123");
+
+        var element = new LazyResolvedElement("Patient/123", reference =>
+        {
+            resolverCallCount++;
+            return mockPatient;
+        });
+
+        var name1 = element.Children("name");
+        var name2 = element.Children("name");
+        var birthDate = element.Children("birthDate");
+
+        resolverCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenResolver_WhenAccessingIdBeforeOtherProperty_ThenDoesNotInvokeResolverForId()
+    {
+        var resolverInvoked = false;
+        IElement mockPatient = new MockElement("Patient", "123");
+
+        var element = new LazyResolvedElement("Patient/123", reference =>
+        {
+            resolverInvoked = true;
+            return mockPatient;
+        });
+
+        var id = element.Children("id");
+        id.ShouldNotBeEmpty();
+        id[0].Value.ShouldBe("123");
+        resolverInvoked.ShouldBeFalse();
+
+        var name = element.Children("name");
+        resolverInvoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenInvalidReference_WhenAccessingId_ThenReturnsEmpty()
+    {
+        var element = new LazyResolvedElement("not-a-valid-reference");
+
+        var children = element.Children("id");
+
+        children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenInvalidReference_WhenGettingInstanceType_ThenReturnsResourceFallback()
+    {
+        var element = new LazyResolvedElement("not-a-valid-reference");
+
+        element.InstanceType.ShouldBe("Resource");
+    }
+
+    [Fact]
+    public void GivenResolver_WhenAccessingAllChildren_ThenInvokesResolver()
+    {
+        var resolverInvoked = false;
+        IElement mockPatient = new MockElement("Patient", "123");
+
+        var element = new LazyResolvedElement("Patient/123", reference =>
+        {
+            resolverInvoked = true;
+            return mockPatient;
+        });
+
+        var children = element.Children(null);
+
+        resolverInvoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenNoResolver_WhenAccessingAllChildren_ThenReturnsEmpty()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        var children = element.Children(null);
+
+        children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenResolverReturnsNull_WhenAccessingProperty_ThenReturnsEmpty()
+    {
+        var element = new LazyResolvedElement("Patient/123", reference => null);
+
+        var children = element.Children("name");
+
+        children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenLocationProperty_WhenAccessed_ThenReturnsOriginalReference()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.Location.ShouldBe("Patient/123");
+    }
+
+    [Fact]
+    public void GivenValueProperty_WhenAccessed_ThenReturnsNull()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenTypeProperty_WhenAccessed_ThenReturnsNull()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.Type.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNameProperty_WhenAccessed_ThenReturnsEmptyString()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.Name.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void GivenMetaMethod_WhenCalled_ThenReturnsNull()
+    {
+        var element = new LazyResolvedElement("Patient/123");
+
+        element.Meta<object>().ShouldBeNull();
+    }
+
+    private class MockElement : IElement
+    {
+        public MockElement(string instanceType, string id)
+        {
+            InstanceType = instanceType;
+            Name = string.Empty;
+            Location = $"{instanceType}/{id}";
+        }
+
+        public string Name { get; }
+        public object? Value => null;
+        public string InstanceType { get; }
+        public string Location { get; }
+        public IType? Type => null;
+        public IReadOnlyList<IElement> Children(string? name = null) => [];
+        public T? Meta<T>() where T : class => null;
+    }
+}

--- a/test/Ignixa.FhirPath.Tests/FhirPathEvaluatorTests.cs
+++ b/test/Ignixa.FhirPath.Tests/FhirPathEvaluatorTests.cs
@@ -991,4 +991,286 @@ public class FhirPathEvaluatorTests
     }
 
     #endregion
+
+    #region Resolve() Function Tests
+
+    [Fact]
+    public void GivenReferenceElement_WhenCallingResolveWithoutResolver_ThenReturnsLazyElementForTypeCheck()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "Patient/123"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve()");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("Patient", resultList[0].InstanceType);
+    }
+
+    [Fact]
+    public void GivenReferenceElement_WhenCheckingResolvedTypeWithoutResolver_ThenTypeCheckWorks()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "participant": [
+            {
+              "individual": {
+                "reference": "Practitioner/456"
+              }
+            }
+          ]
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "participant.individual.where(resolve() is Practitioner)");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+    }
+
+    [Fact]
+    public void GivenReferenceElement_WhenAccessingIdWithoutResolver_ThenReturnsIdFromReference()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "Patient/test-123"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve().id");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("test-123", resultList[0].Value);
+    }
+
+    [Fact]
+    public void GivenReferenceElement_WhenAccessingResourceTypeWithoutResolver_ThenReturnsResourceType()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "Observation/obs-789"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve().resourceType");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("Observation", resultList[0].Value);
+    }
+
+    [Fact]
+    public void GivenReferenceElement_WhenAccessingOtherPropertyWithoutResolver_ThenReturnsEmpty()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "Patient/123"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve().name.family");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GivenReferenceElement_WhenAccessingPropertyWithResolver_ThenCallsResolver()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "Patient/123"
+          }
+        }
+        """;
+
+        var patientJson = """
+        {
+          "resourceType": "Patient",
+          "id": "123",
+          "name": [
+            {
+              "family": "Smith"
+            }
+          ]
+        }
+        """;
+
+        var encounter = ResourceJsonNode.Parse(encounterJson);
+        var encounterElement = encounter.ToElement(_r4Provider);
+
+        var patient = ResourceJsonNode.Parse(patientJson);
+        var patientElement = patient.ToElement(_r4Provider);
+
+        var context = new FhirEvaluationContext
+        {
+            ElementResolver = reference =>
+            {
+                if (reference == "Patient/123")
+                    return patientElement;
+                return null;
+            }
+        };
+
+        var expression = _parser.Parse("subject.resolve().name.family");
+        var result = _evaluator.Evaluate(encounterElement, expression, context);
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("Smith", resultList[0].Value);
+    }
+
+    [Fact]
+    public void GivenAbsoluteReference_WhenResolvingWithoutResolver_ThenParsesTypeCorrectly()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "http://example.org/fhir/Patient/abc-def-123"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve()");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("Patient", resultList[0].InstanceType);
+    }
+
+    [Fact]
+    public void GivenAbsoluteReference_WhenAccessingIdWithoutResolver_ThenReturnsId()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "reference": "https://example.org/fhir/Patient/xyz-789"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve().id");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal("xyz-789", resultList[0].Value);
+    }
+
+    [Fact]
+    public void GivenChainedResolve_WhenResolvingWithoutResolver_ThenTypeChecksWork()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "serviceProvider": {
+            "reference": "Organization/org-123"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "serviceProvider.resolve() is Organization");
+
+        var resultList = result.ToList();
+        Assert.Single(resultList);
+        Assert.Equal(true, resultList[0].Value);
+    }
+
+    [Fact]
+    public void GivenNonReferenceElement_WhenCallingResolve_ThenReturnsEmpty()
+    {
+        var patientJson = """
+        {
+          "resourceType": "Patient",
+          "id": "123",
+          "name": [
+            {
+              "family": "Smith"
+            }
+          ]
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(patientJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "name.resolve()");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GivenEmptyReference_WhenCallingResolve_ThenReturnsEmpty()
+    {
+        var encounterJson = """
+        {
+          "resourceType": "Encounter",
+          "id": "enc1",
+          "subject": {
+            "display": "Patient without reference"
+          }
+        }
+        """;
+
+        var resource = ResourceJsonNode.Parse(encounterJson);
+        var element = resource.ToElement(_r4Provider);
+
+        var result = EvaluatePath(element, "subject.resolve()");
+
+        Assert.Empty(result);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
This pull request introduces a new lazy resolution architecture for the FHIRPath `resolve()` function, improving performance and simplifying reference handling. The main change is the implementation of the `LazyResolvedElement` class, which parses reference strings for type checks without triggering database lookups, only invoking full resolution when necessary. The PR also removes the need for the previous `IReferenceToElementResolver` dependency and updates related code to use the new approach. Comprehensive unit tests are added to validate the lazy resolution behavior.

### Lazy resolution for FHIRPath references

* Added the new `LazyResolvedElement` class in `src/Core/Ignixa.FhirPath/Evaluation/LazyResolvedElement.cs`, which parses reference strings for resource type and ID, and only triggers full resolution via an optional resolver delegate when non-basic properties are accessed.
* Refactored the `resolve()` function in `FhirSpecificFunctions.cs` to return `LazyResolvedElement` instances, enabling lightweight parsing and deferred resolution.

### Removal of old reference resolution mechanism

* Removed the `IReferenceToElementResolver` dependency from `ElementSearchIndexer`, including constructor parameters and usage, simplifying the indexing logic. [[1]](diffhunk://#diff-2fd03e38c9796b9fe80e3d582965e537d73f1756c7351ee543398e3ba07598b6L27) [[2]](diffhunk://#diff-2fd03e38c9796b9fe80e3d582965e537d73f1756c7351ee543398e3ba07598b6L36-L51) [[3]](diffhunk://#diff-2fd03e38c9796b9fe80e3d582965e537d73f1756c7351ee543398e3ba07598b6L62-R60)
* Updated `SearchIndexerFactory.cs` to remove creation and injection of the old resolver, reflecting the new lazy resolution design.

### Testing and validation

* Added a comprehensive test suite for `LazyResolvedElement` in `test/Ignixa.FhirPath.Tests/Evaluation/LazyResolvedElementTests.cs`, covering parsing behavior, resolver invocation, and property access patterns.