### PR TITLE
fix(cli): emit UTF-8 console output from both CLI tools

### DIFF
--- a/test/Ignixa.FhirFakes.Cli.Tests/ConsoleEncodingTests.cs
+++ b/test/Ignixa.FhirFakes.Cli.Tests/ConsoleEncodingTests.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+
+namespace Ignixa.FhirFakes.Cli.Tests;
+
+public class ConsoleEncodingTests
+{
+    [Fact]
+    public void GivenConsoleOutput_WhenEnablingUtf8_ThenNeverThrowsAndUsesUtf8WhenApplied()
+    {
+        var original = Console.OutputEncoding;
+        try
+        {
+            // Must never throw, regardless of whether a console is attached.
+            var applied = Should.NotThrow(() => Program.TryEnableUtf8ConsoleOutput());
+
+            // When a console was available the encoding is now UTF-8; when fully redirected the
+            // assignment is swallowed and reported as not-applied — both are valid outcomes.
+            if (applied)
+            {
+                Console.OutputEncoding.WebName.ShouldBe("utf-8");
+            }
+        }
+        finally
+        {
+            try { Console.OutputEncoding = original; } catch { /* restore is best-effort */ }
+        }
+    }
+}

--- a/test/Ignixa.SqlOnFhir.Cli.Tests/ConsoleEncodingTests.cs
+++ b/test/Ignixa.SqlOnFhir.Cli.Tests/ConsoleEncodingTests.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+
+namespace Ignixa.SqlOnFhir.Cli.Tests;
+
+public class ConsoleEncodingTests
+{
+    [Fact]
+    public void GivenConsoleOutput_WhenEnablingUtf8_ThenNeverThrowsAndUsesUtf8WhenApplied()
+    {
+        var original = Console.OutputEncoding;
+        try
+        {
+            // Must never throw, regardless of whether a console is attached.
+            var applied = Should.NotThrow(() => Program.TryEnableUtf8ConsoleOutput());
+
+            // When a console was available the encoding is now UTF-8; when fully redirected the
+            // assignment is swallowed and reported as not-applied — both are valid outcomes.
+            if (applied)
+            {
+                Console.OutputEncoding.WebName.ShouldBe("utf-8");
+            }
+        }
+        finally
+        {
+            try { Console.OutputEncoding = original; } catch { /* restore is best-effort */ }
+        }
+    }
+}

--- a/tools/Ignixa.FhirFakes.Cli/Ignixa.FhirFakes.Cli.csproj
+++ b/tools/Ignixa.FhirFakes.Cli/Ignixa.FhirFakes.Cli.csproj
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ignixa.FhirFakes.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 

--- a/tools/Ignixa.FhirFakes.Cli/Program.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Program.cs
@@ -5,6 +5,7 @@
 
 using Ignixa.Abstractions;
 using System.CommandLine;
+using System.Text;
 using Ignixa.FhirFakes.Cli.Commands;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
@@ -18,6 +19,11 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
+        // Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in
+        // terminals, redirected output, and notebook runners (e.g. runme.dev), which decode
+        // captured output as UTF-8. Guarded: setting this throws when no console is attached.
+        try { Console.OutputEncoding = new UTF8Encoding(false); } catch { /* no console */ }
+
         // Create root command
         var rootCommand = new RootCommand("FHIR Fakes - Generate and model FHIR test data");
 

--- a/tools/Ignixa.FhirFakes.Cli/Program.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Program.cs
@@ -19,10 +19,7 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        // Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in
-        // terminals, redirected output, and notebook runners (e.g. runme.dev), which decode
-        // captured output as UTF-8. Guarded: setting this throws when no console is attached.
-        try { Console.OutputEncoding = new UTF8Encoding(false); } catch { /* no console */ }
+        TryEnableUtf8ConsoleOutput();
 
         // Create root command
         var rootCommand = new RootCommand("FHIR Fakes - Generate and model FHIR test data");
@@ -38,6 +35,27 @@ class Program
         AddFhirVersionCommands(rootCommand, "r6", new R6CoreSchemaProvider());
 
         return await rootCommand.Parse(args).InvokeAsync();
+    }
+
+    /// <summary>
+    /// Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in terminals,
+    /// redirected output, and notebook runners (e.g. runme.dev), which decode captured output as
+    /// UTF-8. Best-effort: setting the encoding throws when no console is attached (fully
+    /// redirected), so the failure is swallowed and surfaced via the return value.
+    /// </summary>
+    /// <returns><c>true</c> if the encoding was set; <c>false</c> if no console was available.</returns>
+    internal static bool TryEnableUtf8ConsoleOutput()
+    {
+        try
+        {
+            Console.OutputEncoding = new UTF8Encoding(false);
+            return true;
+        }
+        catch (Exception)
+        {
+            // No console attached or the platform doesn't allow changing the encoding.
+            return false;
+        }
     }
 
     /// <summary>

