### PR TITLE
Cleaned up namespaces for IFhirSchemaProvider

### DIFF
--- a/bench/Ignixa.Benchmarks/FhirPathBenchmarks.cs
+++ b/bench/Ignixa.Benchmarks/FhirPathBenchmarks.cs
@@ -5,6 +5,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath;
 using Ignixa.Application.Features.Search;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.FhirPath.Evaluation;
 using Ignixa.FhirPath.Parser;

--- a/codegen/Ignixa.Specification.Generators/CSharpCoreSchemaLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpCoreSchemaLanguage.cs
@@ -121,7 +121,7 @@ public sealed class CSharpCoreSchemaLanguage : ILanguage
         sb.AppendLine($"/// Pre-generated IFhirSchemaProvider for FHIR {fhirVersion}.");
         sb.AppendLine("/// This provider uses IType and ITypeExtended interfaces for type metadata.");
         sb.AppendLine("/// </summary>");
-        sb.AppendLine($"public sealed partial class {fhirVersion}CoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider");
+        sb.AppendLine($"public sealed partial class {fhirVersion}CoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider");
         sb.AppendLine("{");
 
         // ISchema.Version property (explicit interface implementation)

--- a/src/Application/Ignixa.Api.OpenIddict/Extensions/OpenIddictServiceExtensions.cs
+++ b/src/Application/Ignixa.Api.OpenIddict/Extensions/OpenIddictServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Ignixa.Api.OpenIddict.Configuration;
 using Ignixa.Api.OpenIddict.Data;
 using Ignixa.Api.OpenIddict.Services;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/Application/Ignixa.Api.OpenIddict/Services/SmartScopeGenerator.cs
+++ b/src/Application/Ignixa.Api.OpenIddict/Services/SmartScopeGenerator.cs
@@ -8,7 +8,7 @@ namespace Ignixa.Api.OpenIddict.Services;
 /// </summary>
 /// <remarks>
 /// This generator is version-agnostic. Resource types should be provided from
-/// <see cref="Ignixa.Specification.IFhirSchemaProvider.ResourceTypeNames"/> for
+/// <see cref="Ignixa.Abstractions.IFhirSchemaProvider.ResourceTypeNames"/> for
 /// proper multi-version FHIR support.
 /// </remarks>
 public static partial class SmartScopeGenerator

--- a/src/Application/Ignixa.Application/Features/Specification/ICompositeSchemaProviderRegistry.cs
+++ b/src/Application/Ignixa.Application/Features/Specification/ICompositeSchemaProviderRegistry.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.Application.Features.Specification;

--- a/src/Application/Ignixa.Web/Program.cs
+++ b/src/Application/Ignixa.Web/Program.cs
@@ -13,6 +13,7 @@ using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Constants;
 using Ignixa.Domain.Models;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Core/Ignixa.Abstractions/Structure/IFhirSchemaProvider.cs
+++ b/src/Core/Ignixa.Abstractions/Structure/IFhirSchemaProvider.cs
@@ -5,7 +5,7 @@
 
 using Ignixa.Abstractions;
 
-namespace Ignixa.Specification;
+namespace Ignixa.Abstractions;
 
 /// <summary>
 /// Provides FHIR schema metadata for a specific FHIR version.

--- a/src/Core/Ignixa.FhirFakes/Builders/CareTeamBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/CareTeamBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/DiagnosticReportBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/DiagnosticReportBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification;

--- a/src/Core/Ignixa.FhirFakes/Builders/GroupBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/GroupBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/HealthcareServiceBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/HealthcareServiceBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/LocationBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/LocationBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/MedicationDispenseBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/MedicationDispenseBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/MedicationRequestBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/MedicationRequestBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/ObservationBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/ObservationBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/OrganizationAffiliationBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/OrganizationAffiliationBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/OrganizationBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/OrganizationBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Serialization;

--- a/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
 using Bogus;
 using Ignixa.FhirFakes.Builders.Profiles;
 using Ignixa.FhirFakes.Population;

--- a/src/Core/Ignixa.FhirFakes/Builders/PatientBuilderFactory.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PatientBuilderFactory.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Population;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Builders;

