### PR TITLE
Add requiresCapability extension for capability-aware TestScript test skipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,5 @@ test/Ignixa.FhirPath.Tests/TestData/
 # AI assistant scripts
 kimi.ps1
 claude-kimi.ps1
+
+.worktrees/

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -27,7 +27,8 @@ public sealed class TestScriptEvaluator(
     public async Task<TestScriptReport> ExecuteAsync(
         TestScriptDefinition definition,
         CancellationToken cancellationToken,
-        string? fhirVersion = null)
+        string? fhirVersion = null,
+        ResourceJsonNode? capabilityStatement = null)
     {
         var startTime = DateTimeOffset.UtcNow;
         var recorder = new TestScriptResultRecorder();
@@ -41,6 +42,27 @@ public sealed class TestScriptEvaluator(
         {
             if (variable.DefaultValue is not null)
                 context = context.WithVariable(variable.Name, variable.DefaultValue);
+        }
+
+        var (suiteCapabilityMet, suiteCapabilityReason) =
+            IsCapabilityRequirementMet(definition.Metadata.RequiresCapability, capabilityStatement);
+        if (!suiteCapabilityMet)
+        {
+            var reason = suiteCapabilityReason ?? "Required capability not met";
+            foreach (var test in definition.Tests)
+            {
+                if (test.Parameters is null)
+                {
+                    recorder.RecordSkippedTest(test.Name, test.Description, reason);
+                }
+                else
+                {
+                    foreach (var value in test.Parameters.Values)
+                        recorder.RecordSkippedTest($"{test.Name} [{value}]", test.Description, reason);
+                }
+            }
+
+            return recorder.Build(definition.Metadata.Name, startTime, DateTimeOffset.UtcNow);
         }
 
         var hasSetupWork = definition.Fixtures.Count > 0 || definition.Setup.Count > 0;
@@ -94,6 +116,14 @@ public sealed class TestScriptEvaluator(
                 {
                     recorder.RecordSkippedTest(test.Name, test.Description,
                         $"Test targets FHIR version(s) [{string.Join(", ", test.FhirVersions)}] but execution requested '{fhirVersion}'");
+                    continue;
+                }
+
+                var (testCapabilityMet, testCapabilityReason) =
+                    IsCapabilityRequirementMet(test.RequiresCapability, capabilityStatement);
+                if (!testCapabilityMet)
+                {
+                    recorder.RecordSkippedTest(test.Name, test.Description, testCapabilityReason ?? "Required capability not met");
                     continue;
                 }
 
@@ -158,6 +188,32 @@ public sealed class TestScriptEvaluator(
         if (fhirVersions.Count == 0) return true;
         if (fhirVersion is null) return true;
         return fhirVersions.Contains(fhirVersion, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Evaluates a <c>requiresCapability</c> FHIRPath expression against the target's
+    /// CapabilityStatement (fetched once per run by the caller). A missing/empty expression
+    /// always passes. A missing <paramref name="capabilityStatement"/> (couldn't be fetched
+    /// or wasn't supplied) also passes — capability gating fails open rather than silently
+    /// skipping large parts of a run because <c>/metadata</c> happened to be unreachable.
+    /// A malformed expression fails closed (skip) with the exception message as the reason,
+    /// since that's an authoring bug rather than a target-server characteristic.
+    /// </summary>
+    private (bool Met, string? Reason) IsCapabilityRequirementMet(
+        string? requiresCapability, ResourceJsonNode? capabilityStatement)
+    {
+        if (string.IsNullOrWhiteSpace(requiresCapability)) return (true, null);
+        if (capabilityStatement is null) return (true, null);
+
+        try
+        {
+            var met = capabilityStatement.ToElement(schemaProvider).IsTrue(requiresCapability);
+            return (met, met ? null : $"Required capability not met: {requiresCapability}");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"requiresCapability expression '{requiresCapability}' failed to evaluate: {ex.Message}");
+        }
     }
 
     private async Task<TestScriptContext> ExecuteActionsAsync(

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -32,6 +32,7 @@ public sealed class TestScriptEvaluator(
     {
         var startTime = DateTimeOffset.UtcNow;
         var recorder = new TestScriptResultRecorder();
+        var capabilityElement = capabilityStatement?.ToElement(schemaProvider);
 
         var context = new TestScriptContext
         {
@@ -45,22 +46,12 @@ public sealed class TestScriptEvaluator(
         }
 
         var (suiteCapabilityMet, suiteCapabilityReason) =
-            IsCapabilityRequirementMet(definition.Metadata.RequiresCapability, capabilityStatement);
+            EvaluateCapabilityRequirement(definition.Metadata.RequiresCapability, capabilityElement);
         if (!suiteCapabilityMet)
         {
             var reason = suiteCapabilityReason ?? "Required capability not met";
             foreach (var test in definition.Tests)
-            {
-                if (test.Parameters is null)
-                {
-                    recorder.RecordSkippedTest(test.Name, test.Description, reason);
-                }
-                else
-                {
-                    foreach (var value in test.Parameters.Values)
-                        recorder.RecordSkippedTest($"{test.Name} [{value}]", test.Description, reason);
-                }
-            }
+                RecordSkippedTest(recorder, test, reason);
 
             return recorder.Build(definition.Metadata.Name, startTime, DateTimeOffset.UtcNow);
         }
@@ -114,16 +105,16 @@ public sealed class TestScriptEvaluator(
             {
                 if (!IsVersionCompatible(test.FhirVersions, fhirVersion))
                 {
-                    recorder.RecordSkippedTest(test.Name, test.Description,
+                    RecordSkippedTest(recorder, test,
                         $"Test targets FHIR version(s) [{string.Join(", ", test.FhirVersions)}] but execution requested '{fhirVersion}'");
                     continue;
                 }
 
                 var (testCapabilityMet, testCapabilityReason) =
-                    IsCapabilityRequirementMet(test.RequiresCapability, capabilityStatement);
+                    EvaluateCapabilityRequirement(test.RequiresCapability, capabilityElement);
                 if (!testCapabilityMet)
                 {
-                    recorder.RecordSkippedTest(test.Name, test.Description, testCapabilityReason ?? "Required capability not met");
+                    RecordSkippedTest(recorder, test, testCapabilityReason ?? "Required capability not met");
                     continue;
                 }
 
@@ -149,17 +140,7 @@ public sealed class TestScriptEvaluator(
         else
         {
             foreach (var test in definition.Tests)
-            {
-                if (test.Parameters is null)
-                {
-                    recorder.RecordSkippedTest(test.Name, test.Description, "setup failed");
-                }
-                else
-                {
-                    foreach (var value in test.Parameters.Values)
-                        recorder.RecordSkippedTest($"{test.Name} [{value}]", test.Description, "setup failed");
-                }
-            }
+                RecordSkippedTest(recorder, test, "setup failed");
         }
 
         if (definition.Teardown.Count > 0 || definition.Fixtures.Any(f => f.Autodelete))
@@ -192,27 +173,44 @@ public sealed class TestScriptEvaluator(
 
     /// <summary>
     /// Evaluates a <c>requiresCapability</c> FHIRPath expression against the target's
-    /// CapabilityStatement (fetched once per run by the caller). A missing/empty expression
-    /// always passes. A missing <paramref name="capabilityStatement"/> (couldn't be fetched
-    /// or wasn't supplied) also passes — capability gating fails open rather than silently
-    /// skipping large parts of a run because <c>/metadata</c> happened to be unreachable.
-    /// A malformed expression fails closed (skip) with the exception message as the reason,
-    /// since that's an authoring bug rather than a target-server characteristic.
+    /// CapabilityStatement, converted once per <see cref="ExecuteAsync"/> call by the caller.
+    /// A missing/empty expression always passes. A missing <paramref name="capabilityElement"/>
+    /// (couldn't be fetched or wasn't supplied) also passes — capability gating fails open
+    /// rather than silently skipping large parts of a run because <c>/metadata</c> happened
+    /// to be unreachable. A malformed expression fails closed (skip) with the exception message
+    /// as the reason, since that's an authoring bug rather than a target-server characteristic.
     /// </summary>
-    private (bool Met, string? Reason) IsCapabilityRequirementMet(
-        string? requiresCapability, ResourceJsonNode? capabilityStatement)
+    private static (bool IsMet, string? Reason) EvaluateCapabilityRequirement(
+        string? requiresCapability, IElement? capabilityElement)
     {
         if (string.IsNullOrWhiteSpace(requiresCapability)) return (true, null);
-        if (capabilityStatement is null) return (true, null);
+        if (capabilityElement is null) return (true, null);
 
         try
         {
-            var met = capabilityStatement.ToElement(schemaProvider).IsTrue(requiresCapability);
+            var met = capabilityElement.IsTrue(requiresCapability);
             return (met, met ? null : $"Required capability not met: {requiresCapability}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             return (false, $"requiresCapability expression '{requiresCapability}' failed to evaluate: {ex.Message}");
+        }
+    }
+
+    private static void RecordSkippedTest(TestScriptResultRecorder recorder, TestPhaseDefinition test, string reason)
+    {
+        if (test.Parameters is null)
+        {
+            recorder.RecordSkippedTest(test.Name, test.Description, reason);
+        }
+        else
+        {
+            foreach (var value in test.Parameters.Values)
+                recorder.RecordSkippedTest($"{test.Name} [{value}]", test.Description, reason);
         }
     }
 

--- a/src/Core/Ignixa.TestScript/Model/TestPhaseDefinition.cs
+++ b/src/Core/Ignixa.TestScript/Model/TestPhaseDefinition.cs
@@ -9,4 +9,12 @@ public sealed record TestPhaseDefinition
     public IReadOnlyList<ActionExpression> Actions { get; init; } = [];
     public ParametrizeDefinition? Parameters { get; init; }
     public IReadOnlyList<string> FhirVersions { get; init; } = [];
+
+    /// <summary>
+    /// FHIRPath expression (from the <c>http://ignixa.io/testscript/requiresCapability</c>
+    /// extension on this test) evaluated against the target's CapabilityStatement. When
+    /// present and it evaluates to <c>false</c>, this test is skipped rather than executed —
+    /// e.g. <c>"rest.resource.where(type='Patient').operation.where(name='everything').exists()"</c>.
+    /// </summary>
+    public string? RequiresCapability { get; init; }
 }

--- a/src/Core/Ignixa.TestScript/Model/TestPhaseDefinition.cs
+++ b/src/Core/Ignixa.TestScript/Model/TestPhaseDefinition.cs
@@ -15,6 +15,8 @@ public sealed record TestPhaseDefinition
     /// extension on this test) evaluated against the target's CapabilityStatement. When
     /// present and it evaluates to <c>false</c>, this test is skipped rather than executed —
     /// e.g. <c>"rest.resource.where(type='Patient').operation.where(name='everything').exists()"</c>.
+    /// A malformed expression is also treated as a skip (an authoring error), with the
+    /// evaluation failure surfaced as the skip reason.
     /// </summary>
     public string? RequiresCapability { get; init; }
 }

--- a/src/Core/Ignixa.TestScript/Model/TestScriptMetadata.cs
+++ b/src/Core/Ignixa.TestScript/Model/TestScriptMetadata.cs
@@ -7,4 +7,14 @@ public sealed record TestScriptMetadata
     public string? Url { get; init; }
     public string? Status { get; init; }
     public string? Version { get; init; }
+
+    /// <summary>
+    /// FHIRPath expression (from the <c>http://ignixa.io/testscript/requiresCapability</c>
+    /// extension on the TestScript resource) evaluated against the target's CapabilityStatement.
+    /// When present and it evaluates to <c>false</c>, every test in this script is skipped —
+    /// use this to gate an entire suite on a server capability (e.g. a whole $reindex suite on
+    /// a server that doesn't advertise the operation at all). Individual tests can additionally
+    /// carry their own <see cref="TestPhaseDefinition.RequiresCapability"/> for finer-grained gating.
+    /// </summary>
+    public string? RequiresCapability { get; init; }
 }

--- a/src/Core/Ignixa.TestScript/Model/TestScriptMetadata.cs
+++ b/src/Core/Ignixa.TestScript/Model/TestScriptMetadata.cs
@@ -13,8 +13,10 @@ public sealed record TestScriptMetadata
     /// extension on the TestScript resource) evaluated against the target's CapabilityStatement.
     /// When present and it evaluates to <c>false</c>, every test in this script is skipped —
     /// use this to gate an entire suite on a server capability (e.g. a whole $reindex suite on
-    /// a server that doesn't advertise the operation at all). Individual tests can additionally
-    /// carry their own <see cref="TestPhaseDefinition.RequiresCapability"/> for finer-grained gating.
+    /// a server that doesn't advertise the operation at all). A malformed expression is also
+    /// treated as a skip (an authoring error), with the evaluation failure surfaced as the skip
+    /// reason. Individual tests can additionally carry their own
+    /// <see cref="TestPhaseDefinition.RequiresCapability"/> for finer-grained gating.
     /// </summary>
     public string? RequiresCapability { get; init; }
 }

--- a/src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs
+++ b/src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs
@@ -45,7 +45,8 @@ public static class TestScriptParser
             Description = JsonFieldReader.GetString(obj, "description", "$", errors),
             Url = JsonFieldReader.GetString(obj, "url", "$", errors),
             Status = status,
-            Version = JsonFieldReader.GetString(obj, "version", "$", errors)
+            Version = JsonFieldReader.GetString(obj, "version", "$", errors),
+            RequiresCapability = ParseRequiresCapability(obj["extension"]?.AsArray())
         };
 
         var fixtures = ParseFixtures(obj["fixture"]?.AsArray(), errors);
@@ -225,7 +226,8 @@ public static class TestScriptParser
                 Description = JsonFieldReader.GetString(test, "description", path, errors),
                 Actions = ParseActions(test["action"]?.AsArray(), path, errors),
                 Parameters = ParseParametrize(extensions, name, errors),
-                FhirVersions = ParseFhirVersions(extensions)
+                FhirVersions = ParseFhirVersions(extensions),
+                RequiresCapability = ParseRequiresCapability(extensions)
             });
         }
         return result;
@@ -233,6 +235,20 @@ public static class TestScriptParser
 
     private const string ParametrizeUrl = "http://ignixa.io/testscript/parametrize";
     private const string FhirVersionsUrl = "http://ignixa.io/testscript/fhirVersions";
+    private const string RequiresCapabilityUrl = "http://ignixa.io/testscript/requiresCapability";
+
+    private static string? ParseRequiresCapability(JsonArray? extensions)
+    {
+        if (extensions is null) return null;
+        foreach (var ext in extensions)
+        {
+            if (ext is not JsonObject obj) continue;
+            if (obj["url"]?.GetValue<string>() != RequiresCapabilityUrl) continue;
+
+            return obj["valueString"]?.GetValue<string>();
+        }
+        return null;
+    }
 
     private static IReadOnlyList<string> ParseFhirVersions(JsonArray? extensions)
     {

--- a/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
+++ b/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Text;
+using Shouldly;
+using Ignixa.ConformanceMatrix.Cli.Commands;
+
+namespace Ignixa.ConformanceMatrix.Cli.Tests;
+
+public class RunCommandTests
+{
+    [Fact]
+    public async Task GivenSuccessfulMetadataResponse_WhenFetching_ThenReturnsParsedCapabilityStatement()
+    {
+        using var handler = new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"resourceType":"CapabilityStatement","status":"active"}""",
+                    Encoding.UTF8,
+                    "application/fhir+json")
+            });
+        using var httpClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("http://test/") };
+
+        var result = await RunCommand.FetchCapabilityStatementAsync(httpClient, CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result.ResourceType.ShouldBe("CapabilityStatement");
+    }
+
+    [Fact]
+    public async Task GivenNonSuccessMetadataResponse_WhenFetching_ThenReturnsNull()
+    {
+        using var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var httpClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("http://test/") };
+
+        var result = await RunCommand.FetchCapabilityStatementAsync(httpClient, CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenUnparseableMetadataBody_WhenFetching_ThenReturnsNull()
+    {
+        using var handler = new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("not json", Encoding.UTF8, "application/fhir+json")
+            });
+        using var httpClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("http://test/") };
+
+        var result = await RunCommand.FetchCapabilityStatementAsync(httpClient, CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenNetworkFailure_WhenFetching_ThenReturnsNull()
+    {
+        using var handler = new StubHandler(_ => throw new HttpRequestException("connection refused"));
+        using var httpClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("http://test/") };
+
+        var result = await RunCommand.FetchCapabilityStatementAsync(httpClient, CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenCancellationRequested_WhenFetching_ThenThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        using var handler = new StubHandler(_ => throw new OperationCanceledException());
+        using var httpClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("http://test/") };
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => RunCommand.FetchCapabilityStatementAsync(httpClient, cts.Token));
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request));
+    }
+}

--- a/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
@@ -446,6 +446,160 @@ public class TestScriptEvaluatorTests
     }
 
     [Fact]
+    public async Task GivenParametrizedTestRequiringUndeclaredOperation_WhenExecuting_ThenEveryIterationIsSkippedWithValueSuffix()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "ParametrizedCapabilityGated" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "SystemReindex",
+                    RequiresCapability = "rest.operation.where(name='reindex').exists()",
+                    Parameters = new ParametrizeDefinition("id", ["1", "2"]),
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/${id}/$reindex" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults.Count.ShouldBe(2);
+        report.TestResults.Select(r => r.Name).ShouldBe(["SystemReindex [1]", "SystemReindex [2]"]);
+        report.TestResults.ShouldAllBe(t => t.Outcome == TestScriptOutcome.Skip);
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenSuiteGateMetButOneTestGateUnmet_WhenExecuting_ThenOnlyThatTestSkipsAndSiblingsRun()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata
+            {
+                Name = "MixedGating",
+                RequiresCapability = "rest.resource.where(type='Patient').operation.where(name='everything').exists()"
+            },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "Reindex",
+                    RequiresCapability = "rest.operation.where(name='reindex').exists()",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1/$reindex" }]
+                },
+                new TestPhaseDefinition
+                {
+                    Name = "PlainRead",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults.Count.ShouldBe(2);
+        report.TestResults[0].Name.ShouldBe("Reindex");
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[1].Name.ShouldBe("PlainRead");
+        report.TestResults[1].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenTestWithMismatchedFhirVersionAndMalformedCapability_WhenExecuting_ThenVersionSkipWinsWithoutEvaluatingCapability()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionBeforeCapability" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "R4Only",
+                    FhirVersions = ["4.0"],
+                    RequiresCapability = "rest.resource.where(type=",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            fhirVersion: "5.0", capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("FHIR version");
+        report.TestResults[0].Actions[0].Message!.ShouldNotContain("failed to evaluate");
+    }
+
+    [Fact]
+    public async Task GivenSetupFails_WhenTestHasMalformedRequiresCapability_ThenSkipReasonIsSetupFailedNotCapabilityError()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Network failure"));
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "SetupFailsBeforeCapabilityCheck" },
+            Setup = [new OperationExpression { Type = "create", Resource = "Patient" }],
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "BadExpression",
+                    RequiresCapability = "rest.resource.where(type=",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("setup failed");
+        report.TestResults[0].Actions[0].Message!.ShouldNotContain("failed to evaluate");
+    }
+
+    [Fact]
+    public async Task GivenWhitespaceOnlyRequiresCapability_WhenExecuting_ThenTreatedAsAlwaysMet()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "WhitespaceCapability" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PlainRead",
+                    RequiresCapability = "   ",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GivenEmptyTestScript_WhenExecuting_ThenReturnsPassWithNoTests()
     {
         var definition = new TestScriptDefinition

--- a/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
@@ -293,6 +293,158 @@ public class TestScriptEvaluatorTests
         await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
     }
 
+    private static ResourceJsonNode CapabilityStatementWithPatientEverything() => ResourceJsonNode.Parse("""
+        {
+          "resourceType": "CapabilityStatement",
+          "status": "active",
+          "rest": [
+            {
+              "mode": "server",
+              "resource": [
+                {
+                  "type": "Patient",
+                  "interaction": [{"code": "search-type"}],
+                  "operation": [{"name": "everything", "definition": "http://hl7.org/fhir/OperationDefinition/Patient-everything"}]
+                }
+              ]
+            }
+          ]
+        }
+        """);
+
+    [Fact]
+    public async Task GivenTestRequiringDeclaredOperation_WhenExecuting_ThenTestRuns()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "CapabilityGated" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PatientEverything",
+                    RequiresCapability = "rest.resource.where(type='Patient').operation.where(name='everything').exists()",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1/$everything" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenTestRequiringUndeclaredOperation_WhenExecuting_ThenTestIsSkipped()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "CapabilityGated" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "SystemReindex",
+                    RequiresCapability = "rest.operation.where(name='reindex').exists()",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1/$reindex" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("rest.operation.where(name='reindex').exists()");
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenSuiteRequiringUndeclaredOperation_WhenExecuting_ThenAllTestsAreSkipped()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata
+            {
+                Name = "SuiteGated",
+                RequiresCapability = "rest.operation.where(name='reindex').exists()"
+            },
+            Tests =
+            [
+                new TestPhaseDefinition { Name = "Test1", Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }] },
+                new TestPhaseDefinition { Name = "Test2", Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/2" }] }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults.Count.ShouldBe(2);
+        report.TestResults.ShouldAllBe(t => t.Outcome == TestScriptOutcome.Skip);
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenTestRequiringCapability_WhenCapabilityStatementUnavailable_ThenTestRunsAnyway()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "CapabilityGatedNoStatement" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PatientEverything",
+                    RequiresCapability = "rest.resource.where(type='Patient').operation.where(name='everything').exists()",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1/$everything" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, capabilityStatement: null);
+
+        report.TestResults[0].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenMalformedRequiresCapabilityExpression_WhenExecuting_ThenTestIsSkippedWithReason()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "CapabilityMalformed" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "BadExpression",
+                    RequiresCapability = "rest.resource.where(type=",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None,
+            capabilityStatement: CapabilityStatementWithPatientEverything());
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("failed to evaluate");
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task GivenEmptyTestScript_WhenExecuting_ThenReturnsPassWithNoTests()
     {

--- a/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
+++ b/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
@@ -315,6 +315,66 @@ public class TestScriptParserTests
     }
 
     [Fact]
+    public void GivenTestWithRequiresCapabilityExtension_WhenParsed_ThenExpressionPopulated()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript",
+              "name":"CapabilityGated",
+              "status":"active",
+              "test":[{
+                "name":"everything op",
+                "extension":[{"url":"http://ignixa.io/testscript/requiresCapability","valueString":"rest.resource.where(type='Patient').operation.where(name='everything').exists()"}],
+                "action":[{"operation":{"type":{"code":"read"},"resource":"Patient","params":"/123/$everything"}}]
+              }]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Tests[0].RequiresCapability
+            .ShouldBe("rest.resource.where(type='Patient').operation.where(name='everything').exists()");
+    }
+
+    [Fact]
+    public void GivenTestWithoutRequiresCapabilityExtension_WhenParsed_ThenExpressionNull()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript",
+              "name":"Ungated",
+              "status":"active",
+              "test":[{"name":"t","action":[{"assert":{"expression":"Patient.id.exists()"}}]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Tests[0].RequiresCapability.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenTestScriptWithRequiresCapabilityOnMetadata_WhenParsed_ThenExpressionPopulated()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript",
+              "name":"SuiteGated",
+              "status":"active",
+              "extension":[{"url":"http://ignixa.io/testscript/requiresCapability","valueString":"rest.operation.where(name='reindex').exists()"}],
+              "test":[{"name":"t","action":[{"assert":{"expression":"Patient.id.exists()"}}]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Metadata.RequiresCapability.ShouldBe("rest.operation.where(name='reindex').exists()");
+    }
+
+    [Fact]
     public void GivenVariableWithExpression_WhenParsing_ThenCreatesExpressionExtraction()
     {
         var json = """

--- a/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
+++ b/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
@@ -375,6 +375,62 @@ public class TestScriptParserTests
     }
 
     [Fact]
+    public void GivenRequiresCapabilityExtensionWithWrongValueType_WhenParsed_ThenExpressionNull()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript",
+              "name":"WrongValueType",
+              "status":"active",
+              "test":[{
+                "name":"t",
+                "extension":[{"url":"http://ignixa.io/testscript/requiresCapability","valueBoolean":true}],
+                "action":[{"assert":{"expression":"Patient.id.exists()"}}]
+              }]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Tests[0].RequiresCapability.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenTestWithParametrizeFhirVersionsAndRequiresCapabilityTogether_WhenParsed_ThenAllThreePopulate()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript",
+              "name":"AllExtensionsTogether",
+              "status":"active",
+              "test":[{
+                "name":"combined",
+                "extension":[
+                  {"url":"http://ignixa.io/testscript/fhirVersions","valueString":"4.0,4.3"},
+                  {"url":"http://ignixa.io/testscript/requiresCapability","valueString":"Patient.exists()"},
+                  {"url":"http://ignixa.io/testscript/parametrize","extension":[
+                    {"url":"variable","valueString":"id"},
+                    {"url":"values","valueString":"1,2"}
+                  ]}
+                ],
+                "action":[{"operation":{"type":{"code":"read"},"resource":"Patient","params":"/${id}"}}]
+              }]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        var test = result.Value!.Tests[0];
+        test.FhirVersions.ShouldBe(["4.0", "4.3"]);
+        test.RequiresCapability.ShouldBe("Patient.exists()");
+        test.Parameters.ShouldNotBeNull();
+        test.Parameters!.VariableName.ShouldBe("id");
+        test.Parameters.Values.ShouldBe(["1", "2"]);
+    }
+
+    [Fact]
     public void GivenVariableWithExpression_WhenParsing_ThenCreatesExpressionExtraction()
     {
         var json = """

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using System.Text.Json;
 using Ignixa.ConformanceMatrix.Cli.Reporting;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.Generated;
 using Ignixa.TestScript.Client;
 using Ignixa.TestScript.Evaluation;
@@ -89,6 +91,8 @@ internal static class RunCommand
             ]);
             var evaluator = new TestScriptEvaluator(provider, fixtureProvider, schema);
 
+            var capabilityStatement = await FetchCapabilityStatementAsync(httpClient, cancellationToken);
+
             var allResults = new List<ImplReportResult>();
             foreach (var file in files)
             {
@@ -141,7 +145,8 @@ internal static class RunCommand
 
                 try
                 {
-                    var report = await evaluator.ExecuteAsync(parseResult.Value!, cancellationToken, fhirVersion: fhirVersion);
+                    var report = await evaluator.ExecuteAsync(parseResult.Value!, cancellationToken,
+                        fhirVersion: fhirVersion, capabilityStatement: capabilityStatement);
                     var mapped = ReportMapper.Map(report, relFile);
                     allResults.AddRange(mapped);
 
@@ -199,4 +204,36 @@ internal static class RunCommand
 
     internal static int ClassifyExitCode(IReadOnlyList<ImplReportResult> results)
         => results.Any(r => MatrixBuilder.IsFail(r.Status)) ? 1 : 0;
+
+    /// <summary>
+    /// Fetches the target server's CapabilityStatement from <c>/metadata</c> once per run, so it
+    /// can be passed to <see cref="TestScriptEvaluator.ExecuteAsync"/> for <c>requiresCapability</c>
+    /// gating. Any failure (network error, non-success status, unparseable body) is treated as
+    /// "no CapabilityStatement available" — capability gating fails open in that case, matching
+    /// the evaluator's own policy — but is reported so it isn't silently swallowed.
+    /// </summary>
+    internal static async Task<ResourceJsonNode?> FetchCapabilityStatementAsync(HttpClient httpClient, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await httpClient.GetAsync(new Uri("metadata", UriKind.Relative), cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"warning: could not fetch /metadata (HTTP {(int)response.StatusCode}); requiresCapability gating will fail open for this run");
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSourceNodeFactory.Parse(body);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"warning: could not fetch /metadata ({ex.GetType().Name}: {ex.Message}); requiresCapability gating will fail open for this run");
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new `http://ignixa.io/testscript/requiresCapability` TestScript extension whose `valueString` is a **FHIRPath expression evaluated against the target's CapabilityStatement**. When the expression evaluates to `false`, the gated test (or, if set on the TestScript resource itself, every test in the suite) is recorded as `Skip` instead of executed.

This reuses the exact same evaluation call the assert engine already uses for response-body FHIRPath assertions (`ResourceJsonNode.ToElement(schema).IsTrue(expr)`) — no new evaluation machinery.

## Changes

- `TestScriptMetadata.RequiresCapability` — whole-suite gate (parsed from the extension on the TestScript resource root)
- `TestPhaseDefinition.RequiresCapability` — per-test gate (parsed from the extension on `test[]`, same pattern as the existing `fhirVersions` extension)
- `TestScriptEvaluator.ExecuteAsync` gains an optional `ResourceJsonNode? capabilityStatement` parameter (caller fetches `/metadata` once per run and passes it in)
- Suite-level gate: if unmet, every test is recorded `Skip` and setup/teardown don't run at all (mirrors the existing setup-failure cascade)
- Per-test gate: if unmet, only that test is skipped

## Policy choices

- **No CapabilityStatement supplied** (caller couldn't fetch/parse one) → requirement passes (**fail open**) — a target that can't be introspected behaves exactly like today (ungated), rather than silently skipping large parts of a run because `/metadata` was flaky.
- **Expression throws** (e.g. malformed FHIRPath) → **fails closed** (skip), since that's an authoring bug rather than a target-server characteristic; the exception message becomes the skip reason.

## Example expressions

```
rest.resource.where(type='Patient').operation.where(name='everything').exists()
rest.operation.where(name='reindex').exists()
rest.interaction.where(code='transaction').exists()
rest.resource.where(type='Patient').searchParam.where(name='family').exists()
```

## Testing

- 3 new parser tests (`TestScriptParserTests`) covering per-test and metadata-level extension parsing
- 5 new evaluator tests (`TestScriptEvaluatorTests`) covering: declared-capability pass-through, undeclared-capability skip (test-level and suite-level), fail-open on missing CapabilityStatement, fail-closed on malformed expression
- Full `Ignixa.TestScript.Tests` suite: 219/219 passing (net9.0 + net10.0)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>