### PR TITLE
fix(docs): use npm install for the vendored reference suite (lockfile drift)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,11 +84,17 @@ jobs:
         # The reference implementation's own published testResultsUrl is a dead link upstream,
         # so we run its vendored compliance suite ourselves instead of depending on that host.
         # Conformance gaps are tolerated the same way as our own suite: never block publishing.
+        # Uses `npm install` rather than `npm ci`: this is a third-party vendored submodule we
+        # don't control, and its committed package-lock.json is not guaranteed to stay in sync
+        # with its package.json at whatever commit the submodule happens to be pinned to —
+        # `npm ci` fails hard on that drift instead of reconciling it. A genuine install failure
+        # still fails the build via the next step, which requires a real report to have been
+        # produced.
         working-directory: test/Ignixa.SqlOnFhir.Tests/sql-on-fhir-tests/sof-js
         env:
           NODE_OPTIONS: --experimental-vm-modules
         run: |
-          npm ci
+          npm install
           npx jest tests/compliance.test.js \
             || echo "::warning::Reference implementation reported conformance failures; publishing report with recorded results"
 


### PR DESCRIPTION
## Summary
- The docs deploy pipeline's first production run on `main` failed: `npm ci` inside the vendored `sql-on-fhir.js` submodule (`sof-js`) refuses to install because its committed `package-lock.json` is out of sync with its own `package.json` at the pinned submodule commit — that's an upstream inconsistency in a third-party repo we don't control, not something introduced by our own changes.
- Switches that one step to `npm install`, which reconciles the drift instead of hard-failing. A genuine install failure still fails the build via the existing "Verify reference implementation report was produced" step.

## Test plan
- [x] Reproduced the exact CI failure locally against a pristine submodule checkout (`npm ci` -> EUSAGE/lockfile mismatch)
- [x] Confirmed `npm install` succeeds against the same pristine checkout
- [x] Ran the compliance suite to completion afterward (144 tests, report written)
- [ ] CI green on this PR

Generated with Claude Code