### PR TITLE
feat(validation): thread FHIRPath tree-context scope through validation

### DIFF
--- a/docs/features/validation/investigations/slicing-discriminators.md
+++ b/docs/features/validation/investigations/slicing-discriminators.md
@@ -1,0 +1,280 @@
+# Investigation: Slicing & Discriminator Validation
+
+**Feature**: validation
+**Status**: In Progress
+**Created**: 2026-06-17
+
+## Problem Statement
+
+`SlicingMetadata` is captured from every `ElementDefinition.slicing` during code-gen
+(`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs`) but the comment in that file is
+explicit: *"Slicing support is not yet implemented but metadata is captured for future use."*
+`StructureDefinitionSchemaBuilder` builds cardinality, type, shape, invariant, and binding checks
+for every tier (Minimal / Spec / Full — `ValidationDepth.cs`) but produces no `SlicingCheck` in
+`profileChecks` (`StructureDefinitionSchemaBuilder.cs:301-318`). The `ValidationSchema` doc-comment
+at line 29 acknowledges this: *"Profile checks (Full depth) — Slicing, advanced terminology, etc."*
+
+The practical consequence:
+
+- `Extension.extension` is sliced by `url` in every R4 StructureDefinition (the canonical example in
+  `reference-implementations.md`). Without slice assignment, ignixa cannot enforce that two
+  extensions with the same URL do not exceed their per-slice `max`.
+- Profile slicing (e.g., `us-core-patient.name` sliced into `official` / `nickname`) is completely
+  invisible to the validator.
+- Closed/`openAtEnd` slice rules — which must reject unmatched elements — are never applied.
+
+## Key Insight
+
+Slicing is not backward navigation. It is a **parent-altitude check**.
+
+The element *owning* the sliced array — e.g., the `Patient` node owning `name[*]` — already has
+all candidates available through `Children("name")`. The forward-only `IElement` model handles this
+natively: there is no need for a parent pointer, a `ScopedNode` wrapper, or any upward traversal.
+This is the same conclusion the [tree-context-scoping investigation](tree-context-scoping.md) reached
+when it classified slicing as *"not backward navigation at all … a parent-altitude check over
+`Children()`, which the forward-only model already supports"* (tree-context-scoping.md, Key Insight
+section).
+
+What slicing actually requires is a two-responsibility split:
+
+1. **Imperative shell** — slice *assignment*, per-slice cardinality accounting, closed/open rule
+   enforcement, and error reporting. This must be imperative code so diagnostics can say *"you have
+   2 elements matching slice 'official', expected at most 1, at Patient.name[3]"* rather than a
+   single boolean assertion.
+2. **FHIRPath predicate engine** — evaluate the per-element discriminator condition. Only this piece
+   delegates to the existing FhirPath engine. The discriminator `path` is itself restricted
+   FHIRPath: simple property navigation plus `resolve()`, `extension(url)`, and `ofType()`.
+
+This is the accurate reading of the phrase "HAPI compiles checks to FHIRPath" (confirmed in the
+[reference-implementations](reference-implementations.md) SliceValidator section): the FHIRPath
+engine evaluates the *discriminator predicate per candidate element*, not the whole-profile check.
+Firely's `SliceValidator` (`reference-implementations.md:458-506`) does exactly this — `Condition`
+per `SliceCase` is evaluated via `ValidateOne`, assignment is tracked imperatively in `buckets`,
+then per-slice cardinality is enforced over each bucket.
+
+### Discriminator Type Mapping
+
+The FHIR spec defines five discriminator types. Each maps cleanly to existing engine primitives:
+
+| Discriminator `type` | Discriminator `path` evaluates to | Engine primitive | Status |
+|---|---|---|---|
+| `value` | concrete scalar/code | FHIRPath equality: `path = 'literal'` | Fully implemented |
+| `pattern` | element matching a Pattern | FHIRPath `~` (equivalence) or `subsetOf()` | Implemented (`subsetOf`, `supersetOf` in `CollectionFunctions.cs`) |
+| `exists` | presence/absence | `path.exists()` | Implemented (`exists()` in `CollectionFunctions.cs`) |
+| `type` | FHIR type of the element | `ofType(T)` / `is T` | Implemented (`ofType` in `CollectionFunctions.cs`; `is`/`as` in `TypeConversionFunctions.cs`) |
+| `profile` | element conforms to a profile canonical | `conformsTo('url')` | **Stub** — throws `NotSupportedException` (`FhirSpecificFunctions.cs:404-411`); requires tree-context-scoping Solution 1 first |
+
+The most common discriminators in base R4 profiles (`value` on `url` for extensions, `value` on
+`system`/`code` for identifiers) require only equality — already working. `type` discriminators
+require `ofType` — already working. `profile` discriminators are the only case blocked on a
+prerequisite (see Dependency section below).
+
+## Approach
+
+A `SlicingCheck : IValidationCheck` at the **Full tier** (`ValidationDepth.Full`), registered in
+`_profileChecks` of `ValidationSchema`.
+
+The check owns the sliced element path (e.g., `"name"`), the `SlicingMetadata` captured by
+code-gen, and a per-slice list of `(discriminatorPredicate: string, min: int, max: int?)` compiled
+at schema-build time.
+
+Pseudocode of the core algorithm:
+
+```
+SlicingCheck.Validate(element, depth, state):
+    if depth < Full → return success  // guard: slicing is Full-tier only
+
+    candidates = element.Children(slicedPath)   // O(n) — one forward pass
+    if candidates.IsEmpty → check per-slice minimum cardinality for mandatory slices; return
+
+    // Assignment pass — O(slices × candidates) but slices are typically 2-5
+    buckets = Dictionary<sliceName, List<(IElement, int index)>>
+    defaultBucket = List<(IElement, int index)>
+    lastMatchedSliceIndex = -1
+
+    for (i, candidate) in candidates.WithIndex():
+        matched = false
+        for (s, slice) in slices.WithIndex():
+            predicateResult = fhirPathEngine.Evaluate(candidate, slice.DiscriminatorExpression, context)
+            if predicateResult.IsTrue():
+                if metadata.Ordered && s < lastMatchedSliceIndex:
+                    report Issue(OUT_OF_ORDER, "name[{i}] matches slice '{slice.Name}' out of order")
+                buckets[slice.Name].Add((candidate, i))
+                lastMatchedSliceIndex = s
+                matched = true
+                break  // first match wins; FHIR slicing is deterministic
+
+        if !matched:
+            if metadata.Rules == "closed":
+                report Issue(UNMATCHED_SLICE, "name[{i}] matches no slice in a closed slicing")
+            elif metadata.Rules == "openAtEnd" && lastMatchedSliceIndex >= 0:
+                report Issue(UNMATCHED_SLICE, "name[{i}] appears before end in an openAtEnd slicing")
+            else:
+                defaultBucket.Add((candidate, i))
+
+    // Cardinality pass — O(slices)
+    for slice in slices:
+        count = buckets[slice.Name].Count
+        if count < slice.Min:
+            report Issue(CARDINALITY_TOO_FEW, "slice '{slice.Name}': {count} < min {slice.Min}")
+        if slice.Max != null && count > slice.Max:
+            report Issue(CARDINALITY_TOO_MANY, "slice '{slice.Name}': {count} > max {slice.Max}")
+            for (elem, i) in buckets[slice.Name][slice.Max..]:
+                annotate Issue with "at name[{i}]"  // precise per-element location
+```
+
+`StructureDefinitionSchemaBuilder.BuildSchema` plugs this in where slicing metadata is present on
+an element. The builder already has access to `ITypeExtended`, which carries `SlicingMetadata` via
+code-gen.
+
+The `FhirEvaluationContext` passed to the discriminator evaluations must be built from
+`ValidationState.Scope` (the resource-scope populated by Solution 1 of the
+tree-context-scoping investigation) so that `%resource`, `resolve()`, and — once unblocked —
+`conformsTo()` are available.
+
+## Dependency on Tree-Context Scoping
+
+This investigation builds directly on [tree-context-scoping](tree-context-scoping.md) Solutions 1
+and 2:
+
+- **Solution 1 (resource scope threading)** is required for `profile` and `type` discriminators
+  whose `conformsTo()` predicate must be evaluated against the correctly-scoped `%resource`. Without
+  Solution 1, `conformsTo` would evaluate against an unscoped element (wrong), even after its
+  stub is replaced with a real implementation.
+- **Solution 2 (scoped reference index)** is required for reference discriminators that navigate
+  through `resolve()` to reach the target element. `resolve()` already returns empty when no
+  resolver is configured (`FhirSpecificFunctions.cs:94-96`), so without Solution 2, any
+  discriminator path containing `resolve()` silently produces no match and assigns all candidates
+  to the default bucket.
+
+For `value` and `exists` discriminators (the vast majority of base R4 usage), neither tree-context
+dependency is needed — `SlicingCheck` can be delivered as a partial implementation before
+tree-context-scoping lands, with `profile`-type discriminator support gated behind a capability
+flag.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Fits the existing `IValidationCheck` / `_profileChecks` slot without any new abstractions | O(slices × candidates) assignment pass; for rare deeply-nested slicings with many slices this is not O(n) |
+| Precise per-element diagnostics: reports `name[3]` not just "slicing failed" | Discriminator predicate evaluation re-walks the candidate for each slice until a match is found; early-exit on first match mitigates this significantly |
+| Forward-only `IElement` model is sufficient — no `ScopedNode`, no parent pointer | Nested slicing (reslicing within a slice) requires a recursive `SlicingCheck` per sub-slice; compiler complexity grows with nesting depth |
+| Delegate-injection pattern for `conformsTo` is already established (`ElementResolver` on `FhirEvaluationContext`) — clean seam, no new mechanism | `profile` discriminators blocked until tree-context-scoping Solution 1 lands and `conformsTo` stub is replaced |
+| `SlicingMetadata` already captures discriminators, rules, and ordered flag — code-gen work already done | A single-pass assignment (produce O(1) FHIRPath expression collapsing all predicates) would be faster but loses per-element location in error messages |
+| Aligns with Firely `SliceValidator` (bucket-based, condition per slice case) and HAPI's imperative assignment; no novel pattern to justify | `conformsTo()` injection adds a FHIRPath→Validation callback that must be wired carefully to avoid re-entrant validation cycles (same risk as the `ElementResolver` cycle, which is already managed) |
+| Closed/openAtEnd enforcement is straightforward boolean state on the assignment loop | `ordered` slicing requires tracking `lastMatchedSliceIndex`, which means unordered slicings cannot short-circuit early within a candidate's slice loop — minor |
+
+## Alignment
+
+- [x] Follows architectural layering rules — `SlicingCheck` lives in `Ignixa.Validation.Checks`,
+      consumes `IElement` (forward-only), delegates discriminator evaluation to `Ignixa.FhirPath`
+      via the context boundary; no `Hl7.Fhir.*` dependency introduced
+- [x] Developer Experience — plugs into the existing `_profileChecks` list; schema-builder already
+      has the slicing metadata; consumers see the same `IValidationIssue` shape as today
+- [x] Specification compliance — implements FHIR R4 `ElementDefinition.slicing` rules: ordered,
+      closed/open/openAtEnd, per-slice min/max cardinality, five discriminator types
+- [x] Consistent with existing patterns — `IValidationCheck`, `ValidationDepth.Full` gate,
+      `FhirEvaluationContext` from `ValidationState.Scope`, delegate-injection for `conformsTo`
+      mirroring the `ElementResolver` seam
+
+## Weakest-Link Analysis
+
+1. **`conformsTo()` re-entrancy.** Implementing `conformsTo` as a `Func<IElement, string, bool>`
+   delegate on `FhirEvaluationContext` (mirroring `ElementResolver`) means the FHIRPath engine
+   calls back into the validation pipeline for each `profile` discriminator. If a discriminator
+   predicate triggers further slicing which triggers further `conformsTo` calls, a cycle is
+   possible. Mitigation: the same per-resource cycle guard already used by
+   `ContainedResourceCheck` can be reused; `conformsTo` should not itself run Full-depth
+   validation (a Spec-depth structural check is sufficient for slice assignment).
+
+2. **Silent no-match on missing resolver.** A `profile` discriminator before tree-context-scoping
+   lands will cause `conformsTo` to throw `NotSupportedException`
+   (`FhirSpecificFunctions.cs:410`). The check must catch this and either skip the discriminator
+   (treating assignment as indeterminate — unsafe for closed slicings) or report a warning and
+   skip. The safer choice is to gate `profile`-discriminator slices with an explicit capability
+   flag rather than silently assigning all candidates to the default bucket.
+
+3. **`SlicingMetadata.Discriminators` is `string[]` without type annotation.** The current model
+   stores raw strings (`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs:22`) with no
+   separate `type` field — the discriminator type (value/pattern/exists/type/profile) is not
+   captured. Code-gen must be extended to emit a structured discriminator record (type + path)
+   before `SlicingCheck` can construct the correct FHIRPath predicate per discriminator. This is a
+   prerequisite schema-builder change, not a runtime change.
+
+4. **O(slices × candidates) for large arrays.** Patient bundles with hundreds of entries each
+   containing many sliced identifiers could make this quadratic in practice. Mitigation: a
+   single-pass trie-like pre-index over the discriminator values (for pure `value` discriminators)
+   can reduce this to O(candidates + slices); implement as an optimization after correctness is
+   established.
+
+## Evidence
+
+- **Metadata captured, logic absent.** `SlicingMetadata` constructor confirms discriminators,
+  rules, and ordered are all captured (`SlicingMetadata.cs:14-18`). The file-level comment *"not
+  yet implemented"* is unambiguous.
+- **Correct plug-in point.** `ValidationSchema._profileChecks` is explicitly documented as
+  *"Slicing, advanced terminology, etc."* (`ValidationSchema.cs:29`). `StructureDefinitionSchemaBuilder`
+  builds `profileChecks` (line 301) and currently populates it only with `invariantChecks` (line 308).
+  Adding `SlicingCheck` here follows the exact same pattern.
+- **FHIRPath primitives are ready.** `ofType` exists in `CollectionFunctions.cs:575`; `exists` at
+  line 27; `subsetOf`/`supersetOf` for pattern matching present. `is`/`as` type-testing operators
+  are in `TypeConversionFunctions.cs`. The only missing primitive is `conformsTo`
+  (`FhirSpecificFunctions.cs:397-411`), which throws `NotSupportedException` and is explicitly
+  flagged as needing *"profile validation infrastructure"*.
+- **Reference prior art.** Firely's `SliceValidator` in `reference-implementations.md:458-506`
+  uses bucket-based assignment with a `Condition.ValidateOne(candidate, vc, state)` discriminator
+  call — directly analogous to the proposed approach. HAPI's StructureDefinition XML shows the
+  canonical `Extension.extension` sliced-by-`url` example (`reference-implementations.md:579-598`),
+  confirming `value` discriminator on `url` is the single most important case to get right.
+- **GraphQL directive is not reusable.** `FhirSliceDirectiveType.cs` declares a `@slice(path:)`
+  GraphQL directive for HotChocolate query slicing — a completely different concept
+  (splitting a list result in a query response). It contains no slice-matching logic and shares
+  only the name.
+- **`ValidationDepth.Full` is the correct tier.** `ValidationDepth.cs:22` defines Full as
+  *"structure + required and extensible bindings, display checks, invariants/slicing"* — the
+  comment already names slicing explicitly.
+- **ADR-2510** (`docs/adr/adr-2510-validation-architecture.md`) established the three-tier schema
+  architecture that `SlicingCheck` slots into without revision.
+
+## Open Questions
+
+1. **`SlicingMetadata` schema gap.** The current `Discriminators: string[]` captures the
+   discriminator `path` but not the `type` (value/pattern/exists/type/profile). Should code-gen
+   emit a `DiscriminatorDefinition(string Type, string Path)` record, or should `SlicingCheck`
+   parse the type from a convention in the path string? The former is cleaner; it requires a
+   code-gen change and a new type in `Ignixa.Abstractions`.
+
+2. **Partial delivery.** Is it acceptable to ship `SlicingCheck` with `value`, `exists`, and `type`
+   discriminators working (no tree-context dependency) and `profile`/`resolve()` discriminators
+   gated behind a capability flag, before tree-context-scoping lands? Or should slicing wait for
+   the full foundation?
+
+3. **Nested / resliced slices.** When a slice itself contains a further sliced element (reslicing),
+   `SlicingCheck` must be applied recursively. Is the correct approach to emit a nested
+   `SlicingCheck` inside a `NestedComplexTypeCheck`, or to flatten the slice hierarchy at
+   schema-build time?
+
+4. **`conformsTo` cycle guard depth.** The re-entrant validation triggered by `profile`
+   discriminators should run at what depth — Minimal or Spec? Spec is sufficient to establish
+   profile conformance for slice assignment and avoids triggering further Full-depth slicing checks
+   recursively.
+
+## Verdict
+
+*Pending evaluation.* The hybrid approach — imperative assignment + FHIRPath discriminator
+predicate — is the clearly right direction: it matches Firely's `SliceValidator`, HAPI's design,
+and fits the existing `IValidationCheck` / `_profileChecks` slot without new abstractions.
+
+The strongest constraint on sequencing is the `SlicingMetadata` schema gap (Open Question 1): the
+current `string[]` for discriminators cannot distinguish discriminator `type` from `path`, so code-gen
+must emit a structured record before `SlicingCheck` can correctly choose between `value =`,
+`ofType()`, and `conformsTo()` predicates.
+
+Recommended sequencing once that gap is resolved:
+1. Extend code-gen to emit `DiscriminatorDefinition(Type, Path)` in `SlicingMetadata`.
+2. Implement `SlicingCheck` with `value`, `exists`, and `type` discriminators (no tree-context
+   dependency). Gate `profile`-discriminator paths with a capability flag that degrades to
+   open-slicing semantics.
+3. Land [tree-context-scoping](tree-context-scoping.md) Solutions 1 and 2.
+4. Implement `conformsTo()` injection via `FhirEvaluationContext` delegate; wire into
+   `SlicingCheck` for `profile` discriminators; remove the capability flag.