--- a/src/Core/Ignixa.FhirFakes/Builders/PractitionerBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PractitionerBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/PractitionerRoleBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PractitionerRoleBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/RiskAssessmentBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/RiskAssessmentBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Builders/ValueSetBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/ValueSetBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/AdultWellnessSchedule.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/AdultWellnessSchedule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Scenarios;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/ILifecycleEvent.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/ILifecycleEvent.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Scenarios;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/ImmunizationScheduleEvent.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/ImmunizationScheduleEvent.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Lifecycle;
 

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/LifecycleExampleScenarios.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/LifecycleExampleScenarios.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Lifecycle;
 

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/PatientLifecycleGenerator.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/PatientLifecycleGenerator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Scenarios;

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/PediatricWellnessSchedule.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/PediatricWellnessSchedule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Scenarios;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Lifecycle/ProbabilisticConditionOnset.cs
+++ b/src/Core/Ignixa.FhirFakes/Lifecycle/ProbabilisticConditionOnset.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.Specification;

--- a/src/Core/Ignixa.FhirFakes/Population/PopulationGenerator.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/PopulationGenerator.cs
@@ -3,12 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Lifecycle;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Population;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/AdultWellnessSchedule.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/AdultWellnessSchedule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Scenarios.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ILifecycleEvent.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ILifecycleEvent.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Scenarios.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ImmunizationScheduleEvent.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ImmunizationScheduleEvent.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Lifecycle;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/PediatricWellnessSchedule.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/PediatricWellnessSchedule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.FhirFakes.Scenarios.Lifecycle;

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ProbabilisticConditionOnset.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Lifecycle/ProbabilisticConditionOnset.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Lifecycle;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/AsthmaticChildScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/AsthmaticChildScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/CancerCarePathwayScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/CancerCarePathwayScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/CardiovascularScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/CardiovascularScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/ChronicDiseaseScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/ChronicDiseaseScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/ComprehensivePreventiveCareScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/ComprehensivePreventiveCareScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/DiabeticPatientScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/DiabeticPatientScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EarInfectionScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EarInfectionScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EmergencyDepartmentScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EmergencyDepartmentScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EnhancedWellnessVisitScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/EnhancedWellnessVisitScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/HypertensivePatientScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/HypertensivePatientScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/MentalHealthTreatmentScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/MentalHealthTreatmentScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/MetabolicSyndromeProgressionScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/MetabolicSyndromeProgressionScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/PediatricAsthmaOnsetScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/PediatricAsthmaOnsetScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/PregnantPatientScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/PregnantPatientScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/SurgicalPathwayScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/SurgicalPathwayScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/UrinaryTractInfectionScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/UrinaryTractInfectionScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/WellnessVisitScenario.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/Predefined/WellnessVisitScenario.cs
@@ -5,7 +5,9 @@
 
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.Predefined;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/ScenarioBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/ScenarioBuilder.cs
@@ -7,7 +7,9 @@ using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Population;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Specification.Extensions;
 
 namespace Ignixa.FhirFakes.Scenarios;

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/ImmunizationState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/ImmunizationState.cs
@@ -6,8 +6,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using Bogus;
+using Ignixa.Abstractions;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.FhirFakes.Scenarios.States;
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/PatientBuilderState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/PatientBuilderState.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Builders.Profiles;
 using Ignixa.Serialization.SourceNodes;

--- a/src/Core/Ignixa.FhirPath/Analysis/AnalysisContext.cs
+++ b/src/Core/Ignixa.FhirPath/Analysis/AnalysisContext.cs
@@ -4,9 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Immutable;
+using Ignixa.Abstractions;
 using Ignixa.FhirPath.Expressions;
 using Ignixa.FhirPath.Visitors;
-using Ignixa.Specification;
 
 namespace Ignixa.FhirPath.Analysis;
 

--- a/src/Core/Ignixa.FhirPath/Analysis/FhirPathAnalyzer.cs
+++ b/src/Core/Ignixa.FhirPath/Analysis/FhirPathAnalyzer.cs
@@ -7,7 +7,6 @@ using Ignixa.Abstractions;
 using Ignixa.FhirPath.Expressions;
 using Ignixa.FhirPath.Parser;
 using Ignixa.FhirPath.Visitors;
-using Ignixa.Specification;
 
 namespace Ignixa.FhirPath.Analysis;
 

--- a/src/Core/Ignixa.FhirPath/Ignixa.FhirPath.csproj
+++ b/src/Core/Ignixa.FhirPath/Ignixa.FhirPath.csproj
@@ -23,7 +23,6 @@
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Ignixa.Specification\Ignixa.Specification.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Ignixa.FhirPath/Visitors/FhirPathTypeSet.cs
+++ b/src/Core/Ignixa.FhirPath/Visitors/FhirPathTypeSet.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.ObjectModel;
 using Ignixa.Abstractions;
