### PR TITLE
More small fhirpath fixes

### DIFF
--- a/src/Core/Ignixa.FhirPath/Analysis/FhirPathAnalyzer.cs
+++ b/src/Core/Ignixa.FhirPath/Analysis/FhirPathAnalyzer.cs
@@ -44,6 +44,7 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
     private readonly IFhirSchemaProvider _schema;
     private readonly SymbolTable _symbolTable;
     private readonly FhirPathParser _parser;
+    private IFhirPathExpressionVisitor<AnalysisContext, FhirPathTypeSet>? _childVisitor;
 
     /// <summary>
     /// Creates a new FhirPath analyzer with the specified schema provider.
@@ -53,6 +54,11 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
         _schema = schema ?? throw new ArgumentNullException(nameof(schema));
         _symbolTable = new SymbolTable(schema);
         _parser = new FhirPathParser();
+    }
+
+    internal void SetChildVisitor(IFhirPathExpressionVisitor<AnalysisContext, FhirPathTypeSet> visitor)
+    {
+        _childVisitor = visitor;
     }
 
     /// <summary>
@@ -70,13 +76,33 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
         var nodeTypes = new Dictionary<Expression, FhirPathTypeSet>(ReferenceEqualityComparer.Instance);
         
         // First pass: Analyze with the regular analyzer to get types and collect issues
-        var types = expression.AcceptVisitor(this, context);
+        FhirPathTypeSet types = new FhirPathTypeSet();
+        try
+        {
+            types = expression.AcceptVisitor(this, context);
+        }
+        catch (Exception ex)
+        {
+            context.AddIssue(ValidationIssueSeverity.Error, $"Analysis failed: {ex.Message}");
+        }
 
         // Second pass: Walk the tree again to collect types for each node