--- a/docs/features/validation/investigations/tree-context-scoping.md
+++ b/docs/features/validation/investigations/tree-context-scoping.md
@@ -1,0 +1,269 @@
+# Investigation: Tree-Context Scoping (%resource, %rootResource, resolve())
+
+**Feature**: validation
+**Status**: Viable
+**Created**: 2026-06-17
+
+## Problem Statement
+
+ignixa's runtime element model (`IElement`) is **forward-only**: it exposes `Children()` and
+nothing else. There is no `Parent`, no `Ancestors()`, no enclosing-resource pointer. This is a
+deliberate contrast with the Firely SDK, whose `ScopedNode` wraps every `ITypedElement` with
+`Parent` / `ParentResource` pointers and lazily computes `%resource`, `resolve()`, and `Location`
+by walking *up* the tree (`firely-net-sdk/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs`).
+
+Three FHIR validation behaviours appear to need that upward/sideways navigation:
+
+1. **`%resource` / `%rootResource` in invariants** — e.g. `dom-1`, `bdl-*`. A constraint evaluated
+   deep inside a resource needs `%resource` to point back at the enclosing resource.
+2. **`resolve()` across Bundle entries and contained resources** — a `Reference` must find a
+   *sibling* `entry.resource` (by `fullUrl`) or a `#id` contained resource.
+3. **Slicing discriminators** — partition a sibling array into slices.
+
+Today the gap is real and silent. `FhirPathInvariantCheck.Validate` calls
+`_evaluator.Evaluate(element, expression)` with **no context**
+(`src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs:168`), so `%resource` auto-inits to
+*the constrained element itself* (`TypedElementExtensions.Select` defaults `Resource`/`RootResource`
+to the input). For a nested element `%resource` points at the wrong node, and `resolve()` returns
+empty because no resolver is wired. The existing test suite acknowledges this:
+*"Real dom-1 requires %resource variable ... not yet implemented."*
+
+## Key Insight: FHIRPath has no `parent()` operator
+
+The FHIRPath spec exposes exactly two "backward" capabilities — root-ward variables
+(`%resource`/`%rootResource`) and reference resolution (`resolve()`). There is **no** standard way
+for an expression to navigate to an arbitrary parent element. Firely's `ScopedNode.Parent` is
+internal plumbing used to *compute* those two things plus `Location`; it is never surfaced as a
+FHIRPath navigation step.
+
+Therefore ignixa does **not** need a parent pointer on the node. Both backward needs are computable
+**on the way down**: the traversal that descends the tree *is* the ancestor chain, so the walker's
+call stack already holds everything a `Parent` field would store. Storing parent pointers on the
+node would duplicate state the traversal already has — the wrong tool for this codebase.
+
+Slicing is not backward navigation at all (see *Related future work*): it is a parent-altitude check
+over `Children()`, which the forward-only model already supports.
+
+## Approach
+
+Two complementary changes, both staying on the current "dumb node + injected context" pathway. No
+change to `IElement`.
+
+### Solution 1 — Thread resource scope through `ValidationState`
+
+`ValidationState` is already an immutable record threaded through the validation pipeline with three
+levels (Global / Instance / Location) and a `with`-based fluent API
+(`src/Core/Ignixa.Validation/ValidationState.cs`). Add a fourth concern — the resource scope — and
+fork it at resource boundaries during descent.
+
+```csharp
+public record ValidationState
+{
+    public ResourceScope Scope { get; init; } = new();
+
+    // A standalone resource, or an independent Bundle entry: %resource == %rootResource == itself.
+    public ValidationState EnterRootResource(IElement resource) => this with
+    {
+        Scope = new ResourceScope
+        {
+            Resource     = resource,
+            RootResource = resource,
+            Resolver     = BuildResolver(resource, parent: null),  // see Solution 2
+        }
+    };
+
+    // A contained resource C inside parent P: %resource = C, %rootResource = P (the container).
+    public ValidationState EnterContainedResource(IElement contained) => this with
+    {
+        Scope = Scope with
+        {
+            Resource     = contained,
+            RootResource = Scope.Resource,                          // the containing resource
+            Resolver     = BuildResolver(contained, parent: Scope), // contained #ids chain to parent/bundle
+        }
+    };
+}
+
+public record ResourceScope
+{
+    public IElement? Resource { get; init; }       // %resource     = nearest containing resource
+    public IElement? RootResource { get; init; }   // %rootResource = container resource (parent), else == Resource
+    public Func<string, IElement?>? Resolver { get; init; }
+}
+```
+
+The fix at the consumer — `FhirPathInvariantCheck.Validate` stops evaluating context-free:
+
+```csharp
+var context = new FhirEvaluationContext
+{
+    Resource       = state.Scope.Resource,
+    RootResource   = state.Scope.RootResource,
+    ElementResolver = state.Scope.Resolver,
+};
+var result = _evaluator.Value.Evaluate(element, expression, context);
+```
+
+**`%resource` / `%rootResource` semantics (FHIR rule, encoded above):**
+- Standalone resource, or an independent **Bundle entry**: `%resource == %rootResource ==` that resource.
+  A Bundle entry's resource is *not* contained in the Bundle in the FHIRPath sense, so neither variable
+  points at the Bundle.
+- **Contained** resource C inside parent P: `%resource = C`, `%rootResource = P` (the containing resource).
+- The Bundle's own constraints (`bdl-*`): `%resource == %rootResource ==` the Bundle.
+
+Firely reaches the same result by scanning up `ParentResource` and stopping before a Bundle
+(`ScopedNode.ResourceContext` — "do not go past a root resource into a bundle"); we encode it directly
+at the two seed points instead of scanning.
+
+### Solution 2 — Scoped reference index injected as the `ElementResolver`
+
+`resolve()` is already a delegated `Func<string, IElement?>` on `FhirEvaluationContext`
+(`FhirEvaluationContext.cs:35`); the search indexer already wires one
+(`ElementSearchIndexer.cs:65`). The gap is only that validation never builds one with knowledge of
+the enclosing Bundle/contained set. Build that index — Firely's `ReferencedResourceCache`
+equivalent — by the walker, and inject the closure. Do **not** attach it to the node.
+
+```csharp
+sealed class ReferenceIndex
+{
+    readonly Dictionary<string, IElement> _byFullUrl;     // urn:uuid:.., Type/id, Type/id/_history/v
+    readonly Dictionary<string, IElement> _byContainedId; // "#p1"
+    public IElement? Resolve(string r) =>
+        r.StartsWith('#') ? _byContainedId.GetValueOrDefault(r[1..])
+                          : _byFullUrl.GetValueOrDefault(r);
+}
+```
+
+- Built **lazily and cached in `ValidationState.Global.Cache`**, keyed on the owner's
+  `Meta<JsonNode>()` identity — O(entries) once per Bundle, not once per reference.
+- The injected resolver chains **contained-of-current-`%resource` → bundle-of-root**, the correct
+  FHIR resolution order.
+- **Reference integrity** becomes a small new `IValidationCheck`: resolve each `Reference` through
+  the index, report unresolved (respecting external/logical references that legitimately do not
+  resolve).
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| No change to `IElement`; stays on the forward-only model | Each site where a resource becomes a validation root must seed scope (only 2 today) |
+| Reuses existing primitives: `ValidationState` threading + `ElementResolver` delegate | Future nested-root sites (bundle-entry validation) must remember to seed |
+| Functional-core / imperative-shell aligned: node stays pure, shell supplies context | `%resource`/`%rootResource` contained-vs-standalone rule must be encoded correctly |
+| Unblocks `dom-1`, `bdl-*`, and all `%resource`-referencing invariants | Reference index adds O(entries) build cost per Bundle (mitigated by caching) |
+| Cheaper than Firely on the hot path — no per-child `ScopedNode` allocation | Does not by itself solve evaluation of *context-free* deep nodes handed in via a public API (see Open Question) |
+| Same delegate-injection pattern already proven by `resolve()` breaking the FhirPath→storage cycle | |
+
+## Alignment
+
+- [x] Follows architectural layering rules — `Ignixa.FhirPath` stays dependency-free; validation
+      injects context at the boundary (same inversion as `ElementResolver`)
+- [x] Developer Experience — no new public surface; checks read scope from the state they already receive
+- [x] Specification compliance — implements FHIRPath `%resource`/`%rootResource` and `resolve()`
+      semantics including the Bundle-boundary rule
+- [x] Consistent with existing patterns — immutable `with`-based state, injected delegates, lazy caches
+
+## Weakest-Link Analysis
+
+1. **Scope must be seeded at every nested-root site, and only there.** There is no per-element
+   descent in the engine — `ValidationSchema.Validate` runs all checks against one root `element`,
+   so scope changes *only* when a resource becomes a new validation root (handler entry +
+   `ContainedResourceCheck` today; bundle-entry validation in future). Two failure modes:
+   (a) a new nested-root site forgets to call `Enter*Resource` → `%resource` stays stale/null
+   **silently**; (b) if element-level invariants are later wired (evaluating a constraint against a
+   sub-element like `Patient.contact`), a developer might "helpfully" re-point `%resource` per
+   element — wrong: `%resource` must stay the enclosing *resource*. *Mitigation:* expose seeding only
+   as `EnterRootResource` / `EnterContainedResource` on `ValidationState` (no per-element variant),
+   so the invariant "scope forks at resource boundaries, nowhere else" is structurally enforced.
+2. **Silent `resolve()`.** Today `resolve()` returns empty both when *no resolver is configured*
+   (a wiring bug) and when *a reference legitimately does not resolve* (correct per spec)
+   (`FhirSpecificFunctions.cs:94`). In the validation path the resolver should be non-null, so a
+   missing resolver surfaces instead of vanishing. Only genuine misses return empty.
+3. **Index cost.** Eager per-reference rebuild would be O(refs × entries). Lazy build + cache keyed
+   on Bundle identity makes it O(entries) once.
+
+## Evidence
+
+- **Forward-only node, by design.** `IElement` has no parent
+  (`src/Core/Ignixa.Abstractions/Structure/IElement.cs`). The Firely adapter
+  (`Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs`) deliberately does not expose `Parent`. A
+  parent link *does* exist at the substrate (`System.Text.Json` `JsonNode.Parent`) and is used as an
+  escape hatch for mutation only (`Ignixa.DeId/Extensions/ElementMutationExtensions.cs`).
+- **Context is already the carrier.** `EvaluationContext.Resource` / `RootResource` and
+  `GetEnvironmentVariable` resolve `%resource`/`%rootResource` as plain lookups
+  (`EvaluationContext.cs:122-127, 328-336`). `FhirEvaluationContext.ElementResolver` carries
+  `resolve()` (`FhirEvaluationContext.cs:35`).
+- **The seam is confirmed.** `FhirPathInvariantCheck.Validate` evaluates with no context
+  (`FhirPathInvariantCheck.cs:168`); `ValidationState` already threads immutable per-level context
+  (`ValidationState.cs`).
+- **Prior art — Firely.** `ScopedNode.ResourceContext` walks up `ParentResource` until it hits a
+  Bundle; `BundledResources()` / `ContainedResources()` build a `ReferencedResourceCache` of sibling
+  entries. We replicate the *behaviour* (root scope + reference index) without the *mechanism*
+  (per-node parent pointers). See [reference-implementations](reference-implementations.md).
+- **Prior art — HAPI / org.hl7.fhir validator.** Keeps slice assignment + cardinality + reporting
+  imperative for diagnostic granularity, and treats only the discriminator *predicate* as FHIRPath.
+  Confirms scope/resolution belongs in the traversal, not the node.
+- **Injection seam is pre-built.** `conformsTo`, `memberOf`, `validateVS` are registered FhirPath
+  functions that currently `throw NotSupportedException("...requires profile validation
+  infrastructure")` (`FhirSpecificFunctions.cs:397-431`) — the same deferred-delegate pattern as
+  `ElementResolver`. `SlicingMetadata` already captures discriminators
+  (`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs`).
+
+## Related Future Work (out of scope for this investigation)
+
+These build **on top of** Solutions 1 & 2 and are tracked separately:
+
+- **Slicing as a parent-altitude check + FHIRPath discriminators.** Slice *assignment* and
+  cardinality stay imperative at the element owning the sliced array (forward-only over
+  `Children()`); the per-element discriminator predicate is evaluated via the existing FhirPath
+  engine. `SlicingMetadata.Discriminators` already holds the discriminator paths. This is the
+  accurate reading of the "HAPI compiles checks to FHIRPath" idea — predicate-as-FHIRPath, not
+  whole-profile-as-FHIRPath.
+- **`conformsTo()` / `memberOf()` injection.** Implement the stubbed functions by injecting
+  delegates into `FhirEvaluationContext` (mirroring `ElementResolver`). `profile`/`type`
+  discriminators need `conformsTo` evaluated against the correctly-scoped `%resource` (depends on
+  Solution 1); reference discriminators need `resolve()` (depends on Solution 2). This is why 1 & 2
+  are the foundation.
+
+## Open Question
+
+Does ignixa ever evaluate FHIRPath / validate a node handed in **without** a controlled traversal
+establishing scope (e.g. a public `element.Select("%resource.id")` on a deep node, or
+`IElement.Validate()` on an arbitrary sub-element)? If **no** (current state — all evaluation flows
+through indexing or the validation walker), Solutions 1 & 2 are sufficient. If **yes**, that single
+entry point — and only that one — would justify a lazy `ScopedElement : IElement` built from the
+`Meta<JsonNode>()` parent chain. Defer until such an API actually exists.
+
+## Implementation Seam (the three edits)
+
+There is no descent refactor — `ValidationSchema.Validate` already runs against a single root
+`element`, and scope only changes where a resource *becomes* a validation root. That is exactly two
+sites today, plus the consumer:
+
+1. **Seed at the entry point.** `ValidateResourceHandler.cs:196` currently does
+   `var state = new ValidationState();` → change to `new ValidationState().EnterRootResource(element)`.
+   This alone fixes `%resource` for every root-level invariant (`dom-*`, `bdl-*`) — the headline gap.
+2. **Re-scope on contained recursion.** `ContainedResourceCheck.cs:102` currently does
+   `state.WithLocation(containedPath)` → add `.EnterContainedResource(containedElement)`.
+3. **Consume at the check.** `FhirPathInvariantCheck.cs:168` evaluates context-free → build a
+   `FhirEvaluationContext` from `state.Scope` (snippet above) and pass it to `Evaluate`.
+
+Solution 1 is edits 1 + 3 (and the `EnterContainedResource` half of 2). Solution 2 is filling the
+`Resolver` field that those `Enter*` methods already set — `BuildResolver` returns the
+`ReferenceIndex` closure instead of null — plus the reference-integrity check. Same machinery; 2 is
+an increment on 1, not a second mechanism.
+
+## Verdict
+
+**Recommended — adopt Solution 1 with the `Resolver` field in place from the start (Solution 2
+follows as an increment).** Solution 1 alone fixes `%resource`-referencing invariants; leaving the
+`Resolver` field present-but-null means `resolve()`-dependent invariants degrade gracefully (empty)
+until Solution 2 populates it — no API churn between the two.
+
+Sequencing:
+1. Add `ResourceScope` + `EnterRootResource` / `EnterContainedResource` to `ValidationState`.
+2. Seed at `ValidateResourceHandler` entry; re-scope in `ContainedResourceCheck`.
+3. Build `FhirEvaluationContext` from scope in `FhirPathInvariantCheck`. **← Solution 1 done; `dom-*`/`bdl-*` pass.**
+4. Implement `BuildResolver` → `ReferenceIndex` (lazy, cached on `Global.Cache`); add reference-integrity check. **← Solution 2 done.**
+
+Slicing (parent-altitude check + FHIRPath discriminators) and `conformsTo`/`memberOf` injection
+follow as separate investigations, built on this foundation.

