### PR TITLE
fix(testscript): stringify FHIRPath boolean results as lowercase

### DIFF
--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -536,7 +536,8 @@ public sealed class TestScriptEvaluator(
 
         var resolvedExpr = VariableResolver.Resolve(c.Expression, context);
         var resolvedValue = VariableResolver.Resolve(c.Value ?? string.Empty, context);
-        var actual = body.ToElement(schemaProvider).Scalar(resolvedExpr)?.ToString();
+        var scalarValue = body.ToElement(schemaProvider).Scalar(resolvedExpr);
+        var actual = scalarValue is bool boolValue ? (boolValue ? "true" : "false") : scalarValue?.ToString();
 
         var passed = EvaluateWithOperator(actual, resolvedValue, c.Operator);
         return (passed, passed

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
@@ -454,6 +454,29 @@ public class AssertionEvaluatorTests
     }
 
     [Fact]
+    public async Task GivenFhirPathValueCriteria_WhenExpressionReturnsBoolean_ThenComparesAsLowercaseString()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse
+            {
+                StatusCode = 200,
+                Body = JsonSourceNodeFactory.Parse("""{"resourceType": "Patient", "id": "abc"}""")
+            });
+
+        var definition = BuildDefinition(
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/abc" },
+            new AssertExpression
+            {
+                Criteria = new FhirPathValueCriteria("Patient.address.exists()", "false", AssertOperator.Equals)
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _r4Schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
     public async Task GivenFhirPathValueCriteria_WhenValueDoesNotMatch_ThenFails()
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary
- `TestScriptEvaluator.EvaluateFhirPathValue` called raw `.ToString()` on the FHIRPath `Scalar()` result, which for a boxed `bool` yields .NET's `"True"`/`"False"` instead of the FHIRPath-spec lowercase `"true"`/`"false"` (the convention already used elsewhere in the codebase, e.g. `TypeConversionFunctions.ToString()`).
- This caused `fhirpath-value` assertions comparing against boolean-returning expressions (e.g. `Patient.address.exists()` = `'false'`) to fail even when the underlying value was correct — a false negative in the test evaluator, not a server bug.
- Found while running the [ignixa-lab e2e TestScript suites](https://github.com/brendankowitz/ignixa-lab/pull/5) against a live ignixa-fhir instance: `CRUD/patch-fhirpath.json` had 3 assertions failing purely on this casing mismatch.

## Test plan
- [x] Added `GivenFhirPathValueCriteria_WhenExpressionReturnsBoolean_ThenComparesAsLowercaseString` to `AssertionEvaluatorTests`
- [x] `dotnet test test/Ignixa.TestScript.Tests` — 227/227 passing (net9.0 + net10.0), no regressions
- [x] Re-ran `CRUD/patch-fhirpath.json` from the ignixa-lab suite against a live server: the 3 boolean-comparison false negatives now pass (4/20 → 5/20 on that file; remaining failures are an unrelated exception-handling bug in the patch endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)