-        var typeCollector = new TypeCollectorVisitor(this, nodeTypes);
-        var contextForCollection = AnalysisContext.Create(_schema, rootTypeName);
-        expression.AcceptVisitor(typeCollector, contextForCollection);
-
+        // We use a new analyzer instance for the second pass to allow the collector to intercept child visits
+        try
+        {
+            var secondPassAnalyzer = new FhirPathAnalyzer(_schema);
+            var typeCollector = new TypeCollectorVisitor(secondPassAnalyzer, nodeTypes);
+            secondPassAnalyzer.SetChildVisitor(typeCollector);
+            
+            var contextForCollection = AnalysisContext.Create(_schema, rootTypeName);
+            expression.AcceptVisitor(typeCollector, contextForCollection);
+        }
+        catch (Exception)
+        {
+            // Ignore exceptions during type collection to ensure we return partial type information
+            // Validation errors are already captured in the first pass
+        }
+        
         // Create result with NodeTypes populated
         var result = new AnalysisResult
         {
@@ -154,11 +180,12 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
     public override FhirPathTypeSet VisitPropertyAccess(PropertyAccessExpression expression, AnalysisContext context)
     {
         var result = new FhirPathTypeSet();
+        var visitor = _childVisitor ?? this;
 
         FhirPathTypeSet focusTypes;
         if (expression.Focus != null)
         {
-            focusTypes = expression.Focus.AcceptVisitor(this, context);
+            focusTypes = expression.Focus.AcceptVisitor(visitor, context);
         }
         else
         {
@@ -227,11 +254,12 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
     public override FhirPathTypeSet VisitChild(ChildExpression expression, AnalysisContext context)
     {
         var result = new FhirPathTypeSet();
+        var visitor = _childVisitor ?? this;
 
         FhirPathTypeSet focusTypes;
         if (expression.Focus != null && expression.Focus is not ScopeExpression { ScopeName: "that" })
         {
-            focusTypes = expression.Focus.AcceptVisitor(this, context);
+            focusTypes = expression.Focus.AcceptVisitor(visitor, context);
         }
         else
         {
@@ -301,11 +329,12 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
     {
         var result = new FhirPathTypeSet();
         var functionName = expression.FunctionName;
+        var visitor = _childVisitor ?? this;
 
         if (functionName == "builtin.children" && expression is not ChildExpression)
         {
             var focusResult = expression.Focus != null
-                ? expression.Focus.AcceptVisitor(this, context)
+                ? expression.Focus.AcceptVisitor(visitor, context)
                 : context.GetCurrentType();
             return focusResult;
         }
@@ -317,7 +346,7 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
         }
         else
         {
-            focusTypes = expression.Focus.AcceptVisitor(this, context);
+            focusTypes = expression.Focus.AcceptVisitor(visitor, context);
         }
 
         var funcDef = _symbolTable.Get(functionName);
@@ -345,15 +374,22 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
         var argTypes = new List<FhirPathTypeSet>();
         foreach (var arg in expression.Arguments)
         {
-            argTypes.Add(arg.AcceptVisitor(this, innerContext));
+            argTypes.Add(arg.AcceptVisitor(visitor, innerContext));
         }
         if (funcDef != null)
         {
             var issues = new List<ValidationIssue>();
 
-            foreach (var validation in funcDef.Validations)
+            try
             {
-                validation(expression, funcDef, argTypes, issues);
+                foreach (var validation in funcDef.Validations)
+                {
+                    validation(expression, funcDef, argTypes, issues);
+                }
+            }
+            catch (Exception ex)
+            {
+                issues.Add(new ValidationIssue { Severity = ValidationIssueSeverity.Warning, Message = $"Validation failed for function '{functionName}': {ex.Message}" });
             }
 
             foreach (var issue in issues)
@@ -361,17 +397,25 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
                 context.AddIssue(issue.Severity, issue.Message, expression);
             }
 
-            if (funcDef.GetReturnType != null)
+            try
             {
-                var returnTypes = funcDef.GetReturnType(funcDef, focusTypes, argTypes, issues);
-                foreach (var rt in returnTypes)
+                if (funcDef.GetReturnType != null)
                 {
-                    result.Types.Add(rt);
+                    var returnTypes = funcDef.GetReturnType(funcDef, focusTypes, argTypes, issues);
+                    foreach (var rt in returnTypes)
+                    {
+                        result.Types.Add(rt);
+                    }
+                }
+                else
+                {
+                    result.CopyFrom(focusTypes);
                 }
             }
-            else
+            catch (Exception ex)
             {
-                result.CopyFrom(focusTypes);
+                context.AddIssue(ValidationIssueSeverity.Warning, $"Return type calculation failed for function '{functionName}': {ex.Message}", expression);
+                result.CopyFrom(focusTypes); // Fallback to focus types
             }
         }
         else
@@ -391,8 +435,9 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
     public override FhirPathTypeSet VisitBinary(BinaryExpression expression, AnalysisContext context)
     {
         var result = new FhirPathTypeSet();
-        var leftResult = expression.Left?.AcceptVisitor(this, context) ?? new FhirPathTypeSet();
-        var rightResult = expression.Right?.AcceptVisitor(this, context) ?? new FhirPathTypeSet();
+        var visitor = _childVisitor ?? this;
+        var leftResult = expression.Left?.AcceptVisitor(visitor, context) ?? new FhirPathTypeSet();
+        var rightResult = expression.Right?.AcceptVisitor(visitor, context) ?? new FhirPathTypeSet();
 
         switch (expression.Operator)
         {
@@ -449,7 +494,8 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
 
     public override FhirPathTypeSet VisitUnary(UnaryExpression expression, AnalysisContext context)
     {
-        var operandResult = expression.Operand?.AcceptVisitor(this, context) ?? new FhirPathTypeSet();
+        var visitor = _childVisitor ?? this;
+        var operandResult = expression.Operand?.AcceptVisitor(visitor, context) ?? new FhirPathTypeSet();
 
         return expression.Operator switch
         {
@@ -577,15 +623,17 @@ public sealed class FhirPathAnalyzer : DefaultFhirPathExpressionVisitor<Analysis
 
     public override FhirPathTypeSet VisitIndexer(IndexerExpression expression, AnalysisContext context)
     {
-        var collectionResult = expression.Collection?.AcceptVisitor(this, context) ?? new FhirPathTypeSet();
-        expression.Index?.AcceptVisitor(this, context);
+        var visitor = _childVisitor ?? this;
+        var collectionResult = expression.Collection?.AcceptVisitor(visitor, context) ?? new FhirPathTypeSet();
+        expression.Index?.AcceptVisitor(visitor, context);
 
         return collectionResult.AsSingle();
     }
 
     public override FhirPathTypeSet VisitParenthesized(ParenthesizedExpression expression, AnalysisContext context)
     {
-        return expression.InnerExpression?.AcceptVisitor(this, context) ?? new FhirPathTypeSet();
+        var visitor = _childVisitor ?? this;
+        return expression.InnerExpression?.AcceptVisitor(visitor, context) ?? new FhirPathTypeSet();
     }
 
     public override FhirPathTypeSet VisitQuantity(QuantityExpression expression, AnalysisContext context)

--- a/src/Core/Ignixa.FhirPath/Parsing/FhirPathParseTreeGrammar.cs
+++ b/src/Core/Ignixa.FhirPath/Parsing/FhirPathParseTreeGrammar.cs
@@ -113,7 +113,7 @@ internal static class FhirPathParseTreeGrammar
     private static readonly TokenListParser<FhirPathTokenKind, ParseNode> QualifiedIdentifier =
         from parts in Token.EqualTo(FhirPathTokenKind.Identifier)
             .Or(Token.EqualTo(FhirPathTokenKind.DelimitedIdentifier))
-            .ManyDelimitedBy(Token.EqualTo(FhirPathTokenKind.Dot))
+            .AtLeastOnceDelimitedBy(Token.EqualTo(FhirPathTokenKind.Dot))
         select (ParseNode)new IdentifierParseNode(
             string.Join(".", parts.Select(t => UnescapeIdentifier(t.ToStringValue()))),
             Loc(parts.First(), parts.Last()));
@@ -200,7 +200,7 @@ internal static class FhirPathParseTreeGrammar
 
     private static readonly TokenListParser<FhirPathTokenKind, ParseNode> InvocationExpression =
         from initial in Term
-        from invocations in DotInvocation.Or(IndexerInvocation).Many()
+        from invocations in DotInvocation.Try().Or(IndexerInvocation.Try()).Many()
         select invocations.Aggregate(initial, (current, invoke) => invoke(current));
 
     private static readonly TokenListParser<FhirPathTokenKind, ParseNode> PolarityExpression =

--- a/test/Ignixa.FhirPath.Tests/Parsing/ParserEdgeCaseTests.cs
+++ b/test/Ignixa.FhirPath.Tests/Parsing/ParserEdgeCaseTests.cs
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Comprehensive edge case tests for FhirPath parser.
+ * These tests cover malformed expressions, consecutive operators,
+ * unclosed brackets, and other error scenarios to ensure the parser
+ * fails gracefully with clear error messages.
+ */
+
+using Ignixa.FhirPath.Parser;
+
+namespace Ignixa.FhirPath.Tests.Parsing;
+
+/// <summary>
+/// Tests for parser edge cases, particularly around error handling
+/// for malformed expressions that should be rejected.
+/// </summary>
+public class ParserEdgeCaseTests
+{
+    private readonly FhirPathParser _parser = new();
+
+    #region Consecutive Dot Operator Tests
+
+    [Theory]
+    [InlineData("Patient..name")]
+    [InlineData("..name")]
+    [InlineData("name..")]
+    [InlineData("a.b..c")]
+    [InlineData("a.b.c..d.e")]
+    [InlineData("trace('trc').given.join(' ')..combine(family).join(', ')")]
+    public void GivenConsecutiveDots_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("Patient..name")]
+    [InlineData("..name")]
+    [InlineData("name..")]
+    [InlineData("a.b..c")]
+    public void GivenConsecutiveDots_WhenTryParse_ThenReturnsFalseWithError(string expression)
+    {
+        var success = _parser.TryParse(expression, out var result, out var error);
+
+        Assert.False(success);
+        Assert.Null(result);
+        Assert.NotNull(error);
+    }
+
+    #endregion
+
+    #region Trailing Operator Tests
+
+    [Theory]
+    [InlineData("Patient.")]
+    [InlineData("name.given.")]
+    [InlineData("a.b.c.")]
+    public void GivenTrailingDot_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("1 +")]
+    [InlineData("a -")]
+    [InlineData("x *")]
+    [InlineData("y /")]
+    [InlineData("a and")]
+    [InlineData("b or")]
+    [InlineData("c =")]
+    [InlineData("d !=")]
+    [InlineData("e >")]
+    [InlineData("f <")]
+    [InlineData("g >=")]
+    [InlineData("h <=")]
+    public void GivenTrailingBinaryOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    /// <summary>
+    /// Tests that trailing type operators (as/is) without a type throw FormatException.
+    /// </summary>
+    [Theory]
+    [InlineData("value as")]
+    [InlineData("value is")]
+    public void GivenTrailingTypeOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Consecutive Binary Operator Tests
+
+    [Theory]
+    [InlineData("1 + * 2")]
+    [InlineData("1 - / 2")]
+    [InlineData("a and or b")]
+    [InlineData("a = != b")]
+    [InlineData("1 > < 2")]
+    [InlineData("1 + + + 2")]
+    public void GivenConsecutiveBinaryOperators_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Leading Operator Tests
+
+    [Theory]
+    [InlineData("* 2")]
+    [InlineData("/ 2")]
+    [InlineData("and b")]
+    [InlineData("or b")]
+    [InlineData("= 5")]
+    [InlineData("!= 5")]
+    [InlineData("> 5")]
+    [InlineData("< 5")]
+    public void GivenLeadingBinaryOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Fact]
+    public void GivenLeadingUnaryMinus_WhenParsing_ThenSucceeds()
+    {
+        // Unary minus is valid
+        var expr = _parser.Parse("-5");
+        Assert.NotNull(expr);
+    }
+
+    [Fact]
+    public void GivenLeadingUnaryPlus_WhenParsing_ThenSucceeds()
+    {
+        // Unary plus is valid
+        var expr = _parser.Parse("+5");
+        Assert.NotNull(expr);
+    }
+
+    #endregion
+
+    #region Unclosed Bracket Tests
+
+    [Theory]
+    [InlineData("name[0")]
+    [InlineData("name[")]
+    [InlineData("a[b[c]")]
+    [InlineData("items[0][1")]
+    public void GivenUnclosedBracket_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("name]")]
+    [InlineData("]name")]
+    [InlineData("a[0]]")]
+    public void GivenExtraBracket_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("a[]")]
+    public void GivenEmptyIndexer_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Unclosed Parenthesis Tests
+
+    [Theory]
+    [InlineData("(1 + 2")]
+    [InlineData("name.exists(")]
+    [InlineData("where(x = 1")]
+    [InlineData("((a)")]
+    [InlineData("func(a, b")]
+    public void GivenUnclosedParenthesis_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("1 + 2)")]
+    [InlineData(")name")]
+    [InlineData("(a))")]
+    [InlineData("func())")]
+    public void GivenExtraParenthesis_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Fact]
+    public void GivenEmptyParentheses_WhenParsing_ThenThrowsFormatException()
+    {
+        // () by itself is not valid - empty collection is {}
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse("()"));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Malformed String Literal Tests
+
+    [Theory]
+    [InlineData("'unclosed")]
+    [InlineData("'missing end quote")]
+    public void GivenUnterminatedString_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Fact]
+    public void GivenStringWithNewline_WhenParsing_ThenSucceeds()
+    {
+        // FHIRPath spec allows newlines in string literals
+        var expr = _parser.Parse("'has\nnewline'");
+        Assert.NotNull(expr);
+    }
+
+    [Fact]
+    public void GivenEmptyString_WhenParsing_ThenSucceeds()
+    {
+        // '' is a valid empty string literal
+        var expr = _parser.Parse("''");
+        Assert.NotNull(expr);
+    }
+
+    #endregion
+
+    #region Malformed Function Call Tests
+
+    [Theory]
+    [InlineData("name.exists(,)")]
+    [InlineData("name.where(,a)")]
+    [InlineData("name.select(a,)")]
+    [InlineData("func(,,)")]
+    public void GivenMalformedFunctionArguments_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("name.()")]
+    [InlineData(".exists()")]
+    public void GivenMissingFunctionName_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Numeric Literal Edge Cases
+
+    [Fact]
+    public void GivenValidDecimal_WhenParsing_ThenSucceeds()
+    {
+        var expr = _parser.Parse("1.5");
+        Assert.NotNull(expr);
+    }
+
+    [Fact]
+    public void GivenMultipleDecimals_WhenParsing_ThenThrowsFormatException()
+    {
+        // 1.2.3 is not a valid number
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse("1.2.3"));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Empty and Whitespace Tests
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void GivenEmptyOrWhitespace_WhenParsing_ThenThrowsArgumentException(string expression)
+    {
+        Assert.Throws<ArgumentException>(() => _parser.Parse(expression));
+    }
+
+    #endregion
+
+    #region Type Operator Edge Cases
+
+    [Theory]
+    [InlineData("as String")]
+    [InlineData("is Integer")]
+    public void GivenTypeOperatorWithoutOperand_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region External Constant Edge Cases
+
+    [Theory]
+    [InlineData("%")]
+    [InlineData("% ")]
+    public void GivenIncompleteExternalConstant_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Theory]
+    [InlineData("%`unclosed")]
+    [InlineData("%`missing backtick")]
+    public void GivenUnterminatedDelimitedExternalConstant_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Special Character Tests
+
+    [Theory]
+    [InlineData("@")]
+    [InlineData("#")]
+    [InlineData("$")]
+    [InlineData("^")]
+    [InlineData("&")]
+    [InlineData("~")]
+    public void GivenInvalidCharacter_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Complex Malformed Expressions
+
+    [Theory]
+    [InlineData("Patient.name.where(given..first())")]
+    [InlineData("(1 + 2) * (3 +)")]
+    [InlineData("a.b[0].c().d..e")]
+    [InlineData("func1().func2(arg..).func3()")]
+    public void GivenComplexMalformedExpression_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Union and Contains Edge Cases
+
+    [Theory]
+    [InlineData("| b")]
+    [InlineData("a |")]
+    [InlineData("a | | b")]
+    public void GivenMalformedUnion_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    /// <summary>
+    /// Note: "in" and "contains" are valid identifiers in FHIRPath when used standalone.
+    /// They only become operators when in context (e.g., "a in b").
+    /// </summary>
+    [Theory]
+    [InlineData("a in")]
+    [InlineData("in b")]
+    public void GivenMalformedInOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Fact]
+    public void GivenStandaloneInKeyword_WhenParsing_ThenParsesAsIdentifier()
+    {
+        // "in" can be a valid identifier when standalone (property/element name)
+        var expr = _parser.Parse("in");
+        Assert.NotNull(expr);
+    }
+
+    /// <summary>
+    /// Note: "contains" is both a function and an operator.
+    /// When standalone, it parses as an identifier/property access.
+    /// </summary>
+    [Theory]
+    [InlineData("a contains")]
+    [InlineData("contains b")]
+    public void GivenMalformedContainsOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    [Fact]
+    public void GivenStandaloneContainsKeyword_WhenParsing_ThenParsesAsIdentifier()
+    {
+        // "contains" can be a valid identifier when standalone (e.g., ValueSet.expansion.contains)
+        var expr = _parser.Parse("contains");
+        Assert.NotNull(expr);
+    }
+
+    #endregion
+
+    #region Implies Operator Edge Cases
+
+    [Theory]
+    [InlineData("implies")]
+    [InlineData("a implies")]
+    [InlineData("implies b")]
+    public void GivenMalformedImpliesOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Xor Operator Edge Cases
+
+    [Theory]
+    [InlineData("xor")]
+    [InlineData("a xor")]
+    [InlineData("xor b")]
+    public void GivenMalformedXorOperator_WhenParsing_ThenThrowsFormatException(string expression)
+    {
+        var ex = Assert.Throws<FormatException>(() => _parser.Parse(expression));
+        Assert.NotNull(ex.Message);
+    }
+
+    #endregion
+
+    #region Quantity and Duration Edge Cases
+
+    [Fact]
+    public void GivenValidQuantity_WhenParsing_ThenSucceeds()
+    {
+        var expr = _parser.Parse("5 'kg'");
+        Assert.NotNull(expr);
+    }
+
+    [Fact]
+    public void GivenValidDuration_WhenParsing_ThenSucceeds()
+    {
+        var expr = _parser.Parse("1 year");
+        Assert.NotNull(expr);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
This pull request introduces improvements to the FhirPath analyzer, focusing on making the analysis process more robust and extensible, especially in error handling and visitor management. The main changes include adding support for delegating child node visits to custom visitors, improving error tolerance during analysis and validation, and refining the FhirPath parser for stricter identifier handling and safer invocation parsing.

### FhirPath Analyzer extensibility and robustness

* Added a private `_childVisitor` field and a `SetChildVisitor` method to `FhirPathAnalyzer`, allowing delegation of child node visits to a custom visitor. All relevant `Visit*` methods now use `_childVisitor` if set, instead of always using `this`. This enables more flexible analysis and easier extension for tasks like type collection. [[1]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R47) [[2]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R59-R63) [[3]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R183-R188) [[4]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R257-R262) [[5]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R332-R337) [[6]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192L320-R349) [[7]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192L394-R440) [[8]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192L452-R498) [[9]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192L580-R636)

* Updated the two-pass analysis in `Analyze` to use a separate analyzer instance for the second pass, with error handling to ensure that partial results are returned even if type collection fails.

* Improved error handling in function call analysis: exceptions during validation and return type calculation are now caught and reported as warnings, preventing analysis from failing completely due to individual errors. [[1]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192L348-R401) [[2]](diffhunk://#diff-c9ef795fb16545345799d55f6eed2a18970ac808401f5fea8178f92a16ffd192R415-R420)

### FhirPath Parser improvements

* Changed the `QualifiedIdentifier` parser to require at least one identifier part, making parsing stricter and avoiding empty identifiers.

* Updated the `InvocationExpression` parser to use `.Try()` on both `DotInvocation` and `IndexerInvocation`, making the parser more resilient to errors in chained invocation expressions.