--- a/docs/features/validation/readme.md
+++ b/docs/features/validation/readme.md
@@ -29,6 +29,8 @@ FHIR validation is critical for production servers but must balance correctness,
 | [depth-refactor](investigations/depth-refactor.md) | In Progress | Consolidate ValidationTier/Mode into single ValidationDepth enum |
 | [hapi-message-format](investigations/hapi-message-format.md) | Complete | HAPI FHIR OperationOutcome structure for ecosystem compatibility |
 | [primitive-value-validation-gap](investigations/primitive-value-validation-gap.md) | Viable | Non-choice primitives use loose TypeCheck instead of strict FhirPrimitiveValidator — empty strings and invalid calendar dates accepted. Found by fhir-faker edge-case mode |
+| [tree-context-scoping](investigations/tree-context-scoping.md) | Viable | Thread %resource/%rootResource through ValidationState and inject a scoped reference index as the resolve() delegate — unblocks dom-1/bdl-* invariants and Bundle/contained resolution without adding a Parent pointer to IElement. 3-edit seam, no descent refactor |
+| [slicing-discriminators](investigations/slicing-discriminators.md) | In Progress | Slicing as a parent-altitude check: imperative slice assignment + cardinality/reporting, FHIRPath engine for the discriminator predicate only (HAPI-style). Builds on tree-context-scoping (needs conformsTo via %resource, resolve()). Prereq gap: SlicingMetadata.Discriminators lacks a discriminator type field |
 
 ## Decision
 