--- a/tools/Ignixa.SqlOnFhir.Cli/Program.cs
+++ b/tools/Ignixa.SqlOnFhir.Cli/Program.cs
@@ -11,10 +11,7 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        // Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in
-        // terminals, redirected output, and notebook runners (e.g. runme.dev), which decode
-        // captured output as UTF-8. Guarded: setting this throws when no console is attached.
-        try { Console.OutputEncoding = new UTF8Encoding(false); } catch { /* no console */ }
+        TryEnableUtf8ConsoleOutput();
 
         var rootCommand = new RootCommand("SQL on FHIR - Process FHIR resources using ViewDefinitions");
 
@@ -25,6 +22,27 @@ class Program
         AddFhirVersionCommands(rootCommand, "r6",   new R6CoreSchemaProvider());
 
         return await rootCommand.Parse(args).InvokeAsync();
+    }
+
+    /// <summary>
+    /// Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in terminals,
+    /// redirected output, and notebook runners (e.g. runme.dev), which decode captured output as
+    /// UTF-8. Best-effort: setting the encoding throws when no console is attached (fully
+    /// redirected), so the failure is swallowed and surfaced via the return value.
+    /// </summary>
+    /// <returns><c>true</c> if the encoding was set; <c>false</c> if no console was available.</returns>
+    internal static bool TryEnableUtf8ConsoleOutput()
+    {
+        try
+        {
+            Console.OutputEncoding = new UTF8Encoding(false);
+            return true;
+        }
+        catch (Exception)
+        {
+            // No console attached or the platform doesn't allow changing the encoding.
+            return false;
+        }
     }
 
     private static void AddFhirVersionCommands(RootCommand root, string versionCode, IFhirSchemaProvider schemaProvider)

--- a/tools/Ignixa.SqlOnFhir.Cli/Program.cs
+++ b/tools/Ignixa.SqlOnFhir.Cli/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Text;
 using Ignixa.Abstractions;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
@@ -10,6 +11,11 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
+        // Emit UTF-8 so non-ASCII patient names and status glyphs render correctly in
+        // terminals, redirected output, and notebook runners (e.g. runme.dev), which decode
+        // captured output as UTF-8. Guarded: setting this throws when no console is attached.
+        try { Console.OutputEncoding = new UTF8Encoding(false); } catch { /* no console */ }
+
         var rootCommand = new RootCommand("SQL on FHIR - Process FHIR resources using ViewDefinitions");
 
         AddFhirVersionCommands(rootCommand, "stu3", new STU3CoreSchemaProvider());


### PR DESCRIPTION
## Problem

Both CLI tools (`ignixa-sqlonfhir`, `ignixa-fakes`) wrote output in the **OEM console code page** (e.g. CP437), not UTF-8 — even when output is redirected. As a result:

- Non-ASCII patient names came out as invalid UTF-8 — `é` → a lone `0xA0`, CJK names → `?`.
- Status glyphs came out as lone bytes — `✓` → `0xFB`.

These invalid byte sequences break consumers that decode captured output as UTF-8:

- **runme.dev** (and similar notebook runners) throw **"Error rendering output item using 'runme-renderer' — URI malformed"** on any cell that prints a non-ASCII name.
- Terminals render the names as `?`.

This is the root cause behind the `?`-names workaround note (`chcp 65001`) in the DevDays demo `todo.md`.

## Fix

Set `Console.OutputEncoding = new UTF8Encoding(false)` at startup of both CLI `Main` methods, guarded with try/catch so it never throws when no console is attached (fully redirected/piped):

```csharp
try { Console.OutputEncoding = new UTF8Encoding(false); } catch { /* no console */ }
```

## Verification

Built locally and ran the global tools against the DevDays demo data, output redirected to a file (the path a notebook runner captures), **without** `chcp`:

- `ignixa-sqlonfhir r4 preview ... --rows 5` → `Fernández` now emits `c3 a1` (valid UTF-8); zero lone `a0`/`fb` bytes.
- `ignixa-fakes r4 resource Patient --from Seattle` → `✓` now emits `e2 9c 93` (valid UTF-8).
- `run` directory/batch output, validate, and batch beats unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)