### PR TITLE
refactor(fhir-faker): rename GenerationDensity.Maximize to Maximum

### DIFF
--- a/docs/features/fhir-faker/investigations/adversarial-data-generation.md
+++ b/docs/features/fhir-faker/investigations/adversarial-data-generation.md
@@ -39,9 +39,9 @@ So: **mutation/decorator is the mechanism; an extensible category catalog is the
 
 ```
 Core generator (functional core, unchanged except one new axis)
-  + GenerationDensity { Minimal | Realistic | Maximize }   ← single contained core change
+  + GenerationDensity { Minimal | Realistic | Maximum }   ← single contained core change
         │
-        ▼  realistic (or maximize) resource
+        ▼  realistic (or maximum) resource
 Edge-case decorator pipeline            ← new: Core/Ignixa.FhirFakes/EdgeCases/
   • IEdgeCaseStrategy registry (built-in + user-registered)
   • seeded selection + application (own Randomizer)
@@ -72,7 +72,7 @@ public interface IEdgeCaseStrategy
 - **Most strategies are field-level mutators** that walk the resource tree and perturb matching
   elements (unicode, temporal, string-boundary, optional-stripping).
 - **A few are resource-level** (maximal cardinality, deep structural nesting) and lean on the core's
-  `GenerationDensity.Maximize` rather than mutating.
+  `GenerationDensity.Maximum` rather than mutating.
 - `MutationTarget` carries the schema type for the element, so a strategy targets *string* fields for
   unicode and *date* fields for temporal — it never drops a CJK string into a required-bound `code`.
 
@@ -103,7 +103,7 @@ builder.WithEdgeCases(c => c.Only("unicode.rtl", "temporal.leap-year"));
 | `unicode` | `cjk`, `rtl`, `combining`, `emoji`, `zero-width`, `multi-script-long` | mutate string fields | PreservesValidity |
 | `temporal` | `leap-year`, `year-boundary`, `far-past`, `far-future`, `partial-precision`, `tz-extreme` | mutate date/dateTime fields | PreservesValidity |
 | `string` | `max-length`, `empty-present`, `whitespace-only`, `control-chars`, `injection-like` | mutate free-text fields | PreservesValidity* |
-| `cardinality` | `all-optional-omitted`, `every-optional-present` | omit-strip / `Maximize` density | PreservesValidity |
+| `cardinality` | `all-optional-omitted`, `every-optional-present` | omit-strip / `Maximum` density | PreservesValidity |
 | `structural` | `deep-nesting`, `contained-resources`, `forEach-heavy` | synthesize | MayViolate |
 
 \* `string.injection-like` is **robustness testing** (does the pipeline mangle a value that *looks*
@@ -217,7 +217,7 @@ buckets, round-trip pass/fail. Without this signal, "edge-case interestingness" 
 
 **Phase 2:**
 5. `string` and `cardinality` families
-6. `GenerationDensity { Minimal | Realistic | Maximize }` axis in the core (enables `every-optional-present`)
+6. `GenerationDensity { Minimal | Realistic | Maximum }` axis in the core (enables `every-optional-present`)
 7. Public custom-strategy registration API
 8. CI round-trip gate in the E2E project (ingest → store → retrieve → search, byte-stable)
 9. `structural` family (synthesis-heavy; hardest; gate behind `--include-invalid` where it `MayViolate`)

--- a/docs/features/fhir-faker/readme.md
+++ b/docs/features/fhir-faker/readme.md
@@ -35,12 +35,12 @@ The FHIR Faker library generates synthetic FHIR resources for testing and develo
 
 ## Key Components
 
-- `SchemaBasedFhirResourceFaker` - Core resource generator; exposes `Density` property (`Minimal` / `Realistic` / `Maximize`) and a seeded constructor for reproducible output
+- `SchemaBasedFhirResourceFaker` - Core resource generator; exposes `Density` property (`Minimal` / `Realistic` / `Maximum`) and a seeded constructor for reproducible output
 - `PatientBuilder` / `PatientBuilderFactory` - Fluent builder with `WithSeed(int)` for reproducible generation and `WithEdgeCases(int? seed, IEnumerable<string>? selectors)` for opt-in edge-case perturbation
 - `EdgeCaseCatalog` - Extensible registry of edge-case strategies; create the default set via `EdgeCaseCatalog.CreateDefault()`; select by family (`unicode`, `temporal`, `string`) or category (`unicode.rtl`, `temporal.leap-year`, etc.)
 - `EdgeCasePipeline` - Seeded decorator that walks the schema-typed element tree and applies one eligible strategy per leaf; emits a `MutationManifest` for replay
 - `MutationManifest` / `MutationRecord` - Structured record of every applied mutation (category, path, before, after, description); serialises to JSON via `ToJson()`
-- `GenerationDensity` enum - `Minimal` (required only, default), `Realistic` (currently identical to Minimal), `Maximize` (all optional elements populated)
+- `GenerationDensity` enum - `Minimal` (required only, default), `Realistic` (currently identical to Minimal), `Maximum` (all optional elements populated)
 - `ScenarioBuilder` - Fluent API for clinical scenarios
 - `ImmunizationState` - Gold standard for version-aware resource generation
 - `FhirVersionHelper` - Cross-version compatibility utilities

--- a/docs/features/validation/investigations/primitive-value-validation-gap.md
+++ b/docs/features/validation/investigations/primitive-value-validation-gap.md
@@ -70,7 +70,7 @@ invalid-calendar-date cases), confirming they are incidental, not a specified de
 
 ## Evidence (reproduced)
 
-`ignixa-fakes r4 resource Observation --density maximize --edge-cases string,unicode --seed 5
+`ignixa-fakes r4 resource Observation --density maximum --edge-cases string,unicode --seed 5
 --include-invalid --validate` →
 ```
 mutations=15  (string.control-chars: 6, string.empty-present: 1, string.whitespace-only: 2, …)

--- a/docs/site/docs/core-sdk/fhir-fakes.md
+++ b/docs/site/docs/core-sdk/fhir-fakes.md
@@ -391,8 +391,8 @@ ignixa-fakes r4 resource Patient --out ./output --edge-cases --include-invalid -
 # Generate an Observation in a specific clinical state
 ignixa-fakes r4 resource Observation BloodGlucose --out ./output
 
-# Generate any resource type at maximize density (all optional elements populated)
-ignixa-fakes r4 resource AllergyIntolerance --out ./output --density maximize
+# Generate any resource type at maximum density (all optional elements populated)
+ignixa-fakes r4 resource AllergyIntolerance --out ./output --density maximum
 ```
 
 **Exit codes for scripting / CI:**