--- a/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
+++ b/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
@@ -193,8 +193,7 @@ public class ValidateResourceHandler : IRequestHandler<ValidateResourceCommand, 
                         Depth = validationDepth,
                         TerminologyService = _terminologyService
                     };
-                    var state = new ValidationState().EnterRootResource(element);
-                    var validationResult = schema.Validate(element, settings, state);
+                    var validationResult = schema.Validate(element, settings);
 
                 if (!validationResult.IsValid)
                 {

--- a/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
+++ b/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
@@ -193,7 +193,7 @@ public class ValidateResourceHandler : IRequestHandler<ValidateResourceCommand, 
                         Depth = validationDepth,
                         TerminologyService = _terminologyService
                     };
-                    var state = new ValidationState();
+                    var state = new ValidationState().EnterRootResource(element);
                     var validationResult = schema.Validate(element, settings, state);
 
                 if (!validationResult.IsValid)

--- a/src/Core/Ignixa.Validation/Abstractions/ValidationSchema.cs
+++ b/src/Core/Ignixa.Validation/Abstractions/ValidationSchema.cs
@@ -148,6 +148,17 @@ public sealed class ValidationSchema
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState? state = null)
     {
         state ??= new ValidationState();
+
+        // Seed FHIRPath tree-context (%resource / %rootResource / resolve()) automatically for a
+        // resource root when the caller hasn't already. Nested resources are re-scoped explicitly
+        // (see ContainedResourceCheck -> EnterContainedResource) before their recursive Validate
+        // call, leaving Scope already seeded, so this fires only at the top-level entry. Centralizing
+        // it here means callers cannot forget to enable root-referencing invariants and resolve().
+        if (!state.Scope.IsSeeded && (element.Type?.Info.IsResource ?? false))
+        {
+            state = state.EnterRootResource(element);
+        }
+
         var results = new List<ValidationResult>();
 
         // Universal checks always run (all depths)

--- a/src/Core/Ignixa.Validation/Checks/BundleEntryCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/BundleEntryCheck.cs
@@ -1,0 +1,131 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Validates Bundle entry resources against their own StructureDefinition. Tier 2 (Spec).
+/// </summary>
+/// <remarks>
+/// In the Bundle StructureDefinition <c>entry.resource</c> is typed as the abstract
+/// <c>Resource</c>, so without this check entry resources receive only base-resource validation.
+/// This is the Bundle analogue of <see cref="ContainedResourceCheck"/>: each entry resource is
+/// resolved to its concrete schema and validated as an independent root
+/// (<see cref="ValidationState.EnterBundleEntry"/> sets <c>%resource</c>/<c>%rootResource</c> to the
+/// entry resource and keeps intra-bundle references resolvable). Entries without a resource
+/// (request/response-only entries in batch/transaction bundles) are skipped.
+/// </remarks>
+public sealed class BundleEntryCheck(IValidationSchemaResolver schemaResolver) : IValidationCheck
+{
+    private readonly IValidationSchemaResolver _schemaResolver = schemaResolver ?? throw new ArgumentNullException(nameof(schemaResolver));
+
+    /// <summary>
+    /// Validates all entry resources within a Bundle element.
+    /// </summary>
+    /// <param name="element">The Bundle element containing the "entry" array.</param>
+    /// <param name="settings">Validation settings.</param>
+    /// <param name="state">Current validation state.</param>
+    /// <returns>A validation result with issues from all entry resource validations.</returns>
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        if (element.InstanceType != "Bundle")
+        {
+            return ValidationResult.Success();
+        }
+
+        var entries = element.Children("entry");
+        if (entries.Count == 0)
+        {
+            return ValidationResult.Success();
+        }
+
+        var issues = new List<ValidationIssue>();
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            var resourceChildren = entries[i].Children("resource");
+            if (resourceChildren.Count == 0)
+            {
+                // Batch/transaction request/response entries carry no resource — nothing to validate.
+                continue;
+            }
+
+            var entryResource = resourceChildren[0];
+            var entryPath = $"entry[{i}].resource";
+            var resourceType = ResolveResourceType(entryResource);
+
+            if (string.IsNullOrEmpty(resourceType))
+            {
+                issues.Add(new ValidationIssue(
+                    IssueSeverity.Error,
+                    "bundle-entry-missing-resourcetype",
+                    $"{element.Location}.{entryPath}",
+                    "Bundle entry resource must have a 'resourceType' property"));
+                continue;
+            }
+
+            var entrySchema = _schemaResolver.GetSchema(resourceType);
+            if (entrySchema is null)
+            {
+                issues.Add(new ValidationIssue(
+                    IssueSeverity.Error,
+                    "bundle-entry-invalid-resourcetype",
+                    $"{element.Location}.{entryPath}",
+                    $"Unknown resource type '{resourceType}' in bundle entry"));
+                continue;
+            }
+
+            var entryState = state.WithLocation(entryPath).EnterBundleEntry(entryResource);
+            var entryResult = entrySchema.Validate(entryResource, settings, entryState);
+
+            if (!entryResult.IsValid)
+            {
+                var parentPrefix = $"{element.Location}.{entryPath}";
+                foreach (var issue in entryResult.Issues)
+                {
+                    issues.Add(issue with { Path = RebasePath(issue.Path, resourceType, parentPrefix) });
+                }
+            }
+        }
+
+        return issues.Count > 0
+            ? ValidationResult.Failure(issues)
+            : ValidationResult.Success();
+    }
+
+    private static string? ResolveResourceType(IElement entryResource)
+    {
+        var resourceType = entryResource.InstanceType;
+        if (!string.IsNullOrEmpty(resourceType) && resourceType != "Resource")
+        {
+            return resourceType;
+        }
+
+        var resourceTypeChild = entryResource.Children("resourceType");
+        return resourceTypeChild.Count == 0 ? resourceType : resourceTypeChild[0].Value?.ToString();
+    }
+
+    private static string RebasePath(string path, string resourceType, string parentPrefix)
+    {
+        // The nested validation returns paths relative to the entry resource (e.g. "Observation.status").
+        // Re-root them under the entry path so issues point into the Bundle.
+        if (path.StartsWith($"{resourceType}.", StringComparison.Ordinal))
+        {
+            return $"{parentPrefix}.{path[(resourceType.Length + 1)..]}";
+        }
+
+        if (path == resourceType)
+        {
+            return parentPrefix;
+        }
+
+        return path.StartsWith(parentPrefix, StringComparison.Ordinal)
+            ? path
+            : $"{parentPrefix}.{path}";
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/ContainedResourceCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ContainedResourceCheck.cs
@@ -98,8 +98,9 @@ public class ContainedResourceCheck(IValidationSchemaResolver schemaResolver) : 
                 continue;
             }
 
-            // Validate contained resource against its own schema
-            var containedState = state.WithLocation(containedPath);
+            // Validate contained resource against its own schema. Re-scope so %resource points at
+            // the contained resource and %rootResource at the containing parent (FHIR dom-* rule).
+            var containedState = state.WithLocation(containedPath).EnterContainedResource(containedElement);
             var containedResult = containedSchema.Validate(containedElement, settings, containedState);
 
             if (!containedResult.IsValid)

--- a/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
@@ -164,8 +164,12 @@ public class FhirPathInvariantCheck : IValidationCheck
 
         try
         {
-            // Evaluate the FHIRPath expression
-            var result = _evaluator.Value.Evaluate(element, expression);
+            // Evaluate the FHIRPath expression. When tree-context scope has been seeded
+            // (resource roots and contained recursion), supply %resource / %rootResource /
+            // resolve() so root-referencing invariants (dom-*, bdl-*) evaluate correctly.
+            // When scope is unseeded (some direct callers/tests), fall back to context-free
+            // evaluation, which defaults %resource to the constrained element as before.
+            var result = _evaluator.Value.Evaluate(element, expression, BuildEvaluationContext(state));
 
             // Convert result to boolean
             // Per FHIRPath spec: empty result = false, single boolean true = true, all else = false
@@ -209,6 +213,26 @@ public class FhirPathInvariantCheck : IValidationCheck
 
             return ValidationResult.Failure(issue);
         }
+    }
+
+    /// <summary>
+    /// Builds the FHIRPath evaluation context from the validation scope. Returns null when no
+    /// resource scope has been seeded, preserving context-free evaluation for direct callers.
+    /// </summary>
+    private static EvaluationContext? BuildEvaluationContext(ValidationState state)
+    {
+        var scope = state.Scope;
+        if (scope.Resource is null)
+        {
+            return null;
+        }
+
+        return new FhirEvaluationContext
+        {
+            Resource = scope.Resource,
+            RootResource = scope.RootResource,
+            ElementResolver = scope.Resolver
+        };
     }
 
     /// <summary>

--- a/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
@@ -168,7 +168,9 @@ public class FhirPathInvariantCheck : IValidationCheck
             // (resource roots and contained recursion), supply %resource / %rootResource /
             // resolve() so root-referencing invariants (dom-*, bdl-*) evaluate correctly.
             // When scope is unseeded (some direct callers/tests), fall back to context-free
-            // evaluation, which defaults %resource to the constrained element as before.
+            // evaluation: %resource / %rootResource are unbound (empty) and resolve() is
+            // unavailable. The constrained element is still the focus ($this), so element-relative
+            // invariants evaluate as before; only invariants referencing %resource are affected.
             var result = _evaluator.Value.Evaluate(element, expression, BuildEvaluationContext(state));
 
             // Convert result to boolean
@@ -222,7 +224,7 @@ public class FhirPathInvariantCheck : IValidationCheck
     private static EvaluationContext? BuildEvaluationContext(ValidationState state)
     {
         var scope = state.Scope;
-        if (scope.Resource is null)
+        if (!scope.IsSeeded)
         {
             return null;
         }

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -9,22 +9,52 @@ using Ignixa.Validation.Abstractions;
 namespace Ignixa.Validation.Checks;
 
 /// <summary>
-/// Reference-integrity check (Full tier). Flags clearly-local references that fail to resolve
-/// against the scoped resolver: fragment references (<c>#id</c>) and intra-Bundle relative
-/// references (<c>Type/id</c>) inside a Bundle root.
+/// Reference-integrity check (Full tier). Flags local references that fail to resolve against the
+/// scoped resolver, restricted to the cases where non-resolution is unambiguously an error:
+/// fragment references (<c>#id</c>) within their enclosing resource, and bundle-relative
+/// references (<c>Type/id</c>) inside <c>document</c>/<c>message</c> bundles.
 /// </summary>
 /// <remarks>
-/// Scoped narrowly to avoid false positives: absolute URLs (<c>http(s)://</c>), <c>urn:</c>
-/// references, and any reference is left alone when no resolver is configured. External and
-/// logical references legitimately do not resolve locally and are never flagged.
+/// <para>
+/// Deliberately conservative to avoid false positives. A <c>Type/id</c> reference is only required
+/// to resolve within the bundle for <c>document</c> and <c>message</c> bundles; <c>searchset</c>,
+/// <c>transaction</c>, <c>batch</c>, and <c>collection</c> bundles legitimately reference
+/// server-resident resources, so their unresolved <c>Type/id</c> references are never flagged.
+/// Absolute URLs (<c>http(s)://</c>), <c>urn:</c> references, and any reference are left alone when
+/// no resolver is configured.
+/// </para>
+/// <para>
+/// The walk does not descend across resource boundaries (contained resources, bundle entry
+/// resources). Each resource owns its own reference scope and is validated under its own seeded
+/// scope — contained resources via <see cref="ContainedResourceCheck"/> re-validation — so a
+/// reference inside a nested resource is checked exactly once, against the resolver that actually
+/// indexes its enclosing resource.
+/// </para>
 /// </remarks>
 public sealed class ReferenceResolutionCheck : IValidationCheck
 {
+    private readonly IReadOnlySet<string>? _validResourceTypes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferenceResolutionCheck"/> class.
+    /// </summary>
+    /// <param name="validResourceTypes">
+    /// Known FHIR resource type names used to classify <c>Type/id</c> bundle references. When
+    /// supplied, a reference is only treated as bundle-relative if its type token is a real resource
+    /// type, avoiding false positives on tokens like <c>MyCustomType/id</c>. When null, a syntactic
+    /// heuristic (capitalized alphabetic token) is used instead.
+    /// </param>
+    public ReferenceResolutionCheck(IReadOnlySet<string>? validResourceTypes = null)
+    {
+        _validResourceTypes = validResourceTypes;
+    }
+
     /// <summary>
     /// Validates that local references within the resource resolve against the scoped resolver.
     /// </summary>
     /// <param name="element">The resource root element to validate.</param>
-    /// <param name="settings">Validation settings.</param>
+    /// <param name="settings">Validation settings. Unused: gating to the Full tier is handled by
+    /// profile-check registration, not by depth inspection here.</param>
     /// <param name="state">Current validation state carrying the scoped resolver.</param>
     /// <returns>A validation result with an issue per unresolved local reference.</returns>
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
@@ -35,73 +65,105 @@ public sealed class ReferenceResolutionCheck : IValidationCheck
             return ValidationResult.Success();
         }
 
-        var rootIsBundle = state.Scope.RootResource?.InstanceType == "Bundle"
-            || state.Scope.Resource?.InstanceType == "Bundle";
+        var checkBundleRelative = RequiresInternalBundleResolution(state.Scope.Resource);
 
         var issues = new List<ValidationIssue>();
-        CollectUnresolved(element, resolver, rootIsBundle, issues);
+        CollectUnresolved(element, resolver, checkBundleRelative, atRootScope: true, issues);
 
         return issues.Count > 0
             ? ValidationResult.Failure(issues)
             : ValidationResult.Success();
     }
 