-using Ignixa.Specification;
 
 namespace Ignixa.FhirPath.Visitors;
 

--- a/src/Core/Ignixa.FhirPath/Visitors/FhirPathVisitorContext.cs
+++ b/src/Core/Ignixa.FhirPath/Visitors/FhirPathVisitorContext.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Immutable;
-using Ignixa.Specification;
+using Ignixa.Abstractions;
 
 namespace Ignixa.FhirPath.Visitors;
 

--- a/src/Core/Ignixa.FhirPath/Visitors/SymbolTable.cs
+++ b/src/Core/Ignixa.FhirPath/Visitors/SymbolTable.cs
@@ -3,8 +3,8 @@
 // Licensed under the MIT License. See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using Ignixa.FhirPath.Expressions;
-using Ignixa.Specification;
 
 namespace Ignixa.FhirPath.Visitors;
 

--- a/src/Core/Ignixa.NarrativeGenerator/Engine/ScriptFunctions/FhirPathScriptFunctions.cs
+++ b/src/Core/Ignixa.NarrativeGenerator/Engine/ScriptFunctions/FhirPathScriptFunctions.cs
@@ -10,7 +10,6 @@ using Ignixa.FhirPath.Evaluation;
 using Ignixa.FhirPath.Parser;
 using Ignixa.Serialization;
 using Ignixa.Serialization.SourceNodes;
-using Ignixa.Specification;
 
 namespace Ignixa.NarrativeGenerator.Engine.ScriptFunctions;
 

--- a/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License (MIT).See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Globalization;
 using EnsureThat;
 using Ignixa.Specification;

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License (MIT).See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Globalization;
 using EnsureThat;
 using Ignixa.Search.Exceptions;

--- a/src/Core/Ignixa.Search/Indexing/SearchIndexerFactory.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchIndexerFactory.cs
@@ -5,6 +5,7 @@
 
 using System.Reflection;
 using EnsureThat;
+using Ignixa.Abstractions;
 using Microsoft.Extensions.Logging;
 using Ignixa.Specification;
 using Ignixa.Search.Definition;

--- a/src/Core/Ignixa.Search/Indexing/SearchValues/ReferenceSearchValueParser.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchValues/ReferenceSearchValueParser.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License (MIT).See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.RegularExpressions;
 using EnsureThat;
 using Ignixa.Specification;

--- a/src/Core/Ignixa.Specification/Generated/R4BCoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R4BCoreSchemaProvider.g.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Specification.Generated;
 /// Pre-generated IFhirSchemaProvider for FHIR R4B.
 /// This provider uses IType and ITypeExtended interfaces for type metadata.
 /// </summary>