@@ -459,7 +459,7 @@ Pass a seed to the constructor. The seed is propagated to any `PatientBuilder` c
 ```csharp
 var faker = new SchemaBasedFhirResourceFaker(schemaProvider, seed: 42)
 {
-    Density = GenerationDensity.Maximize
+    Density = GenerationDensity.Maximum
 };
 
 var patient = faker.Generate("Patient");
@@ -628,14 +628,14 @@ var manifest = pipeline.Apply(resource, strategies);
 |-------|-----------|
 | `Minimal` | Required elements only. This is the default. |
 | `Realistic` | Currently behaves identically to `Minimal` (reserved for future realistic optional-field selection). |
-| `Maximize` | Required elements plus every optional element populated. |
+| `Maximum` | Required elements plus every optional element populated. |
 
 ### Library Usage
 
 ```csharp
 var faker = new SchemaBasedFhirResourceFaker(schemaProvider)
 {
-    Density = GenerationDensity.Maximize
+    Density = GenerationDensity.Maximum
 };
 
 var fullyPopulatedPatient = faker.Generate("Patient");
@@ -647,20 +647,20 @@ Or with a seed:
 ```csharp
 var faker = new SchemaBasedFhirResourceFaker(schemaProvider, seed: 42)
 {
-    Density = GenerationDensity.Maximize
+    Density = GenerationDensity.Maximum
 };
 ```
 
 ### CLI
 