-    private static void CollectUnresolved(
+    private static bool RequiresInternalBundleResolution(IElement? root)
+    {
+        if (root?.InstanceType != "Bundle")
+        {
+            return false;
+        }
+
+        var typeChildren = root.Children("type");
+        var type = typeChildren.Count == 0 ? null : typeChildren[0].Value?.ToString();
+        return type is "document" or "message";
+    }
+
+    private void CollectUnresolved(
         IElement element,
         Func<string, IElement?> resolver,
-        bool rootIsBundle,
+        bool checkBundleRelative,
+        bool atRootScope,
         List<ValidationIssue> issues)
     {
         foreach (var child in element.Children())
         {
-            if (child.Name == "reference" && child.Value is string reference && IsLocalReference(reference, rootIsBundle))
+            if (child.Name == "reference" && child.Value is string reference
+                && ShouldCheck(reference, checkBundleRelative, atRootScope)
+                && resolver(reference) is null)
             {
-                if (resolver(reference) is null)
-                {
-                    issues.Add(ValidationIssue.InvariantFailure(
-                        "ref-resolve",
-                        $"Local reference '{reference}' does not resolve within the resource",
-                        child.Location));
-                }
+                issues.Add(ValidationIssue.InvariantFailure(
+                    "ref-resolve",
+                    $"Local reference '{reference}' does not resolve within the resource",
+                    child.Location));
             }
 
-            CollectUnresolved(child, resolver, rootIsBundle, issues);
+            // A nested resource (contained, bundle entry resource) starts its own reference scope;
+            // its fragment references resolve against its own contained set, not this resolver.
+            var childAtRootScope = atRootScope && !IsNestedResource(child);
+            CollectUnresolved(child, resolver, checkBundleRelative, childAtRootScope, issues);
         }
     }
 
-    private static bool IsLocalReference(string reference, bool rootIsBundle)
+    private bool ShouldCheck(string reference, bool checkBundleRelative, bool atRootScope)
+    {
+        return Classify(reference, checkBundleRelative) switch
+        {
+            // Fragments resolve within their enclosing resource — only verifiable while the walk is
+            // still within the root resource's own scope (the seeded resolver indexes its contained).
+            ReferenceKind.Fragment => atRootScope,
+            ReferenceKind.BundleRelative => true,
+            _ => false
+        };
+    }
+
+    private ReferenceKind Classify(string reference, bool checkBundleRelative)
     {
         if (string.IsNullOrEmpty(reference))
         {
-            return false;
+            return ReferenceKind.None;
         }
 
         if (reference.StartsWith('#'))
         {
-            return reference.Length > 1;
+            return reference.Length > 1 ? ReferenceKind.Fragment : ReferenceKind.None;
         }
 
-        if (!rootIsBundle)
+        if (!checkBundleRelative)
         {
-            return false;
+            return ReferenceKind.None;
         }
 
         if (reference.Contains("://", StringComparison.Ordinal)
             || reference.StartsWith("urn:", StringComparison.OrdinalIgnoreCase))
         {
-            return false;
+            return ReferenceKind.None;
         }
 
         var slash = reference.IndexOf('/', StringComparison.Ordinal);
         if (slash <= 0 || slash == reference.Length - 1)
         {
-            return false;
+            return ReferenceKind.None;
         }
 
-        return IsResourceTypeToken(reference.AsSpan(0, slash));
+        return IsResourceTypeToken(reference.AsSpan(0, slash))
+            ? ReferenceKind.BundleRelative
+            : ReferenceKind.None;
     }
 
-    private static bool IsResourceTypeToken(ReadOnlySpan<char> token)
+    private static bool IsNestedResource(IElement element)
+        => (element.Type?.Info.IsResource ?? false)
+            || element.Name is "contained" or "resource";
+
+    private bool IsResourceTypeToken(ReadOnlySpan<char> token)
     {
         if (token.Length == 0 || !char.IsUpper(token[0]))
         {
@@ -116,6 +178,15 @@ public sealed class ReferenceResolutionCheck : IValidationCheck
             }
         }
 
-        return true;
+        // Prefer the real resource-type registry when available; fall back to the syntactic shape
+        // (capitalized alphabetic token) for direct callers that don't supply one.
+        return _validResourceTypes is not { Count: > 0 } || _validResourceTypes.Contains(token.ToString());
+    }
+
+    private enum ReferenceKind
+    {
+        None,
+        Fragment,
+        BundleRelative
     }
 }

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -1,0 +1,121 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Reference-integrity check (Full tier). Flags clearly-local references that fail to resolve
+/// against the scoped resolver: fragment references (<c>#id</c>) and intra-Bundle relative
+/// references (<c>Type/id</c>) inside a Bundle root.
+/// </summary>
+/// <remarks>
+/// Scoped narrowly to avoid false positives: absolute URLs (<c>http(s)://</c>), <c>urn:</c>
+/// references, and any reference is left alone when no resolver is configured. External and
+/// logical references legitimately do not resolve locally and are never flagged.
+/// </remarks>
+public sealed class ReferenceResolutionCheck : IValidationCheck
+{
+    /// <summary>
+    /// Validates that local references within the resource resolve against the scoped resolver.
+    /// </summary>
+    /// <param name="element">The resource root element to validate.</param>
+    /// <param name="settings">Validation settings.</param>
+    /// <param name="state">Current validation state carrying the scoped resolver.</param>
+    /// <returns>A validation result with an issue per unresolved local reference.</returns>
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        var resolver = state.Scope.Resolver;
+        if (resolver is null)
+        {
+            return ValidationResult.Success();
+        }
+
+        var rootIsBundle = state.Scope.RootResource?.InstanceType == "Bundle"
+            || state.Scope.Resource?.InstanceType == "Bundle";
+
+        var issues = new List<ValidationIssue>();
+        CollectUnresolved(element, resolver, rootIsBundle, issues);
+
+        return issues.Count > 0
+            ? ValidationResult.Failure(issues)
+            : ValidationResult.Success();
+    }
+
+    private static void CollectUnresolved(
+        IElement element,
+        Func<string, IElement?> resolver,
+        bool rootIsBundle,
+        List<ValidationIssue> issues)
+    {
+        foreach (var child in element.Children())
+        {
+            if (child.Name == "reference" && child.Value is string reference && IsLocalReference(reference, rootIsBundle))
+            {
+                if (resolver(reference) is null)
+                {
+                    issues.Add(ValidationIssue.InvariantFailure(
+                        "ref-resolve",
+                        $"Local reference '{reference}' does not resolve within the resource",
+                        child.Location));
+                }
+            }
+
+            CollectUnresolved(child, resolver, rootIsBundle, issues);
+        }
+    }
+
+    private static bool IsLocalReference(string reference, bool rootIsBundle)
+    {
+        if (string.IsNullOrEmpty(reference))
+        {
+            return false;
+        }
+
+        if (reference.StartsWith('#'))
+        {
+            return reference.Length > 1;
+        }
+
+        if (!rootIsBundle)
+        {
+            return false;
+        }
+
+        if (reference.Contains("://", StringComparison.Ordinal)
+            || reference.StartsWith("urn:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var slash = reference.IndexOf('/', StringComparison.Ordinal);
+        if (slash <= 0 || slash == reference.Length - 1)
+        {
+            return false;
+        }
+
+        return IsResourceTypeToken(reference.AsSpan(0, slash));
+    }
+
+    private static bool IsResourceTypeToken(ReadOnlySpan<char> token)
+    {
+        if (token.Length == 0 || !char.IsUpper(token[0]))
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            if (!char.IsLetter(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Core/Ignixa.Validation/ReferenceIndex.cs
+++ b/src/Core/Ignixa.Validation/ReferenceIndex.cs
@@ -78,6 +78,9 @@ public sealed class ReferenceIndex
             var id = FirstChildValue(contained, "id");
             if (!string.IsNullOrEmpty(id))
             {
+                // First-wins on duplicate ids: a deliberate, deterministic resolution policy.
+                // Duplicate contained ids are themselves invalid and are surfaced by validation
+                // checks, not by this resolver. Do not change to an overwrite.
                 byContainedId.TryAdd(id, contained);
             }
         }
@@ -95,6 +98,8 @@ public sealed class ReferenceIndex
 
             var resource = resourceChildren[0];
 
+            // First-wins on duplicate keys (deliberate, deterministic). Duplicate fullUrls/keys are
+            // a bundle integrity problem reported by validation (e.g. bdl-7), not silently repaired here.
             var fullUrl = FirstChildValue(entry, "fullUrl");
             if (!string.IsNullOrEmpty(fullUrl))
             {

--- a/src/Core/Ignixa.Validation/ReferenceIndex.cs
+++ b/src/Core/Ignixa.Validation/ReferenceIndex.cs
@@ -1,0 +1,132 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+
+namespace Ignixa.Validation;
+
+/// <summary>
+/// Scoped reference index that resolves FHIRPath <c>resolve()</c> targets within a single
+/// resource root. Indexes contained resources (by <c>#id</c>) and, when the root is a Bundle,
+/// sibling entry resources (by <c>fullUrl</c>, <c>Type/id</c>, and <c>Type/id/_history/versionId</c>).
+/// </summary>
+/// <remarks>
+/// Built once per resource root (O(entries)); the closure injected as the FHIRPath element
+/// resolver chains a contained-of-current scope to its parent scope. Mirrors the
+/// contained + bundle resolution algorithm of Firely's <c>ScopedNode.BundledResources()</c> /
+/// <c>ContainedResources()</c> without per-node parent pointers.
+/// </remarks>
+public sealed class ReferenceIndex
+{
+    private readonly Dictionary<string, IElement> _byContainedId;
+    private readonly Dictionary<string, IElement> _byBundleKey;
+
+    private ReferenceIndex(
+        Dictionary<string, IElement> byContainedId,
+        Dictionary<string, IElement> byBundleKey)
+    {
+        _byContainedId = byContainedId;
+        _byBundleKey = byBundleKey;
+    }
+
+    /// <summary>
+    /// Builds a reference index from a resource element, indexing its contained resources and,
+    /// for a Bundle root, its entry resources.
+    /// </summary>
+    /// <param name="root">The resource element to index. Must not be null.</param>
+    /// <returns>An index that resolves contained and intra-Bundle references for this root.</returns>
+    public static ReferenceIndex Build(IElement root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        var byContainedId = new Dictionary<string, IElement>(StringComparer.Ordinal);
+        var byBundleKey = new Dictionary<string, IElement>(StringComparer.Ordinal);
+
+        IndexContained(root, byContainedId);
+
+        if (root.InstanceType == "Bundle")
+        {
+            IndexBundleEntries(root, byBundleKey);
+        }
+
+        return new ReferenceIndex(byContainedId, byBundleKey);
+    }
+
+    /// <summary>
+    /// Resolves a reference to its target element within this index.
+    /// </summary>
+    /// <param name="reference">A fragment reference (<c>#id</c>) or a Bundle key (<c>fullUrl</c> / <c>Type/id</c>).</param>
+    /// <returns>The matching element, or null when the reference is not present in this index.</returns>
+    public IElement? Resolve(string reference)
+    {
+        if (string.IsNullOrEmpty(reference))
+        {
+            return null;
+        }
+
+        return reference.StartsWith('#')
+            ? _byContainedId.GetValueOrDefault(reference[1..])
+            : _byBundleKey.GetValueOrDefault(reference);
+    }
+
+    private static void IndexContained(IElement root, Dictionary<string, IElement> byContainedId)
+    {
+        foreach (var contained in root.Children("contained"))
+        {
+            var id = FirstChildValue(contained, "id");
+            if (!string.IsNullOrEmpty(id))
+            {
+                byContainedId.TryAdd(id, contained);
+            }
+        }
+    }
+
+    private static void IndexBundleEntries(IElement bundle, Dictionary<string, IElement> byBundleKey)
+    {
+        foreach (var entry in bundle.Children("entry"))
+        {
+            var resourceChildren = entry.Children("resource");
+            if (resourceChildren.Count == 0)
+            {
+                continue;
+            }
+
+            var resource = resourceChildren[0];
+
+            var fullUrl = FirstChildValue(entry, "fullUrl");
+            if (!string.IsNullOrEmpty(fullUrl))
+            {
+                byBundleKey.TryAdd(fullUrl, resource);
+            }
+
+            var id = FirstChildValue(resource, "id");
+            if (string.IsNullOrEmpty(id))
+            {
+                continue;
+            }
+
+            var type = resource.InstanceType;
+            byBundleKey.TryAdd($"{type}/{id}", resource);
+
+            var versionId = MetaVersionId(resource);
+            if (!string.IsNullOrEmpty(versionId))
+            {
+                byBundleKey.TryAdd($"{type}/{id}/_history/{versionId}", resource);
+            }
+        }
+    }
+
+    private static string? FirstChildValue(IElement element, string childName)
+    {
+        var children = element.Children(childName);
+        return children.Count == 0 ? null : children[0].Value?.ToString();
+    }
+
+    private static string? MetaVersionId(IElement resource)
+    {
+        var meta = resource.Children("meta");
+        return meta.Count == 0 ? null : FirstChildValue(meta[0], "versionId");
+    }
+}

--- a/src/Core/Ignixa.Validation/ResourceScope.cs
+++ b/src/Core/Ignixa.Validation/ResourceScope.cs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+
+namespace Ignixa.Validation;
+
+/// <summary>
+/// FHIRPath tree-context scope threaded through validation. Carries the resource-rooted
+/// variables (<c>%resource</c>, <c>%rootResource</c>) and the <c>resolve()</c> delegate so a
+/// constraint evaluated deep inside a resource sees the correct enclosing resource and can
+/// resolve sibling references — without the runtime element model exposing a parent pointer.
+/// </summary>
+/// <remarks>
+/// Immutable. Forked at resource boundaries via <see cref="ValidationState.EnterRootResource"/>
+/// and <see cref="ValidationState.EnterContainedResource"/>. Never re-pointed per element:
+/// <c>%resource</c> must remain the enclosing resource, not the constrained sub-element.
+/// </remarks>
+public record ResourceScope
+{
+    /// <summary>
+    /// Gets the nearest containing resource (the FHIRPath <c>%resource</c> variable).
+    /// </summary>
+    public IElement? Resource { get; init; }
+
+    /// <summary>
+    /// Gets the container/parent resource (the FHIRPath <c>%rootResource</c> variable).
+    /// Equals <see cref="Resource"/> for a standalone resource or an independent Bundle entry;
+    /// points at the containing resource for a contained resource.
+    /// </summary>
+    public IElement? RootResource { get; init; }
+
+    /// <summary>
+    /// Gets the reference resolver backing the FHIRPath <c>resolve()</c> function. Returns the
+    /// target <see cref="IElement"/> for a reference, or null when it does not resolve.
+    /// </summary>
+    public Func<string, IElement?>? Resolver { get; init; }
+}

--- a/src/Core/Ignixa.Validation/ResourceScope.cs
+++ b/src/Core/Ignixa.Validation/ResourceScope.cs
@@ -14,27 +14,65 @@ namespace Ignixa.Validation;
 /// resolve sibling references — without the runtime element model exposing a parent pointer.
 /// </summary>
 /// <remarks>
-/// Immutable. Forked at resource boundaries via <see cref="ValidationState.EnterRootResource"/>
-/// and <see cref="ValidationState.EnterContainedResource"/>. Never re-pointed per element:
+/// Immutable, and constructed only through the factories so the three fields move together: a
+/// scope is either fully seeded (all three set, <see cref="IsSeeded"/> true) or the
+/// <see cref="Unseeded"/> sentinel (all null). This makes a partially-seeded scope
+/// unrepresentable, so every consumer agrees on whether tree-context is active.
+/// Forked at resource boundaries via <see cref="ValidationState.EnterRootResource"/> and
+/// <see cref="ValidationState.EnterContainedResource"/>. Never re-pointed per element:
 /// <c>%resource</c> must remain the enclosing resource, not the constrained sub-element.
 /// </remarks>
-public record ResourceScope
+public sealed record ResourceScope
 {
+    /// <summary>
+    /// The unseeded scope: no resource context. Direct callers/tests that validate without seeding
+    /// run context-free (<c>%resource</c>/<c>%rootResource</c> unbound, <c>resolve()</c> unavailable).
+    /// </summary>
+    public static readonly ResourceScope Unseeded = new(null, null, null);
+
+    private ResourceScope(IElement? resource, IElement? rootResource, Func<string, IElement?>? resolver)
+    {
+        Resource = resource;
+        RootResource = rootResource;
+        Resolver = resolver;
+    }
+
     /// <summary>
     /// Gets the nearest containing resource (the FHIRPath <c>%resource</c> variable).
     /// </summary>
-    public IElement? Resource { get; init; }
+    public IElement? Resource { get; }
 
     /// <summary>
     /// Gets the container/parent resource (the FHIRPath <c>%rootResource</c> variable).
-    /// Equals <see cref="Resource"/> for a standalone resource or an independent Bundle entry;
-    /// points at the containing resource for a contained resource.
+    /// Equals <see cref="Resource"/> for a standalone resource; points at the containing resource
+    /// for a contained resource.
     /// </summary>
-    public IElement? RootResource { get; init; }
+    public IElement? RootResource { get; }
 
     /// <summary>
     /// Gets the reference resolver backing the FHIRPath <c>resolve()</c> function. Returns the
     /// target <see cref="IElement"/> for a reference, or null when it does not resolve.
     /// </summary>
-    public Func<string, IElement?>? Resolver { get; init; }
+    public Func<string, IElement?>? Resolver { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether resource context has been seeded. The single source of truth
+    /// for "is tree-context active?" — keying off any one field is equivalent because the factories
+    /// seed all three atomically.
+    /// </summary>
+    public bool IsSeeded => Resource is not null;
+
+    /// <summary>
+    /// Creates a scope for a resource that is its own validation root: <c>%resource</c> and
+    /// <c>%rootResource</c> both point at the resource itself.
+    /// </summary>
+    internal static ResourceScope Root(IElement resource, Func<string, IElement?> resolver)
+        => new(resource, resource, resolver);
+
+    /// <summary>
+    /// Creates a scope for a contained resource C inside parent resource P: <c>%resource</c> is C
+    /// and <c>%rootResource</c> is P (or null when C is entered without a seeded root).
+    /// </summary>
+    internal static ResourceScope Contained(IElement contained, IElement? rootResource, Func<string, IElement?> resolver)
+        => new(contained, rootResource, resolver);
 }

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -307,12 +307,13 @@ public class StructureDefinitionSchemaBuilder
         var invariantChecks = ExtractInvariantChecks(elements, typeDefinition, schema, _parser, _logger);
         profileChecks.AddRange(invariantChecks);
 
-        // Reference-integrity (Full tier): flag local references (#id, intra-Bundle Type/id) that
-        // fail to resolve against the scoped resolver. No-ops when no resolver is seeded, so it is
-        // inert outside the scoped validation pipeline.
+        // Reference-integrity (Full tier): flag unresolved local references — fragments (#id) and,
+        // for document/message bundles, relative Type/id references. The scoped resolver is seeded
+        // automatically by ValidationSchema.Validate for resource roots; the check no-ops only when
+        // validating a non-resource element with no seeded scope.
         if (typeDefinition.Info.IsResource)
         {
-            profileChecks.Add(new ReferenceResolutionCheck());
+            profileChecks.Add(new ReferenceResolutionCheck(validResourceTypes));
         }
 
         // Build the canonical URL from the type name

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -307,6 +307,14 @@ public class StructureDefinitionSchemaBuilder
         var invariantChecks = ExtractInvariantChecks(elements, typeDefinition, schema, _parser, _logger);
         profileChecks.AddRange(invariantChecks);
 
+        // Reference-integrity (Full tier): flag local references (#id, intra-Bundle Type/id) that
+        // fail to resolve against the scoped resolver. No-ops when no resolver is seeded, so it is
+        // inert outside the scoped validation pipeline.
+        if (typeDefinition.Info.IsResource)
+        {
+            profileChecks.Add(new ReferenceResolutionCheck());
+        }
+
         // Build the canonical URL from the type name
         var canonicalUrl = $"http://hl7.org/fhir/StructureDefinition/{typeDefinition.Info.Name}";
 

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -295,6 +295,13 @@ public class StructureDefinitionSchemaBuilder
         if (typeDefinition.Info.IsResource && validationSchemaResolver is not null)
         {
             specChecks.Add(new ContainedResourceCheck(validationSchemaResolver));
+
+            // Bundle entry resources are typed as the abstract Resource in the Bundle definition;
+            // validate each against its concrete schema as an independent root.
+            if (typeDefinition.Info.Name == "Bundle")
+            {
+                specChecks.Add(new BundleEntryCheck(validationSchemaResolver));
+            }
         }
 
         // Tier 3 (Profile): Advanced checks - FHIRPath invariants, slicing, advanced terminology

--- a/src/Core/Ignixa.Validation/ValidationState.cs
+++ b/src/Core/Ignixa.Validation/ValidationState.cs
@@ -94,10 +94,9 @@ public record ValidationState
     /// resolver is built rooted at this resource.
     /// </summary>
     /// <remarks>
-    /// Bundle entry resources are independent roots in the FHIRPath sense, but the validation
-    /// pipeline does not currently re-root them: a resource sitting in a Bundle entry is validated
-    /// with %resource still pointing at the enclosing Bundle. Wiring per-entry re-rooting (the
-    /// Bundle analogue of <see cref="EnterContainedResource"/>) is a separate enhancement.
+    /// Bundle entry resources are independent roots and are re-rooted during validation via
+    /// <see cref="EnterBundleEntry"/> (the Bundle analogue of <see cref="EnterContainedResource"/>),
+    /// driven by <c>BundleEntryCheck</c>.
     /// </remarks>
     /// <param name="resource">The resource element becoming the validation root.</param>
     /// <returns>A new validation state scoped to this resource.</returns>
@@ -131,6 +130,29 @@ public record ValidationState
                 contained,
                 parentScope.Resource,
                 reference => index.Resolve(reference) ?? parentResolver?.Invoke(reference))
+        };
+    }
+
+    /// <summary>
+    /// Enters a Bundle entry resource E. Unlike a contained resource, a bundle entry is an
+    /// independent root: both %resource and %rootResource become E (the enclosing Bundle is not E's
+    /// %rootResource). The resolver chains E's own contained set to the bundle scope's resolver so
+    /// intra-bundle sibling references (fullUrl, Type/id) remain resolvable from within the entry.
+    /// </summary>
+    /// <param name="entryResource">The Bundle entry resource element being entered.</param>
+    /// <returns>A new validation state scoped to the entry resource.</returns>
+    public ValidationState EnterBundleEntry(IElement entryResource)
+    {
+        ArgumentNullException.ThrowIfNull(entryResource);
+
+        var bundleResolver = Scope.Resolver;
+        var index = ReferenceIndex.Build(entryResource);
+
+        return this with
+        {
+            Scope = ResourceScope.Root(
+                entryResource,
+                reference => index.Resolve(reference) ?? bundleResolver?.Invoke(reference))
         };
     }
 

--- a/src/Core/Ignixa.Validation/ValidationState.cs
+++ b/src/Core/Ignixa.Validation/ValidationState.cs
@@ -3,6 +3,8 @@
 //     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // </copyright>
 
+using Ignixa.Abstractions;
+
 namespace Ignixa.Validation;
 
 /// <summary>
@@ -44,6 +46,13 @@ public record ValidationState
     public LocationState Location { get; init; }
 
     /// <summary>
+    /// Gets the FHIRPath tree-context scope (%resource, %rootResource, resolve()) for the
+    /// resource currently being validated. Seeded at resource boundaries via
+    /// <see cref="EnterRootResource"/> / <see cref="EnterContainedResource"/>.
+    /// </summary>
+    public ResourceScope Scope { get; init; } = new();
+
+    /// <summary>
     /// Creates a new state with updated instance information.
     /// </summary>
     /// <param name="resourceType">The resource type being validated (e.g., "Patient").</param>
@@ -75,6 +84,57 @@ public record ValidationState
             {
                 InstancePath = instancePath,
                 DefinitionPath = definitionPath
+            }
+        };
+    }
+
+    /// <summary>
+    /// Enters a resource that becomes a validation root: a standalone resource or an independent
+    /// Bundle entry. Both %resource and %rootResource point at the resource itself (a Bundle entry's
+    /// resource is not "contained" in the Bundle in the FHIRPath sense). Builds a fresh resolver
+    /// rooted at this resource.
+    /// </summary>
+    /// <param name="resource">The resource element becoming the validation root.</param>
+    /// <returns>A new validation state scoped to this resource.</returns>
+    public ValidationState EnterRootResource(IElement resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var index = ReferenceIndex.Build(resource);
+        return this with
+        {
+            Scope = new ResourceScope
+            {
+                Resource = resource,
+                RootResource = resource,
+                Resolver = index.Resolve
+            }
+        };
+    }
+
+    /// <summary>
+    /// Enters a contained resource C inside the current parent resource P: %resource becomes C and
+    /// %rootResource becomes P (the containing resource). The resolver chains C's own contained set
+    /// to the parent scope's resolver, matching FHIR resolution order (contained-of-current then
+    /// bundle/contained-of-root).
+    /// </summary>
+    /// <param name="contained">The contained resource element being entered.</param>
+    /// <returns>A new validation state scoped to the contained resource.</returns>
+    public ValidationState EnterContainedResource(IElement contained)
+    {
+        ArgumentNullException.ThrowIfNull(contained);
+
+        var parentScope = Scope;
+        var index = ReferenceIndex.Build(contained);
+        var parentResolver = parentScope.Resolver;
+
+        return this with
+        {
+            Scope = parentScope with
+            {
+                Resource = contained,
+                RootResource = parentScope.Resource,
+                Resolver = reference => index.Resolve(reference) ?? parentResolver?.Invoke(reference)
             }
         };
     }

--- a/src/Core/Ignixa.Validation/ValidationState.cs
+++ b/src/Core/Ignixa.Validation/ValidationState.cs
@@ -50,7 +50,7 @@ public record ValidationState
     /// resource currently being validated. Seeded at resource boundaries via
     /// <see cref="EnterRootResource"/> / <see cref="EnterContainedResource"/>.
     /// </summary>
-    public ResourceScope Scope { get; init; } = new();
+    public ResourceScope Scope { get; init; } = ResourceScope.Unseeded;
 
     /// <summary>
     /// Creates a new state with updated instance information.
@@ -89,11 +89,16 @@ public record ValidationState
     }
 
     /// <summary>
