### PR TITLE
fix(release): tag-prefix versioning + per-package stability suffixing (ADR 2606)

### DIFF
--- a/.github/actions/dotnet-build-and-test/action.yml
+++ b/.github/actions/dotnet-build-and-test/action.yml
@@ -30,8 +30,8 @@ outputs:
     description: 'Full informational version with metadata'
     value: ${{ steps.gitversion.outputs.informationalVersion }}
   nuget-version:
-    description: 'NuGet version'
-    value: ${{ steps.gitversion.outputs.nuGetVersion }}
+    description: 'Clean MAJOR.MINOR.PATCH base version for package stability suffixing (ADR 2606). GitVersion 6 removed the legacy nuGetVersion output; majorMinorPatch carries no pre-release tag so Directory.Build.targets can safely append -beta/-alpha.'
+    value: ${{ steps.gitversion.outputs.majorMinorPatch }}
 
 runs:
   using: 'composite'
@@ -52,7 +52,7 @@ runs:
         echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
         echo "AssemblySemVer: ${{ steps.gitversion.outputs.assemblySemVer }}"
         echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
-        echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
+        echo "MajorMinorPatch (BasePackageVersion): ${{ steps.gitversion.outputs.majorMinorPatch }}"
       shell: bash
 
     - name: Setup .NET
@@ -67,7 +67,7 @@ runs:
       shell: bash
 
     - name: Build solution
-      run: dotnet build "${{ inputs.solution-file }}" --configuration ${{ inputs.build-configuration }} --no-restore --verbosity minimal /p:Version=${{ steps.gitversion.outputs.nuGetVersion }}
+      run: dotnet build "${{ inputs.solution-file }}" --configuration ${{ inputs.build-configuration }} --no-restore --verbosity minimal /p:Version=${{ steps.gitversion.outputs.majorMinorPatch }}
       shell: bash
 
     - name: Run unit tests

--- a/.github/actions/dotnet-build-and-test/action.yml
+++ b/.github/actions/dotnet-build-and-test/action.yml
@@ -67,7 +67,7 @@ runs:
       shell: bash
 
     - name: Build solution
-      run: dotnet build "${{ inputs.solution-file }}" --configuration ${{ inputs.build-configuration }} --no-restore --verbosity minimal /p:Version=${{ steps.gitversion.outputs.majorMinorPatch }}
+      run: dotnet build "${{ inputs.solution-file }}" --configuration ${{ inputs.build-configuration }} --no-restore --verbosity minimal /p:Version=${{ steps.gitversion.outputs.semVer }}
       shell: bash
 
     - name: Run unit tests

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,8 @@
 workflow: TrunkBased/preview1
 assembly-versioning-scheme: MajorMinorPatch
-next-version: 0.5.0
+# Recognize release/X.Y.Z tags as version sources so the version auto-increments
+# from the last release instead of repo height. Per-commit bumps via commit message:
+#   +semver: major | minor | patch | none
+# Do NOT add next-version alongside tag-prefix: GitVersion 6 throws "Failed to parse"
+# when both are set.
+tag-prefix: 'release/'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,3 @@
 workflow: TrunkBased/preview1
 assembly-versioning-scheme: MajorMinorPatch
+next-version: 0.5.0


### PR DESCRIPTION
## Why

Release-prep for **0.5.0**. Two CI bugs on the version → package-version path, both invisible to a green CI run.

### 1. Versioning couldn't produce a deliberate release number
`GitVersion.yml` was `TrunkBased/preview1` with no `next-version` and no `tag-prefix`. `release/*` tags weren't matched by the default prefix (`[vV]?`), so the version was repo-height (`0.0.19x`).

**Fix:** `tag-prefix: 'release/'` so `release/X.Y.Z` tags drive the version and it auto-increments from the last release. Per-commit bumps via the `semver` commit-message directives (major/minor/patch).

> Why not `next-version: 0.5.0`? It **pins** the version permanently (every build computes the same value — verified), and GitVersion 6 **throws** (`Failed to parse`) when `next-version` and `tag-prefix` are set together. tag-prefix is the sustainable model.

### 2. ADR 2606 per-package stability suffixing was silently inert in CI
GitVersion 6 removed the legacy `nuGetVersion` output, but the composite action still referenced it → `nuget-version` resolved to empty → CI packed with `-p:BasePackageVersion=` → the `Directory.Build.targets` guard skipped the entire suffix block → every package emitted flat-stable (beta packages shipping as stable; `NU5104` never firing).

**Fix:** point the output at `majorMinorPatch` (clean `X.Y.Z`; `-beta`/`-alpha` concatenation stays well-formed even on PR builds). Build-step `/p:Version` uses `semVer` to preserve the pre-release tag in assembly metadata (per review feedback).

## Action required — how to cut 0.5.0

The `release/0.4.0` base tag is already pushed. **Merge this PR with `+semver: minor` in the squash commit message.** That makes the release compute to exactly `0.5.0` (verified: base 0.4.0 + minor bump = 0.5.0, and trailing plain commits keep it there).

After 0.5.0 is published (which creates `release/0.5.0`):
- delete the bootstrap tag: `git push origin :refs/tags/release/0.4.0`
- future builds auto-increment from `release/0.5.0` → `0.5.1`, with `+semver: minor`/`major` for bumps.

## Verification (local GitVersion 6.5.1)
- Branch now computes `0.4.1`; with a `+semver: minor` merge commit → `0.5.0`.
- `dotnet pack` with `BasePackageVersion=0.5.0`: `Ignixa.FhirPath.0.5.0.nupkg` (stable, flat), `Ignixa.TestScript.0.5.0-beta.nupkg` (beta). Both branches of the targets condition exercised.

## After merge — verify before publishing (this bug had green CI)
1. Re-run CI, download `nuget-packages-core`, confirm beta packages carry `-beta`, stable stay flat, `version.txt` = `0.5.0`.
2. Dry-run **Publish Release** with `skip_nuget` + `skip_tag` to confirm the resolved version and preview notes.

## Out of scope (follow-ups)
- `check-code-quality` job logs `GitVersion.MsBuild MSB3073 ... exited with code 1` (hidden by `continue-on-error: true`).
- Release notes should call out the version jump and the ADR 2606 versioning policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