-Pass `--density minimal|realistic|maximize` to the `resource` command:
+Pass `--density minimal|realistic|maximum` to the `resource` command:
 
 ```bash
-ignixa-fakes r4 resource AllergyIntolerance --out ./output --density maximize
-ignixa-fakes r4 resource Patient --out ./output --density maximize --seed 42
+ignixa-fakes r4 resource AllergyIntolerance --out ./output --density maximum
+ignixa-fakes r4 resource Patient --out ./output --density maximum --seed 42
 ```
 
-**Important:** when `--density` is `realistic` or `maximize`, the `resource` command uses the schema-based generator for any resource type and **ignores** `--firstname`, `--surname`, `--from`, and the Observation `stateName` specialisation. The filename includes the density label: `{version}-{resourcetype}-{density}-{id}.json`.
+**Important:** when `--density` is `realistic` or `maximum`, the `resource` command uses the schema-based generator for any resource type and **ignores** `--firstname`, `--surname`, `--from`, and the Observation `stateName` specialisation. The filename includes the density label: `{version}-{resourcetype}-{density}-{id}.json`.
 
 ---
 

--- a/src/Core/Ignixa.FhirFakes/GenerationDensity.cs
+++ b/src/Core/Ignixa.FhirFakes/GenerationDensity.cs
@@ -28,5 +28,5 @@ public enum GenerationDensity
     /// Required elements PLUS every optional element populated.
     /// Maps to the "every-optional-present" cardinality edge case.
     /// </summary>
-    Maximize
+    Maximum
 }

--- a/src/Core/Ignixa.FhirFakes/SchemaBasedFhirResourceFaker.cs
+++ b/src/Core/Ignixa.FhirFakes/SchemaBasedFhirResourceFaker.cs
@@ -183,7 +183,7 @@ public class SchemaBasedFhirResourceFaker
     /// <summary>
     /// Generates a fake FHIR resource by resource type name. Population is governed by
     /// <see cref="Density"/>: required elements only by default (Minimal/Realistic); under
-    /// <see cref="GenerationDensity.Maximize"/> every optional element is included as well. Inclusion
+    /// <see cref="GenerationDensity.Maximum"/> every optional element is included as well. Inclusion
     /// is deterministic for a given density — optionals are never sampled at random.
     /// </summary>
     public ResourceJsonNode Generate(string resourceType)
@@ -230,7 +230,7 @@ public class SchemaBasedFhirResourceFaker
             // For choice elements, we need to pick a type and append it to the element name
             var (actualElementName, actualElement) = ResolveChoiceElement(child);
 