-    /// Enters a resource that becomes a validation root: a standalone resource or an independent
-    /// Bundle entry. Both %resource and %rootResource point at the resource itself (a Bundle entry's
-    /// resource is not "contained" in the Bundle in the FHIRPath sense). Builds a fresh resolver
-    /// rooted at this resource.
+    /// Enters a resource that becomes a validation root (the top-level resource passed to
+    /// validation). Both %resource and %rootResource point at the resource itself, and a fresh
+    /// resolver is built rooted at this resource.
     /// </summary>
+    /// <remarks>
+    /// Bundle entry resources are independent roots in the FHIRPath sense, but the validation
+    /// pipeline does not currently re-root them: a resource sitting in a Bundle entry is validated
+    /// with %resource still pointing at the enclosing Bundle. Wiring per-entry re-rooting (the
+    /// Bundle analogue of <see cref="EnterContainedResource"/>) is a separate enhancement.
+    /// </remarks>
     /// <param name="resource">The resource element becoming the validation root.</param>
     /// <returns>A new validation state scoped to this resource.</returns>
     public ValidationState EnterRootResource(IElement resource)
@@ -101,15 +106,7 @@ public record ValidationState
         ArgumentNullException.ThrowIfNull(resource);
 
         var index = ReferenceIndex.Build(resource);
