### PR TITLE
enable large_files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
           files: '**/e2e-test-results.trx'
           check_name: 'E2E Test Results'
           comment_mode: 'off'
+          large_files: true
 
       - name: Capture SQL Server logs on failure
         if: failure()


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The change enables support for handling large files in the E2E test results step.

* CI workflow: Added the `large_files: true` option to the E2E test results upload step in `.github/workflows/ci.yml`.