-            // Minimal/Realistic: required elements only. Maximize: required plus optional.
+            // Minimal/Realistic: required elements only. Maximum: required plus optional.
             if (!ShouldPopulate(child))
             {
                 continue;
@@ -453,7 +453,7 @@ public class SchemaBasedFhirResourceFaker
             // Handle choice elements
             var (actualElementName, actualElement) = ResolveChoiceElement(child);
 
-            // Minimal/Realistic: required only. Maximize: required plus optional.
+            // Minimal/Realistic: required only. Maximum: required plus optional.
             // The depth guard above bounds optional complex children too.
             if (!ShouldPopulate(child))
             {
@@ -1043,9 +1043,9 @@ public class SchemaBasedFhirResourceFaker
 
     /// <summary>
     /// Determines whether an element should be populated for the current <see cref="Density"/>.
-    /// Required elements are always populated; optional elements only under <see cref="GenerationDensity.Maximize"/>.
+    /// Required elements are always populated; optional elements only under <see cref="GenerationDensity.Maximum"/>.
     /// </summary>
-    private bool ShouldPopulate(IType child) => child.IsRequired || Density == GenerationDensity.Maximize;
+    private bool ShouldPopulate(IType child) => child.IsRequired || Density == GenerationDensity.Maximum;
 
     /// <summary>
     /// Applies the configured tag to a resource's meta.tag array.

--- a/test/Ignixa.FhirFakes.Tests/GenerationDensityTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/GenerationDensityTests.cs
@@ -16,8 +16,8 @@ namespace Ignixa.FhirFakes.Tests;
 
 /// <summary>
 /// Tests for the <see cref="GenerationDensity"/> axis on <see cref="SchemaBasedFhirResourceFaker"/>.
-/// Verifies that Minimal preserves required-only behavior, Maximize populates optional elements,
-/// Realistic is equivalent to Minimal, and Maximize generation terminates and validates.
+/// Verifies that Minimal preserves required-only behavior, Maximum populates optional elements,
+/// Realistic is equivalent to Minimal, and Maximum generation terminates and validates.
 /// </summary>
 public class GenerationDensityTests
 {
@@ -54,40 +54,40 @@ public class GenerationDensityTests
     }
 
     [Fact]
-    public void GivenMaximizeDensity_WhenGeneratingPatient_ThenOptionalGenderIsPresent()
+    public void GivenMaximumDensity_WhenGeneratingPatient_ThenOptionalGenderIsPresent()
     {
-        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximize };
+        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximum };
 
         var patient = faker.Generate("Patient");
 
         patient.MutableNode["gender"].ShouldNotBeNull(
-            "Patient.gender is optional and should be populated under Maximize density");
+            "Patient.gender is optional and should be populated under Maximum density");
     }
 
     [Fact]
-    public void GivenMaximizeDensity_WhenGeneratingObservation_ThenOptionalBodySiteIsPresent()
+    public void GivenMaximumDensity_WhenGeneratingObservation_ThenOptionalBodySiteIsPresent()
     {
-        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximize };
+        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximum };
 
         var observation = faker.Generate("Observation");
 
         observation.MutableNode["bodySite"].ShouldNotBeNull(
-            "Observation.bodySite is optional and should be populated under Maximize density");
+            "Observation.bodySite is optional and should be populated under Maximum density");
     }
 
     [Fact]
-    public void GivenMaximizeDensity_WhenGeneratingPatient_ThenPopulatesMoreElementsThanMinimal()
+    public void GivenMaximumDensity_WhenGeneratingPatient_ThenPopulatesMoreElementsThanMinimal()
     {
         var minimal = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Minimal }
             .Generate("Patient");
-        var maximal = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximize }
+        var maximal = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximum }
             .Generate("Patient");
 
         var minimalKeys = ((JsonObject)minimal.MutableNode).Count;
         var maximalKeys = ((JsonObject)maximal.MutableNode).Count;
 
         maximalKeys.ShouldBeGreaterThan(minimalKeys,
-            "Maximize density should populate strictly more top-level elements than Minimal");
+            "Maximum density should populate strictly more top-level elements than Minimal");
     }
 
     [Theory]
@@ -95,9 +95,9 @@ public class GenerationDensityTests
     [InlineData("Observation")]
     [InlineData("Questionnaire")]
     [InlineData("Bundle")]
-    public void GivenMaximizeDensity_WhenGeneratingNestedTypes_ThenTerminatesWithoutThrowing(string resourceType)
+    public void GivenMaximumDensity_WhenGeneratingNestedTypes_ThenTerminatesWithoutThrowing(string resourceType)
     {
-        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 7) { Density = GenerationDensity.Maximize };
+        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 7) { Density = GenerationDensity.Maximum };
 
         var resource = Should.NotThrow(() => faker.Generate(resourceType));
 
@@ -138,9 +138,9 @@ public class GenerationDensityTests
     }
 
     [Fact]