-public sealed partial class R4BCoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider
+public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider
 {
     Ignixa.Abstractions.FhirVersion Ignixa.Abstractions.ISchema.Version => Ignixa.Abstractions.FhirVersion.R4B;
 

--- a/src/Core/Ignixa.Specification/Generated/R4CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R4CoreSchemaProvider.g.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Specification.Generated;
 /// Pre-generated IFhirSchemaProvider for FHIR R4.
 /// This provider uses IType and ITypeExtended interfaces for type metadata.
 /// </summary>
-public sealed partial class R4CoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider
+public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider
 {
     Ignixa.Abstractions.FhirVersion Ignixa.Abstractions.ISchema.Version => Ignixa.Abstractions.FhirVersion.R4;
 

--- a/src/Core/Ignixa.Specification/Generated/R5CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R5CoreSchemaProvider.g.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Specification.Generated;
 /// Pre-generated IFhirSchemaProvider for FHIR R5.
 /// This provider uses IType and ITypeExtended interfaces for type metadata.
 /// </summary>
-public sealed partial class R5CoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider
+public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider
 {
     Ignixa.Abstractions.FhirVersion Ignixa.Abstractions.ISchema.Version => Ignixa.Abstractions.FhirVersion.R5;
 

--- a/src/Core/Ignixa.Specification/Generated/R6CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R6CoreSchemaProvider.g.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Specification.Generated;
 /// Pre-generated IFhirSchemaProvider for FHIR R6.
 /// This provider uses IType and ITypeExtended interfaces for type metadata.
 /// </summary>
-public sealed partial class R6CoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider
+public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider
 {
     Ignixa.Abstractions.FhirVersion Ignixa.Abstractions.ISchema.Version => Ignixa.Abstractions.FhirVersion.R6;
 

--- a/src/Core/Ignixa.Specification/Generated/STU3CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/STU3CoreSchemaProvider.g.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Specification.Generated;
 /// Pre-generated IFhirSchemaProvider for FHIR STU3.
 /// This provider uses IType and ITypeExtended interfaces for type metadata.
 /// </summary>
-public sealed partial class STU3CoreSchemaProvider : Ignixa.Specification.IFhirSchemaProvider
+public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSchemaProvider
 {
     Ignixa.Abstractions.FhirVersion Ignixa.Abstractions.ISchema.Version => Ignixa.Abstractions.FhirVersion.Stu3;
 

--- a/test/Ignixa.Api.E2ETests/_Infrastructure/Harness/SearchTestHarness.cs
+++ b/test/Ignixa.Api.E2ETests/_Infrastructure/Harness/SearchTestHarness.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Ignixa.Application.Features.Metadata.Models;

--- a/test/Ignixa.Api.E2ETests/_TestData/Fixtures/DataTypeSearch/CompositeSearchFixture.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Fixtures/DataTypeSearch/CompositeSearchFixture.cs
@@ -82,7 +82,7 @@ public class CompositeSearchFixture : IAsyncLifetime
         DocumentReferences = await CreateDocumentReferencesAsync(schemaProvider);
     }
 
-    private async Task<IReadOnlyList<ResourceJsonNode>> CreateObservationsAsync(Ignixa.Specification.IFhirSchemaProvider schemaProvider)
+    private async Task<IReadOnlyList<ResourceJsonNode>> CreateObservationsAsync(Ignixa.Abstractions.IFhirSchemaProvider schemaProvider)
     {
         var observations = new[]
         {
@@ -161,7 +161,7 @@ public class CompositeSearchFixture : IAsyncLifetime
         return await _apiFixture.Harness.CreateResourcesAsync(observations);
     }
 
-    private async Task<IReadOnlyList<ResourceJsonNode>> CreateDocumentReferencesAsync(Ignixa.Specification.IFhirSchemaProvider schemaProvider)
+    private async Task<IReadOnlyList<ResourceJsonNode>> CreateDocumentReferencesAsync(Ignixa.Abstractions.IFhirSchemaProvider schemaProvider)
     {
         var documentReferences = new[]
         {
@@ -176,7 +176,7 @@ public class CompositeSearchFixture : IAsyncLifetime
     }
 
     private static ResourceJsonNode CreateBloodPressureObservation(
-        Ignixa.Specification.IFhirSchemaProvider schemaProvider,
+        Ignixa.Abstractions.IFhirSchemaProvider schemaProvider,
         string tag,
         string patientId)
     {
@@ -268,7 +268,7 @@ public class CompositeSearchFixture : IAsyncLifetime
     }
 
     private static ResourceJsonNode CreateDocumentReference(
-        Ignixa.Specification.IFhirSchemaProvider schemaProvider,
+        Ignixa.Abstractions.IFhirSchemaProvider schemaProvider,
         string tag,
         string patientId,
         string relatesToCode,

--- a/test/Ignixa.Api.E2ETests/_TestData/Fixtures/Sorting/SortTestFixture.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Fixtures/Sorting/SortTestFixture.cs
@@ -6,6 +6,7 @@
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Population;
 using Ignixa.Serialization.SourceNodes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 
 namespace Ignixa.Api.E2ETests._TestData.Fixtures.Sorting;

--- a/test/Ignixa.Api.E2ETests/_TestData/Scenarios/ChainingScenario.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Scenarios/ChainingScenario.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Ignixa.FhirFakes;
 using Ignixa.FhirFakes.Scenarios;
@@ -10,6 +11,7 @@ using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.Api.E2ETests._TestData.Scenarios;
 

--- a/test/Ignixa.Api.E2ETests/_TestData/Scenarios/IncludeSearchScenario.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Scenarios/IncludeSearchScenario.cs
@@ -6,7 +6,9 @@
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.Serialization.SourceNodes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.Api.E2ETests._TestData.Scenarios;
 

--- a/test/Ignixa.Api.E2ETests/_TestData/Scenarios/PatientCompartmentScenario.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Scenarios/PatientCompartmentScenario.cs
@@ -6,7 +6,9 @@
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.Serialization.SourceNodes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 
 namespace Ignixa.Api.E2ETests._TestData.Scenarios;
 

--- a/test/Ignixa.Application.Tests/Search/Indexing/CompositeSearchIndexingDiagnosticTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Indexing/CompositeSearchIndexingDiagnosticTests.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Shouldly;
 using Microsoft.Extensions.Logging;

--- a/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 using Shouldly;
 using Ignixa.FhirFakes.Builders;

--- a/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
@@ -7,6 +7,7 @@ using Shouldly;
 using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Builders.Profiles;
 using Ignixa.FhirFakes.Population;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilder_TypedIdentifierTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilder_TypedIdentifierTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Shouldly;
 using Ignixa.FhirFakes.Builders;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/ComprehensiveValidationTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/ComprehensiveValidationTests.cs
@@ -10,6 +10,7 @@ using Ignixa.FhirFakes.Scenarios.Codes;
 using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Specification.Generated;
 using Ignixa.Validation;
 using Ignixa.Validation.Abstractions;

--- a/test/Ignixa.FhirFakes.Tests/PatientLifecycleGeneratorTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/PatientLifecycleGeneratorTests.cs
@@ -7,7 +7,9 @@ using Shouldly;
 using Ignixa.FhirFakes.Lifecycle;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Specification.Generated;
 
 namespace Ignixa.FhirFakes.Tests;

--- a/test/Ignixa.FhirFakes.Tests/Population/PopulationGeneratorTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/PopulationGeneratorTests.cs
@@ -8,6 +8,7 @@ using Ignixa.FhirFakes.Builders.Profiles;
 using Ignixa.FhirFakes.Population;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.Serialization.Models;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Xunit;

--- a/test/Ignixa.FhirFakes.Tests/Scenarios/ScenarioBuilderPatientBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Scenarios/ScenarioBuilderPatientBuilderTests.cs
@@ -8,7 +8,9 @@ using Ignixa.FhirFakes.Builders;
 using Ignixa.FhirFakes.Population;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Specification.Generated;
 
 namespace Ignixa.FhirFakes.Tests.Scenarios;

--- a/test/Ignixa.FhirFakes.Tests/Scenarios/ScenarioBuilderReferenceTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Scenarios/ScenarioBuilderReferenceTests.cs
@@ -6,7 +6,9 @@
 using Shouldly;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.Codes;
+using Ignixa.Abstractions;
 using Ignixa.Specification;
+using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Specification.Generated;
 
 namespace Ignixa.FhirFakes.Tests.Scenarios;

--- a/test/Ignixa.Validation.Cli.Tests/ValidationCliTests.cs
+++ b/test/Ignixa.Validation.Cli.Tests/ValidationCliTests.cs
@@ -4,6 +4,7 @@ using Ignixa.Specification.Generated;
 using Ignixa.Validation.Abstractions;
 using Ignixa.Validation.Schema;
 using Ignixa.Serialization.SourceNodes;
+using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
 
 namespace Ignixa.Validation.Cli.Tests;

--- a/tools/Ignixa.FhirFakes.Cli/Commands/PopulationCommand.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Commands/PopulationCommand.cs
@@ -1,3 +1,4 @@
+using Ignixa.Abstractions;
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;

--- a/tools/Ignixa.FhirFakes.Cli/Commands/ResourceCommand.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Commands/ResourceCommand.cs
@@ -1,3 +1,4 @@
+using Ignixa.Abstractions;
 using System.CommandLine;
 using System.Text.Json;
 using Ignixa.FhirFakes.Cli.Discovery;

--- a/tools/Ignixa.FhirFakes.Cli/Commands/ScenarioCommand.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Commands/ScenarioCommand.cs
@@ -1,3 +1,4 @@
+using Ignixa.Abstractions;
 using System.CommandLine;
 using System.Text.Json;
 using Ignixa.FhirFakes.Cli.Discovery;

--- a/tools/Ignixa.FhirFakes.Cli/Discovery/ScenarioDiscovery.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Discovery/ScenarioDiscovery.cs
@@ -1,3 +1,4 @@
+using Ignixa.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Ignixa.FhirFakes.Scenarios;

--- a/tools/Ignixa.FhirFakes.Cli/Program.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Program.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.CommandLine;
 using Ignixa.FhirFakes.Cli.Commands;
 using Ignixa.Specification;

--- a/tools/Ignixa.SqlOnFhir.Cli/Commands/ValidateCommand.cs
+++ b/tools/Ignixa.SqlOnFhir.Cli/Commands/ValidateCommand.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.CommandLine;
 using Ignixa.Serialization;
 using Ignixa.Specification;

--- a/tools/Ignixa.SqlOnFhir.Cli/Program.cs
+++ b/tools/Ignixa.SqlOnFhir.Cli/Program.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.CommandLine;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;

--- a/tools/Ignixa.Validation.Cli/Program.cs
+++ b/tools/Ignixa.Validation.Cli/Program.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Abstractions;
 using System.CommandLine;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;


### PR DESCRIPTION
This pull request refactors the codebase to move the `IFhirSchemaProvider` interface from the `Ignixa.Specification` namespace to the new `Ignixa.Abstractions` namespace. The update ensures a clearer separation of abstractions and implementation details, and all relevant usages and references throughout the solution have been updated accordingly.

### Namespace and Interface Refactoring

* Moved the `IFhirSchemaProvider` interface from `Ignixa.Specification` to `Ignixa.Abstractions`, and updated its namespace declaration in `IFhirSchemaProvider.cs`.

* Updated all usages and imports of `IFhirSchemaProvider` in various files and feature areas to reference `Ignixa.Abstractions` instead of `Ignixa.Specification`. This includes benchmark files, application extensions, OpenIddict services, specification registries, web program startup, and FhirFakes builders. [[1]](diffhunk://#diff-ac7dcafdcbf422eb6d9d6188b910a85f501548b304f4222be49186db5f2fae13R8) [[2]](diffhunk://#diff-a6ae3bb73927ce492138b83cef232b0879c65bb3df72910d15496bf0044c4ab9R4) [[3]](diffhunk://#diff-6d24f9ebd40eba0c80d9cb28addda2cdc1eeb134c157b3e00c7e7589888581fcR8) [[4]](diffhunk://#diff-f9e6d6db40f31929b7f4c8b620ab9e18c67b4da9bf8cbecfed036ef9210ff694R16) [[5]](diffhunk://#diff-abff4df0704f7e51afa05ee3f6aee9b40d9b43fb3e44c55673b4f8e746698f70R6) [[6]](diffhunk://#diff-6166e233698e09ec3c2f796ceb20bcf0dbbdc22f16d8a999269fffd3cb7f52bbR6) [[7]](diffhunk://#diff-c1c8bdf3210c6b5d1b22faf4df4fdb3af4d8e033c14882e6d8b5b69e7fca0a1dR6) [[8]](diffhunk://#diff-af7aa19e8d09fa0c006a2e3fdd74db5b2fcb397644a8092ba7931aa182ff4481R6) [[9]](diffhunk://#diff-52a245c696d2d067f879331693da51e19c612953b9e2a423f5cbc59e0d2f33afR6) [[10]](diffhunk://#diff-57a52187bc61603b4973f5dda2c1f3606f5adc0175019d3911c05e8462960791R6) [[11]](diffhunk://#diff-e7efa65e136ce6992fc47d54f59ff0176e6e465ed6e46ff4c561a81664f10e74R6) [[12]](diffhunk://#diff-f51e9a774350c0467b06a8b23d528ee534f979dad56089ffb7ba60296637924dR6) [[13]](diffhunk://#diff-8f5044fa6f517590deee119aa1e6c2ae1c122767d1f78dc3dfb126bce195085bR6) [[14]](diffhunk://#diff-6c74c60b4c7c921aaaafa53402e4d5bc8c6d673de79721e9715f44947f224945R6) [[15]](diffhunk://#diff-c3ce41362e2e95d7e8f6e3167eeea3d665e371901b91647e19b3eed0b4b11695R6) [[16]](diffhunk://#diff-3cf7227ad8578539f47b964b64690f8dcbdfdd034d6ef5adcb991f315cb5a641R8) [[17]](diffhunk://#diff-6ddcebda2fb5e4a2f3e99592ff5b73d08ab9cd2fd234c9864ff7ee7b14a2ef9bR7)

### Documentation and Code Generation Updates

* Updated XML documentation and code generation logic to reference `Ignixa.Abstractions.IFhirSchemaProvider` for multi-version FHIR support and type metadata, replacing previous references to `Ignixa.Specification.IFhirSchemaProvider`. [[1]](diffhunk://#diff-f6fbacdc42b124680f4c6a0793cbd4f25eb8182df577ed8ec4ceea16c6386b79L11-R11) [[2]](diffhunk://#diff-4db8ae797577c626741e79f29e80963853ebe3b2a8b2452ff3519a03a1b8da89L124-R124)

This refactoring improves code organization and maintainability by clearly separating abstractions from implementation details.