### PR TITLE
ci(sof): fetch full history in weekly job so GitVersion build succeeds

### DIFF
--- a/.github/workflows/sof-compat.yml
+++ b/.github/workflows/sof-compat.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0   # GitVersion (GitVersion.MsBuild) needs full history or the build fails
           submodules: recursive
 
       - name: Bump sql-on-fhir-tests to upstream main


### PR DESCRIPTION
## Problem

The weekly **SoF Conformance** workflow (`sof-compat.yml`, merged in #285) failed on its first run on `main` ([run 28204544357](https://github.com/brendankowitz/ignixa-fhir/actions/runs/28204544357)):

```
GitVersion.MsBuild.targets(32,9): error MSB3073: ... gitversion.dll ... exited with code 1
```

The checkout step omitted `fetch-depth: 0`, so GitVersion.MsBuild couldn't compute a version on the shallow clone and the build failed **before any test ran**.

## Not a conformance problem

The evaluator/suite are fine. The workflow's hardening behaved correctly — it classified the failure as `SOF_STATUS=no-result` (runner/build failure) and opened a *runner-failure* issue (#287), **not** a false "conformance drift" alarm.

## Fix

Add `fetch-depth: 0` to the checkout, matching `ci.yml` and `pr-build.yml`. One line.

Closes #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)