-        return this with
-        {
-            Scope = new ResourceScope
-            {
-                Resource = resource,
-                RootResource = resource,
-                Resolver = index.Resolve
-            }
-        };
+        return this with { Scope = ResourceScope.Root(resource, index.Resolve) };
     }
 
     /// <summary>
@@ -130,12 +127,10 @@ public record ValidationState
 
         return this with
         {
-            Scope = parentScope with
-            {
-                Resource = contained,
-                RootResource = parentScope.Resource,
-                Resolver = reference => index.Resolve(reference) ?? parentResolver?.Invoke(reference)
-            }
+            Scope = ResourceScope.Contained(
+                contained,
+                parentScope.Resource,
+                reference => index.Resolve(reference) ?? parentResolver?.Invoke(reference))
         };
     }
 

--- a/test/Ignixa.Validation.Tests/ReferenceIndexTests.cs
+++ b/test/Ignixa.Validation.Tests/ReferenceIndexTests.cs
@@ -1,0 +1,128 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ReferenceIndex"/> contained, bundle, and miss resolution.
+/// </summary>
+public class ReferenceIndexTests
+{
+    private static IElement ToElement(string json)
+    {
+        var node = JsonNode.Parse(json);
+        return JsonNodeSourceNode.Create(node!).ToElement(TestSchemaProvider.GetR4Schema());
+    }
+
+    [Fact]
+    public void GivenContainedResource_WhenResolvingFragment_ThenReturnsContained()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [
+                { ""resourceType"": ""Practitioner"", ""id"": ""p1"" }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var resolved = index.Resolve("#p1");
+
+        // Assert
+        resolved.ShouldNotBeNull();
+        resolved!.InstanceType.ShouldBe("Practitioner");
+    }
+
+    [Fact]
+    public void GivenBundle_WhenResolvingByTypeAndId_ThenReturnsEntryResource()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var byTypeId = index.Resolve("Patient/1");
+        var byFullUrl = index.Resolve("http://example.org/fhir/Patient/1");
+
+        // Assert
+        byTypeId.ShouldNotBeNull();
+        byTypeId!.InstanceType.ShouldBe("Patient");
+        byFullUrl.ShouldNotBeNull();
+        byFullUrl!.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenBundleEntryWithVersionId_WhenResolvingVersionedReference_ThenReturnsEntryResource()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Patient"",
+                        ""id"": ""1"",
+                        ""meta"": { ""versionId"": ""3"" }
+                    }
+                }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var resolved = index.Resolve("Patient/1/_history/3");
+
+        // Assert
+        resolved.ShouldNotBeNull();
+        resolved!.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenUnknownReference_WhenResolving_ThenReturnsNull()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [ { ""resourceType"": ""Practitioner"", ""id"": ""p1"" } ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act & Assert
+        index.Resolve("#missing").ShouldBeNull();
+        index.Resolve("Patient/999").ShouldBeNull();
+        index.Resolve(string.Empty).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNonBundleRoot_WhenResolvingRelativeReference_ThenReturnsNull()
+    {
+        // Arrange
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act & Assert
+        index.Resolve("Patient/1").ShouldBeNull();
+    }
+}

--- a/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
+++ b/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
@@ -11,6 +11,7 @@ using Ignixa.Specification;
 using Ignixa.Specification.Generated;
 using Ignixa.Validation.Abstractions;
 using Ignixa.Validation.Checks;
+using Ignixa.Validation.Schema;
 using Ignixa.Validation.Tests.TestHelpers;
 using Shouldly;
 using Xunit;