-    public void GivenMaximizeDensity_WhenGeneratingPatient_ThenStillValidates()
+    public void GivenMaximumDensity_WhenGeneratingPatient_ThenStillValidates()
     {
-        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximize };
+        var faker = new SchemaBasedFhirResourceFaker(_schemaProvider, seed: 5) { Density = GenerationDensity.Maximum };
 
         var patient = faker.Generate("Patient");
         var errors = ValidateResource(patient).Issues
@@ -148,7 +148,7 @@ public class GenerationDensityTests
             .ToList();
 
         errors.ShouldBeEmpty(
-            $"Maximize Patient should remain valid. Issues: {string.Join(", ", errors.Select(e => $"{e.Path}: {e.Message}"))}");
+            $"Maximum Patient should remain valid. Issues: {string.Join(", ", errors.Select(e => $"{e.Path}: {e.Message}"))}");
     }
 
     private ValidationResult ValidateResource(ResourceJsonNode resource)

--- a/tools/Ignixa.FhirFakes.Cli/Commands/ResourceCommand.cs
+++ b/tools/Ignixa.FhirFakes.Cli/Commands/ResourceCommand.cs
@@ -31,7 +31,7 @@ internal static class ResourceCommand
         var edgeCasesOption = new Option<string?>("--edge-cases") { Description = "Enable edge-case perturbation. Optionally specify comma-separated selectors (families or categories).", Arity = ArgumentArity.ZeroOrOne };
         var seedOption = new Option<int?>("--seed") { Description = "Seed for reproducible edge-case generation" };
         var includeInvalidOption = new Option<bool>("--include-invalid") { Description = "Include non-validity-preserving (MayViolate/AlwaysInvalid) strategies when edge-cases are enabled", DefaultValueFactory = _ => false };
-        var densityOption = new Option<string?>("--density") { Description = "Generation density: minimal|realistic|maximize (default minimal). realistic/maximize use the schema generator for ANY resource type and therefore IGNORE --firstname/--surname/--from and the Observation stateName specialization. realistic currently behaves identically to minimal." };
+        var densityOption = new Option<string?>("--density") { Description = "Generation density: minimal|realistic|maximum (default minimal). realistic/maximum use the schema generator for ANY resource type and therefore IGNORE --firstname/--surname/--from and the Observation stateName specialization. realistic currently behaves identically to minimal." };
         var verboseOption = new Option<bool>("--verbose") { Description = "Print full exception details (type and stack trace) on error", DefaultValueFactory = _ => false };
 
         resourceCommand.Arguments.Add(resourceTypeArg);
@@ -67,7 +67,7 @@ internal static class ResourceCommand
 
             if (!TryParseDensity(parseResult.GetValue(densityOption), out var density))
             {
-                await Console.Error.WriteLineAsync($"✗ Invalid --density value '{parseResult.GetValue(densityOption)}'. Use minimal, realistic, or maximize.");
+                await Console.Error.WriteLineAsync($"✗ Invalid --density value '{parseResult.GetValue(densityOption)}'. Use minimal, realistic, or maximum.");
                 Environment.ExitCode = 2;
                 return;
             }


### PR DESCRIPTION
Follow-up to #282.

#282 landed the density value as `Maximize` — a verb that reads inconsistently next to `Minimal` / `Realistic`. This renames it to `Maximum` so the CLI token, SDK enum, generated filename label, and docs are grammatically consistent.

## Changes
- `GenerationDensity.Maximize` → `Maximum` (enum member)
- CLI: `--density maximum` (help text + invalid-value error)
- `SchemaBasedFhirResourceFaker` logic + doc comments
- `GenerationDensityTests` (enum refs, test names, assertion messages)
- Docs: `fhir-fakes.md`, `fhir-faker/readme.md`, two investigation docs

Plain-English uses of "maximal" in the investigation doc (maximal cardinality/coverage) are intentionally left as-is.

Behavior unchanged. CLI builds 0 warnings / 0 errors; all 13 density tests pass on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)