### PR TITLE
chore(deps): update Scriban 7.0.6 → 7.2.0 (fix NU1903 vulnerability)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,7 +66,7 @@
     <!-- Localization -->
     <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.14" />
     <!-- Templating -->
-    <PackageVersion Include="Scriban" Version="7.0.6" />
+    <PackageVersion Include="Scriban" Version="7.2.0" />
     <!-- Testing -->
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
Fixes GHSA-24c8-4792-22hx — high severity vulnerability in Scriban 7.0.6 that blocks all PR CI builds.

Updates to 7.2.0 (latest stable). This is a one-line change in \Directory.Packages.props\.

Once merged, all open FHIRPath fix PRs (#251, #252, #253) will be rebased onto the new main.