@@ -25,6 +26,8 @@ public class TreeContextScopingTests
 {
     private readonly ISchema _schema = new R4CoreSchemaProvider();
     private readonly FhirPathParser _parser = new();
+    private readonly IValidationSchemaResolver _schemaResolver =
+        new CachedValidationSchemaResolver(new StructureDefinitionSchemaResolver(new R4CoreSchemaProvider()));
 
     private static IElement ToElement(string json)
     {
@@ -240,12 +243,13 @@ public class TreeContextScopingTests
     }
 
     [Fact]
-    public void GivenBundleWithDanglingLocalReference_WhenReferenceResolutionCheck_ThenReportsIssue()
+    public void GivenDocumentBundleWithDanglingRelativeReference_WhenReferenceResolutionCheck_ThenReportsIssue()
     {
-        // Arrange
+        // Arrange — a document bundle requires intra-bundle reference integrity, so a Type/id
+        // reference that points outside the bundle is genuinely unresolved.
         var element = ToElement(@"{
             ""resourceType"": ""Bundle"",
-            ""type"": ""collection"",
+            ""type"": ""document"",
             ""entry"": [
                 {
                     ""fullUrl"": ""http://example.org/fhir/Observation/2"",
@@ -269,6 +273,161 @@ public class TreeContextScopingTests
         // Assert
         result.IsValid.ShouldBeFalse();
         result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Theory]
+    [InlineData("searchset")]
+    [InlineData("transaction")]
+    [InlineData("collection")]
+    public void GivenNonDocumentBundleWithUnresolvedRelativeReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue(string bundleType)
+    {
+        // Arrange — searchset/transaction/collection bundles legitimately reference server-resident
+        // resources not present in the bundle. A Type/id reference that is absent must NOT be flagged.
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": """ + bundleType + @""",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/999"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenDocumentBundleWithResolvableRelativeReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — the referenced Patient/1 is present as a bundle entry, so it resolves.
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""document"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                },
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenDocumentBundleEntryWithOwnFragmentReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — a #fragment reference inside an entry resource resolves against THAT entry's own
+        // contained set, which the bundle-root resolver does not index. The root check must not flag
+        // it (it is checked under the entry's own scope, not here).
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""document"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/MedicationRequest/2"",
+                    ""resource"": {
+                        ""resourceType"": ""MedicationRequest"",
+                        ""id"": ""2"",
+                        ""status"": ""active"",
+                        ""intent"": ""order"",
+                        ""subject"": { ""reference"": ""Patient/1"" },
+                        ""contained"": [ { ""resourceType"": ""Medication"", ""id"": ""med1"" } ],
+                        ""medicationReference"": { ""reference"": ""#med1"" }
+                    }
+                },
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert — the entry-local #med1 must not be flagged by the bundle-root walk.
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve" && i.Path.Contains("med1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenResourceWithDanglingFragmentReference_WhenReferenceResolutionCheck_ThenReportsIssue()
+    {
+        // Arrange — a seeded resolver with no matching contained resource: the #missing fragment is
+        // genuinely unresolved and must be flagged (non-Bundle local-reference path).
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""1"",
+            ""generalPractitioner"": [ { ""reference"": ""#missing"" } ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenResourceWithResolvableFragmentReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — the #p1 fragment resolves to a contained resource.
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""1"",
+            ""contained"": [ { ""resourceType"": ""Practitioner"", ""id"": ""p1"" } ],
+            ""generalPractitioner"": [ { ""reference"": ""#p1"" } ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
     }
 
     [Fact]
@@ -321,5 +480,92 @@ public class TreeContextScopingTests
         // Assert
         result.IsValid.ShouldBeTrue();
         result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenDocumentBundleWithUnknownTypeToken_WhenCheckHasResourceTypeRegistry_ThenDoesNotReportIssue()
+    {
+        // Arrange — "MyCustomType/1" is shaped like a relative reference but is not a real resource
+        // type. With a resource-type registry the token is rejected, so it is never treated as a
+        // bundle-relative reference and not flagged as unresolved.
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""document"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""MyCustomType/1"" }
+                    }
+                }
+            ]
+        }");
+        var registry = new HashSet<string>(StringComparer.Ordinal) { "Patient", "Observation", "Bundle" };
+        var check = new ReferenceResolutionCheck(registry);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenDanglingReferenceInsideContained_WhenValidatingAtFullDepth_ThenReportsRefResolveExactlyOnce()
+    {
+        // Arrange — a dangling fragment reference lives INSIDE a contained resource. The full
+        // pipeline runs the root resource's ReferenceResolutionCheck (which must not descend into
+        // the contained resource's scope) and ContainedResourceCheck's re-validation of the
+        // contained resource (which owns and checks it). The issue must be reported exactly once.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Observation"",
+            ""id"": ""obs1"",
+            ""status"": ""final"",
+            ""code"": { ""text"": ""x"" },
+            ""contained"": [
+                {
+                    ""resourceType"": ""Patient"",
+                    ""id"": ""p1"",
+                    ""managingOrganization"": { ""reference"": ""#nope"" }
+                }
+            ]
+        }");
+        var sourceNode = JsonNodeSourceNode.Create(json!);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var schema = _schemaResolver.GetSchema("Observation").ShouldNotBeNull();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+
+        // Act — note: no explicit EnterRootResource. ValidationSchema.Validate auto-seeds the root
+        // scope, so the reference-integrity check runs without callers having to remember to seed.
+        var result = schema.Validate(element, settings);
+
+        // Assert
+        result.Issues.Count(i => i.Code == "ref-resolve").ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenUnseededState_WhenValidatingResourceThroughSchema_ThenScopeIsAutoSeeded()
+    {
+        // Arrange — a dangling #fragment in a standalone resource. The caller does NOT seed the
+        // scope; ValidationSchema.Validate must seed it so the reference-integrity check fires.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""1"",
+            ""managingOrganization"": { ""reference"": ""#missing"" }
+        }");
+        var element = JsonNodeSourceNode.Create(json!).ToElement(TestSchemaProvider.GetR4Schema());
+        var schema = _schemaResolver.GetSchema("Patient").ShouldNotBeNull();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+
+        // Act — unseeded state passed in; auto-seeding inside Validate enables the check.
+        var result = schema.Validate(element, settings, new ValidationState());
+
+        // Assert
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
     }
 }

--- a/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
+++ b/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
@@ -568,4 +568,72 @@ public class TreeContextScopingTests
         // Assert
         result.Issues.ShouldContain(i => i.Code == "ref-resolve");
     }
+
+    [Fact]
+    public void GivenBundleEntryResourceViolatingItsSchema_WhenValidatingBundle_ThenReportsEntryScopedIssue()
+    {
+        // Arrange — the Observation entry omits the required 'status' (1..1). Validated as a base
+        // Resource the omission is invisible; BundleEntryCheck validates it against the Observation
+        // schema, so the cardinality violation surfaces with an entry-scoped path.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""code"": { ""text"": ""x"" }
+                    }
+                }
+            ]
+        }");
+        var element = JsonNodeSourceNode.Create(json!).ToElement(TestSchemaProvider.GetR4Schema());
+        var schema = _schemaResolver.GetSchema("Bundle").ShouldNotBeNull();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+
+        // Act
+        var result = schema.Validate(element, settings);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Path.Contains("entry[0].resource", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenBundleEntry_WhenEnterBundleEntry_ThenEntryIsItsOwnRootAndSiblingsResolve()
+    {
+        // Arrange
+        var bundle = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                },
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var observationEntry = bundle.Children("entry")[1].Children("resource")[0];
+
+        // Act
+        var state = new ValidationState().EnterRootResource(bundle).EnterBundleEntry(observationEntry);
+
+        // Assert — the entry is its own root (not contained), and sibling Patient/1 still resolves
+        // through the chained bundle resolver.
+        state.Scope.Resource.ShouldBeSameAs(observationEntry);
+        state.Scope.RootResource.ShouldBeSameAs(observationEntry);
+        state.Scope.Resolver.ShouldNotBeNull();
+        state.Scope.Resolver!("Patient/1").ShouldNotBeNull();
+    }
 }

--- a/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
+++ b/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
@@ -1,0 +1,325 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.FhirPath.Parser;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests;
+
+/// <summary>
+/// Tests for FHIRPath tree-context scoping: %resource / %rootResource seeding via ValidationState,
+/// resolve() across contained and Bundle scopes, and the reference-integrity check.
+/// </summary>
+public class TreeContextScopingTests
+{
+    private readonly ISchema _schema = new R4CoreSchemaProvider();
+    private readonly FhirPathParser _parser = new();
+
+    private static IElement ToElement(string json)
+    {
+        var node = JsonNode.Parse(json);
+        return JsonNodeSourceNode.Create(node!).ToElement(TestSchemaProvider.GetR4Schema());
+    }
+
+    private static IElement ToElement(JsonNode node)
+        => JsonNodeSourceNode.Create(node).ToElement(TestSchemaProvider.GetR4Schema());
+
+    [Fact]
+    public void GivenResource_WhenEnterRootResource_ThenResourceEqualsRootResource()
+    {
+        // Arrange
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+
+        // Act
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Assert
+        state.Scope.Resource.ShouldBeSameAs(element);
+        state.Scope.RootResource.ShouldBeSameAs(element);
+        state.Scope.Resolver.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GivenContained_WhenEnterContainedResource_ThenResourceIsContainedAndRootIsParent()
+    {
+        // Arrange
+        var parent = ToElement(@"{
+            ""resourceType"": ""Observation"",
+            ""id"": ""obs1"",
+            ""contained"": [ { ""resourceType"": ""Patient"", ""id"": ""p1"" } ]
+        }");
+        var contained = parent.Children("contained")[0];
+
+        // Act
+        var state = new ValidationState()
+            .EnterRootResource(parent)
+            .EnterContainedResource(contained);
+
+        // Assert
+        state.Scope.Resource.ShouldBeSameAs(contained);
+        state.Scope.RootResource.ShouldBeSameAs(parent);
+    }
+
+    [Fact]
+    public void GivenResourceConstraintReferencingResourceVariable_WhenSeeded_ThenEvaluatesAgainstResource()
+    {
+        // Arrange
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-id",
+            Severity = ConstraintSeverity.Error,
+            Human = "Resource must have an id",
+            Expression = "%resource.id.exists()",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""abc"" }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenContainedConstraintReferencingResourceVariable_WhenScopedToContained_ThenEvaluatesAgainstContained()
+    {
+        // Arrange — a constraint asserting %resource is a Patient. When evaluated on the contained
+        // resource with proper scoping, %resource must be the contained Patient, not the parent.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-is-patient",
+            Severity = ConstraintSeverity.Error,
+            Human = "%resource must be a Patient",
+            Expression = "%resource.id = 'p1'",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var parent = ToElement(@"{
+            ""resourceType"": ""Observation"",
+            ""id"": ""obs1"",
+            ""contained"": [ { ""resourceType"": ""Patient"", ""id"": ""p1"" } ]
+        }");
+        var contained = parent.Children("contained")[0];
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState()
+            .EnterRootResource(parent)
+            .EnterContainedResource(contained);
+
+        // Act
+        var result = check.Validate(contained, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenUnseededState_WhenEvaluatingConstraintWithoutResourceVariable_ThenEvaluatesContextFree()
+    {
+        // Arrange — no scope seeded. Evaluation must proceed exactly as before (context-free):
+        // ordinary element-relative constraints still work, preserving existing-test behavior.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-fallback",
+            Severity = ConstraintSeverity.Error,
+            Human = "Has an id",
+            Expression = "id.exists()",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert — unseeded evaluation must not throw and remains valid for element-relative checks
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenContainedReference_WhenConstraintUsesResolve_ThenResolvesContained()
+    {
+        // Arrange
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "resolve-contained",
+            Severity = ConstraintSeverity.Error,
+            Human = "generalPractitioner resolves to a Practitioner",
+            Expression = "generalPractitioner.reference.resolve().is(Practitioner)",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [ { ""resourceType"": ""Practitioner"", ""id"": ""p1"" } ],
+            ""generalPractitioner"": [ { ""reference"": ""#p1"" } ]
+        }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenBundleEntryReference_WhenConstraintUsesResolve_ThenResolvesSiblingEntry()
+    {
+        // Arrange — a Bundle constraint resolving an intra-bundle reference by Type/id.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "resolve-bundle",
+            Severity = ConstraintSeverity.Error,
+            Human = "Observation.subject resolves within bundle",
+            Expression = "entry.resource.ofType(Observation).subject.reference.resolve().is(Patient)",
+            Xpath = null,
+            AppliesTo = new[] { "Bundle" }
+        };
+
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                },
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenBundleWithDanglingLocalReference_WhenReferenceResolutionCheck_ThenReportsIssue()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/999"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenExternalReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — absolute external URL must not be flagged even though it doesn't resolve locally.
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""https://other.example.org/fhir/Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenNoResolverSeeded_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — without a seeded resolver the check is inert.
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""1"",
+            ""generalPractitioner"": [ { ""reference"": ""#missing"" } ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
Wire %resource, %rootResource, and resolve() into invariant evaluation without adding a parent pointer to the forward-only IElement model. Context is injected at resource boundaries during descent rather than walked up the tree.

- ResourceScope: immutable %resource/%rootResource/resolver carrier
- ValidationState.EnterRootResource/EnterContainedResource: fork scope at the two resource-root sites (handler entry + contained recursion)
- FhirPathInvariantCheck: build FhirEvaluationContext from scope, with context-free fallback when scope is unseeded (direct callers/tests)
- ReferenceIndex: resolve() backing — contained #id plus intra-Bundle fullUrl / Type/id / Type/id/_history/v
- ReferenceResolutionCheck: Full-tier integrity check for unresolved local references, narrowly scoped to avoid external/urn false positives

Unblocks dom-* and bdl-* invariants. Adds ReferenceIndexTests and TreeContextScopingTests. Includes the tree-context-scoping (Viable) and slicing-discriminators (In Progress) investigation docs.