### PR TITLE
Add UK Core Patient profile + fix postal-code/country generation bugs in FhirFakes

### DIFF
--- a/docs/features/fhir-faker/investigations/country-aware-postal-codes.md
+++ b/docs/features/fhir-faker/investigations/country-aware-postal-codes.md
@@ -1,0 +1,180 @@
+# Investigation: Country-Aware Postal Code Sampling
+
+**Feature**: fhir-faker
+**Status**: In Progress
+**Created**: 2026-07-04
+
+## Approach
+
+Replace `DemographicsDataProvider.SampleZipCode`'s single hardcoded numeric-suffix format with a
+small, data-driven `PostalCodeFormat` enum carried on `CityDemographics` itself, and a `switch` in
+`SampleZipCode` over that enum instead of one-size-fits-all string concatenation.
+
+### The bug is already shipping, not just a future UK problem
+
+This surfaced while investigating [uk-core-patient-profile](uk-core-patient-profile.md), but it isn't
+UK-specific — it's already producing wrong-shaped postal codes for the two international cities that
+exist today:
+
+```csharp
+// DemographicsDataProvider.cs — current implementation
+public string SampleZipCode(CityDemographics city, Bogus.Randomizer randomizer)
+{
+    var suffix = randomizer.Int(0, 99).ToString("D2");
+    return city.ZipCodePrefix + suffix;
+}
+```
+
+| City | `ZipCodePrefix` | Current output | Real format |
+|---|---|---|---|
+| Boston (US) | `"021"` | `"02105"` — correct | 5-digit ZIP |
+| Melbourne (AU) | `"3000"` | `"300047"` — **6 digits, invalid** | 4-digit postcode, no suffix |
+| Sydney (AU) | `"2000"` | `"200012"` — **6 digits, invalid** | 4-digit postcode, no suffix |
+| Amsterdam (NL) | `"1011"` | `"101123"` — **6 digits, wrong shape entirely** | 4 digits + space + 2 letters (e.g. `"1011 AB"`) |
+| London (UK, proposed) | `"SW1A"` | `"SW1A05"` — **wrong shape entirely** | outward code + space + digit + 2 letters (e.g. `"SW1A 1AA"`) |
+
+Both call sites are affected equally: `PatientBuilder.FromCity` (`PatientBuilder.cs:726`) and
+`OrganizationState.GenerateAddress` (`OrganizationState.cs:349`) both call `SampleZipCode`
+unconditionally with no country branch today.
+
+**Related, separately-discovered bug (out of scope here, noting for visibility):**
+`OrganizationState.GenerateAddress` also hardcodes `Country: "USA"` (`OrganizationState.cs:362`)
+regardless of which city was actually sampled — so an organization generated from Melbourne gets
+`"USA"` as its country. Same root cause (country-specific address shaping wasn't threaded through
+when international cities were added) but a distinct fix; flagging for a follow-up, not folding into
+this investigation.
+
+## Options Considered
+
+### Option 1 — Inline switch on `city.Country` inside `DemographicsDataProvider`
+
+Add private per-country helpers (`SampleUsZipCode`, `SampleAuPostcode`, `SampleNlPostcode`,
+`SampleUkPostcode`); `SampleZipCode` becomes a switch expression on `city.Country`.
+
+- **Pros**: smallest diff; matches the existing "small dictionary/switch keyed by country" style already
+  used by `DefaultNameGenerationStrategy.CountryToLocaleMapping` and
+  `AUBasePatientProfile.IndigenousStatusDisplay`.
+- **Cons**: format is keyed by country code as a string, duplicating a piece of knowledge that also
+  lives in `PatientProfileFactory`'s country-keyed registry, but in a second, unsynchronized place —
+  a consumer registering a new country profile via `PatientProfileFactory.RegisterProfile` gets no
+  signal that they also need to add a case here. Silent fallthrough to the wrong format for any new
+  country.
+
+### Option 2 — New `IPostalCodeFormatStrategy` + registry, parallel to `PatientProfileFactory`
+
+A new interface (`string Sample(string prefix, Bogus.Randomizer randomizer)`), a
+`PostalCodeFormatFactory` with `RegisterFormat(countryCode, strategy)`, mirroring the existing
+profile-registration extensibility story exactly.
+
+- **Pros**: fully consistent, pluggable extensibility across all three country-varying axes (profile
+  extensions, name locale, postal format) — a consumer adding a new country registers all three the
+  same way, discoverable by pattern-matching what US/AU/UK already did.
+- **Cons**: a fourth small interface/factory pair for what is fundamentally a handful of string-format
+  branches. `SampleAge`, `SampleGender`, and `SampleAreaCode` — the other three demographic sampling
+  methods on this same class — are plain code today, not strategy objects, because they don't need
+  country-specific *behavior*, just country-specific *data* (a distribution, a ratio, a list). Postal
+  code shape is the same kind of thing: data-shaped, not behavior-shaped. Promoting it to a strategy
+  interface would be inconsistent with its three neighbors on the same class.
+
+### Option 3 — `PostalCodeFormat` enum as a `CityDemographics` property (recommended)
+
+Add an enum and a property on the record itself, declared explicitly per city at construction time —
+the same way `AreaCodes` and `ZipCodePrefix` already are:
+
+```csharp
+public enum PostalCodeFormat
+{
+    /// <summary>US-style: append a 2-digit numeric suffix (e.g. "021" -> "02105"). Default — preserves current behavior for existing cities.</summary>
+    NumericSuffix,
+
+    /// <summary>Fixed code, no suffix (e.g. Australian postcodes: "3000").</summary>
+    FixedNumeric,
+
+    /// <summary>Dutch-style: 4 digits + space + 2 letters (e.g. "1011 AB").</summary>
+    DutchAlphaNumeric,
+
+    /// <summary>UK-style: alpha-numeric outward code + space + digit + 2 letters (e.g. "SW1A 1AA").</summary>
+    UkAlphaNumeric
+}
+```
+
+```csharp
+// CityDemographics.cs — new optional trailing parameter, non-breaking for existing named-argument call sites
+public record CityDemographics(
+    ...
+    IReadOnlyDictionary<string, object>? Attributes = null,
+    PostalCodeFormat PostalCodeFormat = PostalCodeFormat.NumericSuffix
+)
+```
+
+```csharp
+// DemographicsDataProvider.cs
+public string SampleZipCode(CityDemographics city, Bogus.Randomizer randomizer)
+{
+    ArgumentNullException.ThrowIfNull(randomizer);
+
+    return city.PostalCodeFormat switch
+    {
+        PostalCodeFormat.FixedNumeric => city.ZipCodePrefix,
+        PostalCodeFormat.DutchAlphaNumeric => $"{city.ZipCodePrefix} {SampleLetters(randomizer, 2)}",
+        PostalCodeFormat.UkAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.Int(0, 9)}{SampleLetters(randomizer, 2)}",
+        _ => city.ZipCodePrefix + randomizer.Int(0, 99).ToString("D2"),
+    };
+}
+
+private static string SampleLetters(Bogus.Randomizer randomizer, int count) =>
+    new(Enumerable.Range(0, count).Select(_ => (char)randomizer.Int('A', 'Z')).ToArray());
+```
+
+- **Pros**: fixes the already-shipping AU/NL bug with the same change that unblocks UK; format is
+  explicit, visible, and co-located with the rest of a city's declared shape (`ZipCodePrefix`,
+  `AreaCodes`) rather than inferred from `Country` in a second lookup table — matches "make invalid
+  state unrepresentable" (the format is part of the data, not derived/guessed); default parameter value
+  (`NumericSuffix`) means every existing `AddCity(...)` call in `DemographicsDataProvider.CreateDefault`
+  keeps compiling and behaving identically with zero changes required to the 11 existing US cities.
+- **Cons**: same as Option 1, a genuinely new format still means editing the switch in
+  `DemographicsDataProvider` (not pluggable without a code change) — but this is consistent with how
+  `SampleAge`'s age-bucket logic and `SampleGender`'s ratio logic already work on this same class; none
+  of the three sibling sampling methods are externally pluggable today either.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Fixes a real, already-shipping bug (Melbourne/Sydney/Amsterdam postcodes are wrong shape today), not just a hypothetical UK blocker | UK postcode generation only approximates shape (outward-code + digit + 2 letters); it does not enforce Royal Mail's letter-exclusion rules per position (e.g. certain letters never appear in the first position of certain outward codes) — acceptable for test-data purposes, worth stating explicitly so nobody assumes real-world postcode validity |
+| `PostalCodeFormat` as city-level data keeps the fix consistent with `SampleAge`/`SampleGender`/`SampleAreaCode`, which are also plain data-driven, not strategy objects | A truly new/exotic format (e.g. Canadian `A1A 1A1`, Japanese 3+4 digit) still requires a code change to `DemographicsDataProvider`, same as today |
+| Default enum value preserves current behavior for all 11 existing US cities with zero call-site changes | Doesn't fix the separately-discovered `Country: "USA"` hardcoding bug in `OrganizationState` — needs its own fix |
+
+## Alignment
+
+- [x] Follows architectural layering rules — stays entirely inside `Ignixa.FhirFakes` (Core), no new external dependency
+- [x] Developer Experience (works with minimal setup) — existing `KnownCities.*` call sites need no changes; new cities just declare their format like they already declare `AreaCodes`
+- [x] Specification compliance (if applicable) — postal code *shape* only; not attempting full national postal-authority validation rules (documented above as an explicit non-goal)
+- [x] Consistent with existing patterns — matches the plain-data style of `SampleAge`/`SampleGender`/`SampleAreaCode` on `DemographicsDataProvider`, and the "default parameter preserves compatibility" convention already used for `CityDemographics.Attributes`
+
+## Evidence
+
+- Confirmed via direct read of `DemographicsDataProvider.cs:466-472` that `SampleZipCode` has no
+  country branch and unconditionally appends a `D2` numeric suffix.
+- Confirmed both call sites (`PatientBuilder.cs:726`, `OrganizationState.cs:349`) invoke
+  `SampleZipCode` the same unconditional way — the fix needs to live in `DemographicsDataProvider`,
+  not in either caller.
+- Manually traced today's output for Melbourne (`"3000"` + 2-digit suffix → 6-digit string) and
+  Amsterdam (`"1011"` + 2-digit suffix → 6-digit numeric string, when a real Dutch postcode is 4
+  digits + space + 2 letters) against the actual `CreateDefault()` data
+  (`DemographicsDataProvider.cs:339-394`) — confirms this is a live bug in cities already shipping
+  today, not a hypothetical.
+- Read `OrganizationState.cs:346-364` — confirms the `Country: "USA"` hardcoding as a related but
+  distinct defect, noted for follow-up rather than folded into this fix.
+- Cross-referenced against `CityDemographics.cs` record shape — adding a trailing optional parameter
+  with a default is the same non-breaking-change pattern already used when `Attributes` was added
+  (`Attributes: IReadOnlyDictionary<string, object>? = null`).
+
+## Verdict
+
+**Recommended: Option 3** (`PostalCodeFormat` enum on `CityDemographics`). It's the smallest change
+that (a) fixes the currently-shipping AU/NL bug, (b) unblocks UK cities, and (c) stays consistent with
+how its three sibling sampling methods on `DemographicsDataProvider` already work — data on the record,
+not a new strategy/registry layer. Not yet implemented — pending confirmation to proceed, and pending
+a decision on whether the separately-discovered `OrganizationState` country-hardcoding bug should be
+fixed in the same change or filed as its own follow-up.

--- a/docs/features/fhir-faker/investigations/country-aware-postal-codes.md
+++ b/docs/features/fhir-faker/investigations/country-aware-postal-codes.md
@@ -1,8 +1,9 @@
 # Investigation: Country-Aware Postal Code Sampling
 
 **Feature**: fhir-faker
-**Status**: In Progress
+**Status**: Implemented
 **Created**: 2026-07-04
+**Implemented**: 2026-07-04 (PR #300)
 
 ## Approach
 
@@ -172,9 +173,15 @@ private static string SampleLetters(Bogus.Randomizer randomizer, int count) =>
 
 ## Verdict
 
-**Recommended: Option 3** (`PostalCodeFormat` enum on `CityDemographics`). It's the smallest change
-that (a) fixes the currently-shipping AU/NL bug, (b) unblocks UK cities, and (c) stays consistent with
-how its three sibling sampling methods on `DemographicsDataProvider` already work — data on the record,
-not a new strategy/registry layer. Not yet implemented — pending confirmation to proceed, and pending
-a decision on whether the separately-discovered `OrganizationState` country-hardcoding bug should be
-fixed in the same change or filed as its own follow-up.
+**Implemented: Option 3** (`PostalCodeFormat` enum on `CityDemographics`). Shipped in PR #300: fixes
+the previously-shipping AU/NL bug, unblocks UK cities (London), and stays consistent with how its three
+sibling sampling methods on `DemographicsDataProvider` already work — data on the record, not a new
+strategy/registry layer. The separately-discovered `OrganizationState` country-hardcoding bug was fixed
+in the same change (`Country: city.Country` instead of a hardcoded `"USA"` literal).
+
+Post-merge review hardened the implementation further: `SampleZipCode`'s switch now has an explicit
+`NumericSuffix` arm plus a throwing default arm (instead of a catch-all `_ =>` that would have silently
+produced US-shaped output for any future `PostalCodeFormat` value with no compiler warning), and
+`PostalCodeFormat.UkAlphaNumeric` was renamed to `UKAlphaNumeric` for consistency with
+`UKCorePatientProfile`'s capitalization (two-letter acronyms stay fully capitalized per .NET naming
+guidelines).

--- a/docs/features/fhir-faker/investigations/uk-core-patient-profile.md
+++ b/docs/features/fhir-faker/investigations/uk-core-patient-profile.md
@@ -1,8 +1,9 @@
 # Investigation: UK Core Patient Profile
 
 **Feature**: fhir-faker
-**Status**: In Progress
+**Status**: Implemented
 **Created**: 2026-07-04
+**Implemented**: 2026-07-04 (PR #300)
 
 ## Approach
 
@@ -97,7 +98,7 @@ it benefits Melbourne/Sydney/Amsterdam regardless of whether UK ships.
 - [x] Follows architectural layering rules — profile stays entirely inside `Ignixa.FhirFakes` (Core), no `Hl7.Fhir.*` dependency, matches existing US/AU profiles' file-per-type layout
 - [x] Developer Experience (works with minimal setup) — `PatientProfileFactory.GetProfile("GB")` and `KnownCities.London` would work with no new setup, same as `KnownCities.Boston` today
 - [x] Specification compliance (if applicable) — profile URL, NHS Number identifier system, and ethnic category CodeSystem/extension URLs are taken directly from the published UK Core IG rather than invented
-- [ ] Consistent with existing patterns — mostly yes, but the postcode-format gap (see above) means UK cities can't fully reuse `SampleZipCode` without either an accepted inaccuracy or a sampler change; this needs a decision before implementation
+- [x] Consistent with existing patterns — the postcode-format gap (see above) was resolved by the `PostalCodeFormat` enum in [country-aware-postal-codes](country-aware-postal-codes.md), so London (and Melbourne/Sydney/Amsterdam) now sample correctly-shaped postal codes through the same `SampleZipCode` method every city uses
 
 ## Evidence
 
@@ -106,15 +107,17 @@ it benefits Melbourne/Sydney/Amsterdam regardless of whether UK ships.
 - Ran a throwaway console app against the restored `Bogus 35.6.5` NuGet package (`~/.nuget/packages/bogus/35.6.5`) to confirm `en_GB` and `en_IE` are real, loadable Bogus locales, not just documented-but-absent ones.
 - Grepped the repo (`UKCore`, `UK Core`, `en_GB`, `NHS number`, `nhs-number`) — no prior UK work exists; only unrelated matches in generated FHIR ValueSet resx files.
 - Checked `docs/adr/` and `docs/site/docs/core-sdk/fhir-fakes.md` — no ADR or documented plan for UK support; NL (Amsterdam) is the only non-US/AU city today and it deliberately ships with `DefaultPatientProfile` (no country-specific extensions), which is the fallback this investigation would improve on for GB specifically.
-- UK Core FHIR IG structure (profile URL, NHS Number system/verification-status codes, Ethnic Category extension URL and ONS 2011 code list) is from HL7 UK Core (`fhir.hl7.org.uk`) — **not yet cross-checked against the current published IG version in this session**; before implementation, re-verify exact StructureDefinition/CodeSystem canonical URLs and code list against the live IG, since UK Core has had multiple versions.
+- UK Core FHIR IG structure (profile URL, NHS Number system/verification-status codes, Ethnic Category extension URL and ONS 2011 code list) is from HL7 UK Core (`fhir.hl7.org.uk`). **Cross-checked against the live IG at implementation time** via web search (`build.fhir.org/ig/HL7-UK/UK-Core-Access`, `fhir.hl7.org.uk` CodeSystem/StructureDefinition pages, NHS Data Dictionary's "ETHNIC CATEGORY" data element) — the profile URL, NHS Number identifier system, both extension URLs, and the full ethnic category code list were confirmed to match the values used in `UKCorePatientProfile.cs` before merge, not just carried over from this doc's original estimate.
 
 ## Verdict
 
-*Pending evaluation.* Three independent decisions to make before implementation:
+**Implemented** — all three decisions below were carried out in PR #300:
 
-1. Ship the `en_GB`/`en_IE` locale fix now regardless of the rest (low risk, no dependencies).
-2. Build `UKCorePatientProfile` following the US/AU pattern (needs canonical URLs re-verified against the live UK Core IG, and real ONS 2021 per-city ethnicity distributions rather than estimates).
-3. Ship the postal code fix — see [country-aware-postal-codes](country-aware-postal-codes.md), which recommends a `PostalCodeFormat` enum on `CityDemographics` and found this already affects Melbourne/Sydney/Amsterdam, not just UK.
+1. Shipped the `en_GB`/`en_IE` locale fix in `DefaultNameGenerationStrategy` (also later extended to the informal `UK` alias, mapped to `en_GB`, following review feedback).
+2. Built `UKCorePatientProfile` following the US/AU pattern, with canonical URLs verified against the live UK Core IG (see updated Evidence above) and a London ethnic-category distribution derived from 2021 Census data.
+3. Shipped the postal code fix — see [country-aware-postal-codes](country-aware-postal-codes.md) — as a `PostalCodeFormat` enum on `CityDemographics`, fixing the already-live Melbourne/Sydney/Amsterdam bug in the same change.
+
+Post-merge review (5 specialized review agents + the `ocr` CLI + Gemini Code Assist) surfaced one real correctness bug not caught before merge: `UKCorePatientProfile.GenerateNhsNumber` used `Random.Shared` instead of the seeded `Bogus.Randomizer`, silently breaking this library's seeded-reproducibility contract for UK Core patients specifically (every other profile's sampling was already seed-aware). Fixed as a follow-up commit on the same PR by threading `Bogus.Randomizer` through `IPatientProfile.BuildIdentifiers`.
 
 ## Alternatives noted for future investigation
 

--- a/docs/features/fhir-faker/investigations/uk-core-patient-profile.md
+++ b/docs/features/fhir-faker/investigations/uk-core-patient-profile.md
@@ -1,0 +1,132 @@
+# Investigation: UK Core Patient Profile
+
+**Feature**: fhir-faker
+**Status**: In Progress
+**Created**: 2026-07-04
+
+## Approach
+
+Add a fourth national `IPatientProfile` implementation — `UKCorePatientProfile` — following the exact
+pattern already established by `USCorePatientProfile` and `AUBasePatientProfile`, plus a small set of
+UK cities in `DemographicsDataProvider`. Two smaller, independent fixes fall out of the same research
+and could ship on their own regardless of whether the full profile is built.
+
+### 1. UKCorePatientProfile (new)
+
+Modeled on the HL7 UK Core FHIR Implementation Guide (`fhir.hl7.org.uk`):
+
+- `ProfileUrl`: `https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient`
+- `CountryCode`: `"GB"`
+- `NameGenerationStrategy`: new `UKCoreNameGenerationStrategy` using Bogus locale `en_GB` (see finding
+  below — this locale exists but is currently unused).
+- `RequiredAttributes`: `["ethnicCategory"]`
+- `BuildExtensions`: UK Core Ethnic Category extension
+  (`https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory`), coded from the ONS
+  2011 census ethnic category CodeSystem (`https://fhir.hl7.org.uk/CodeSystem/UKCore-EthnicCategory`),
+  plus the existing BMI extension pattern shared by all profiles.
+- `BuildIdentifiers`: NHS Number identifier (`system: https://fhir.nhs.uk/Id/nhs-number`), with the
+  `NHSNumberVerificationStatus` extension on the identifier (codes `01`–`06`, e.g. `01` = "Number
+  present and verified"). This is the UK analogue of what AU Base leaves as "not implemented" for
+  Medicare/IHI numbers — NHS Number is the one identifier every UK Core `Patient` example in the IG
+  carries, so it's worth implementing rather than deferring.
+- `SampleProfileAttributes`: samples an ethnic category code from a per-city distribution key
+  (`ethnicCategoryDistribution`), same shape as `EthnicityDistributionKey` (US) and
+  `IndigenousStatusDistributionKey` (AU).
+
+ONS 2011 ethnic category codes (18 total, grouped): White (`A` British, `B` Irish, `C` Other White),
+Mixed (`D` White+Black Caribbean, `E` White+Black African, `F` White+Asian, `G` Other Mixed), Asian
+(`H` Indian, `J` Pakistani, `K` Bangladeshi, `L` Other Asian), Black (`M` Caribbean, `N` African, `P`
+Other Black), Other (`R` Chinese, `S` Other ethnic group), plus `Z` Not stated. This is structurally
+identical to `USCorePatientProfile.Race` — a nested static class of string constants would follow the
+same convention.
+
+### 2. UK/Ireland name locale fix (independent, no profile needed)
+
+`DefaultNameGenerationStrategy.CountryToLocaleMapping` currently maps `GB`, `UK`, and `IE` all to the
+generic `"en"` Bogus locale. Verified against the installed `Bogus 35.6.5` package
+(`~/.nuget/packages/bogus/35.6.5`) that `en_GB` and `en_IE` are real, working locales — not just
+theoretical Bogus features:
+
+```
+en_GB: OK first=Leland last=Rutherford
+en_IE: OK first=Rachel last=Hilpert
+```
+
+This is a one-line-per-entry change to the mapping table regardless of whether `UKCorePatientProfile`
+ships, and would also fix the same gap for Ireland.
+
+### 3. UK cities + postcode format gap
+
+Candidate cities for `DemographicsDataProvider.CreateDefault()`, by population, with dialing code and
+postcode outward-code prefix:
+
+| City | Dialing code | Postcode outward prefix | Nation |
+|---|---|---|---|
+| London | 020 | SW1 (illustrative — London spans dozens of outward codes) | England |
+| Birmingham | 0121 | B1 | England |
+| Manchester | 0161 | M1 | England |
+| Glasgow | 0141 | G1 | Scotland |
+| Edinburgh | 0131 | EH1 | Scotland |
+| Leeds | 0113 | LS1 | England |
+| Liverpool | 0151 | L1 | England |
+| Bristol | 0117 | BS1 | England |
+| Cardiff | 029 | CF10 | Wales |
+| Belfast | 028 | BT1 | Northern Ireland |
+
+**Real blocker, not just missing data — and it turns out to already be live, not just a UK
+problem**: `DemographicsDataProvider.SampleZipCode` unconditionally appends a 2-digit numeric suffix
+(`randomizer.Int(0, 99).ToString("D2")`) to `ZipCodePrefix`. That's correct for a US ZIP (`021` + `05`
+→ `02105`), but it's *already wrong* for the two international cities shipping today — Melbourne
+(`3000` + `05` → `300005`, a 6-digit string, when a real AU postcode is 4 digits) and Amsterdam
+(`1011` + `23` → `101123`, when a real Dutch postcode is `1011 AB`-shaped). A UK postcode would fail
+the same way (`SW1A` + `05` → `SW1A05`, when a real one looks like `SW1A 1AA`). This is spun out into
+its own investigation — see [country-aware-postal-codes](country-aware-postal-codes.md) — since fixing
+it benefits Melbourne/Sydney/Amsterdam regardless of whether UK ships.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Follows an established, well-tested pattern (`IPatientProfile` + `INameGenerationStrategy` + registry) almost exactly — low design risk | UK Core ethnic category (18 ONS codes) is a different shape than US Core race (free-text) or AU indigenous status (5 codes) — needs its own CodeSystem constant, not reuse |
+| NHS Number + verification status is a real, spec-backed identifier every UK Core Patient example uses — good test-data fidelity | Realistic per-city ethnic category *distributions* need real ONS 2021 census data — London's diversity is far above the national average; guessing risks quietly-wrong demographics that look plausible in a demo |
+| en_GB/en_IE locale fix is decoupled — ships independently of everything else, zero risk | UK postcode format doesn't fit the existing numeric-suffix sampler — either ship approximate postcodes now or take on a bigger `DemographicsDataProvider` refactor |
+| Extends country coverage to 4 profiles (US/AU/UK/default-NL), improving international test-data credibility | Adds another `IPatientProfile` singleton + strategy pair to maintain and version alongside FHIR schema/version changes |
+
+## Alignment
+
+- [x] Follows architectural layering rules — profile stays entirely inside `Ignixa.FhirFakes` (Core), no `Hl7.Fhir.*` dependency, matches existing US/AU profiles' file-per-type layout
+- [x] Developer Experience (works with minimal setup) — `PatientProfileFactory.GetProfile("GB")` and `KnownCities.London` would work with no new setup, same as `KnownCities.Boston` today
+- [x] Specification compliance (if applicable) — profile URL, NHS Number identifier system, and ethnic category CodeSystem/extension URLs are taken directly from the published UK Core IG rather than invented
+- [ ] Consistent with existing patterns — mostly yes, but the postcode-format gap (see above) means UK cities can't fully reuse `SampleZipCode` without either an accepted inaccuracy or a sampler change; this needs a decision before implementation
+
+## Evidence
+
+- Read `src/Core/Ignixa.FhirFakes/Builders/Profiles/{IPatientProfile,PatientProfileFactory,USCorePatientProfile,AUBasePatientProfile,AUBaseNameGenerationStrategy,DefaultPatientProfile,DefaultNameGenerationStrategy,INameGenerationStrategy}.cs` — confirmed the profile/strategy contract and registry shape.
+- Read `src/Core/Ignixa.FhirFakes/Population/{DemographicsDataProvider,CityDemographics,KnownCities,LocalBasedNameGenerator}.cs` — confirmed city data lives inline in `DemographicsDataProvider.CreateDefault()`, `CityDemographics.GetProfile()` dispatches via `PatientProfileFactory`, and `SampleZipCode`'s numeric-suffix logic is the format blocker.
+- Ran a throwaway console app against the restored `Bogus 35.6.5` NuGet package (`~/.nuget/packages/bogus/35.6.5`) to confirm `en_GB` and `en_IE` are real, loadable Bogus locales, not just documented-but-absent ones.
+- Grepped the repo (`UKCore`, `UK Core`, `en_GB`, `NHS number`, `nhs-number`) — no prior UK work exists; only unrelated matches in generated FHIR ValueSet resx files.
+- Checked `docs/adr/` and `docs/site/docs/core-sdk/fhir-fakes.md` — no ADR or documented plan for UK support; NL (Amsterdam) is the only non-US/AU city today and it deliberately ships with `DefaultPatientProfile` (no country-specific extensions), which is the fallback this investigation would improve on for GB specifically.
+- UK Core FHIR IG structure (profile URL, NHS Number system/verification-status codes, Ethnic Category extension URL and ONS 2011 code list) is from HL7 UK Core (`fhir.hl7.org.uk`) — **not yet cross-checked against the current published IG version in this session**; before implementation, re-verify exact StructureDefinition/CodeSystem canonical URLs and code list against the live IG, since UK Core has had multiple versions.
+
+## Verdict
+
+*Pending evaluation.* Three independent decisions to make before implementation:
+
+1. Ship the `en_GB`/`en_IE` locale fix now regardless of the rest (low risk, no dependencies).
+2. Build `UKCorePatientProfile` following the US/AU pattern (needs canonical URLs re-verified against the live UK Core IG, and real ONS 2021 per-city ethnicity distributions rather than estimates).
+3. Ship the postal code fix — see [country-aware-postal-codes](country-aware-postal-codes.md), which recommends a `PostalCodeFormat` enum on `CityDemographics` and found this already affects Melbourne/Sydney/Amsterdam, not just UK.
+
+## Alternatives noted for future investigation
+
+- **Country-aware postal code sampling in `DemographicsDataProvider`** — spun out into its own
+  investigation: [country-aware-postal-codes](country-aware-postal-codes.md). Turned out to be more
+  than a UK blocker: `SampleZipCode`'s numeric-suffix logic already produces invalid postcodes for
+  Melbourne, Sydney, and Amsterdam today.
+- **NL (Dutch) Core Patient profile** — Amsterdam already exists as a city but sits on
+  `DefaultPatientProfile` with no country-specific extensions; a `NLCorePatientProfile` would be the
+  same shape of work as this UK investigation, for a country that already has partial data in the
+  system.
+- **Real census/ONS data ingestion instead of hand-maintained per-city dictionaries** — the doc
+  comment on `DemographicsDataProvider` already flags "Future enhancement: Load from demographics.csv
+  for 29,000+ cities"; a UK profile built on hand-estimated ethnicity percentages is exactly the kind
+  of data this future enhancement would replace.

--- a/docs/features/fhir-faker/readme.md
+++ b/docs/features/fhir-faker/readme.md
@@ -16,8 +16,8 @@ Test data generation library for creating realistic FHIR resources across versio
 | [improvements-summary](investigations/improvements-summary.md) | Complete | 2025-12-02 | Implementation summary of cross-version compatibility work |
 | [adversarial-data-generation](investigations/adversarial-data-generation.md) | In Progress | 2026-06-16 | Edge-case/fuzz data as a first-class type — extensible category catalog + seeded decorator pipeline, validity measured & bucketed |
 | [theme-consistent-generation](investigations/theme-consistent-generation.md) | MVP Implemented | 2026-07-04 | Carry a clinical "theme" through generation so sibling coded fields on one resource stay semantically coherent, independent of density |
-| [uk-core-patient-profile](investigations/uk-core-patient-profile.md) | In Progress | 2026-07-04 | UKCorePatientProfile (NHS number + ONS ethnic category) and candidate UK cities, following the US Core/AU Base pattern |
-| [country-aware-postal-codes](investigations/country-aware-postal-codes.md) | In Progress | 2026-07-04 | Fix `SampleZipCode`'s US-shaped numeric-suffix logic — already produces invalid postcodes for Melbourne/Sydney/Amsterdam today, not just a UK blocker |
+| [uk-core-patient-profile](investigations/uk-core-patient-profile.md) | Implemented | 2026-07-04 | UKCorePatientProfile (NHS number + ONS ethnic category) and London, following the US Core/AU Base pattern |
+| [country-aware-postal-codes](investigations/country-aware-postal-codes.md) | Implemented | 2026-07-04 | Fixed `SampleZipCode`'s US-shaped numeric-suffix logic — was already producing invalid postcodes for Melbourne/Sydney/Amsterdam |
 
 ## Overview
 

--- a/docs/features/fhir-faker/readme.md
+++ b/docs/features/fhir-faker/readme.md
@@ -16,6 +16,8 @@ Test data generation library for creating realistic FHIR resources across versio
 | [improvements-summary](investigations/improvements-summary.md) | Complete | 2025-12-02 | Implementation summary of cross-version compatibility work |
 | [adversarial-data-generation](investigations/adversarial-data-generation.md) | In Progress | 2026-06-16 | Edge-case/fuzz data as a first-class type — extensible category catalog + seeded decorator pipeline, validity measured & bucketed |
 | [theme-consistent-generation](investigations/theme-consistent-generation.md) | MVP Implemented | 2026-07-04 | Carry a clinical "theme" through generation so sibling coded fields on one resource stay semantically coherent, independent of density |
+| [uk-core-patient-profile](investigations/uk-core-patient-profile.md) | In Progress | 2026-07-04 | UKCorePatientProfile (NHS number + ONS ethnic category) and candidate UK cities, following the US Core/AU Base pattern |
+| [country-aware-postal-codes](investigations/country-aware-postal-codes.md) | In Progress | 2026-07-04 | Fix `SampleZipCode`'s US-shaped numeric-suffix logic — already produces invalid postcodes for Melbourne/Sydney/Amsterdam today, not just a UK blocker |
 
 ## Overview
 

--- a/docs/superpowers/plans/2026-07-04-postal-code-format-fix.md
+++ b/docs/superpowers/plans/2026-07-04-postal-code-format-fix.md
@@ -1,0 +1,770 @@
+# Country-Aware Postal Code Format Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `DemographicsDataProvider.SampleZipCode` so it produces correctly-shaped postal codes per
+country instead of always appending a US-style 2-digit numeric suffix, and fix
+`OrganizationState.GenerateAddress` hardcoding `Country: "USA"` regardless of which city was actually
+sampled.
+
+**Architecture:** Add a `PostalCodeFormat` enum as a new optional trailing property on the
+`CityDemographics` record (default `NumericSuffix`, preserving current behavior for all 11 existing US
+cities with zero call-site changes). `DemographicsDataProvider.SampleZipCode` switches on
+`city.PostalCodeFormat` instead of always doing US-shaped concatenation. Existing AU/NL cities get
+tagged with their correct format as part of this fix (this is not cosmetic — Melbourne, Sydney, and
+Amsterdam produce invalid postal codes today). `OrganizationState.GenerateAddress` starts reading
+`city.Country` (already present on every `CityDemographics`) instead of a hardcoded literal, matching
+what `PatientBuilder.FromCity` already does.
+
+**Tech Stack:** .NET, C# records/enums, Bogus (`Bogus.Randomizer`), xUnit + Shouldly (existing test
+stack in `Ignixa.FhirFakes.Tests`).
+
+## Global Constraints
+
+- Nullable reference types enabled — no new `#nullable disable`.
+- One type per file — the new enum gets its own file, not appended to `CityDemographics.cs`.
+- No `#region` blocks in new files (existing files that already use them are not touched for that).
+- AAA test structure, BDD naming (`GivenX_WhenY_ThenZ`), using `Shouldly` assertions — match
+  `test/Ignixa.FhirFakes.Tests/Population/PopulationGeneratorTests.cs` conventions exactly.
+- `CancellationToken` rules don't apply here — none of the touched methods are async.
+- This plan does **not** add UK cities or a `UKCorePatientProfile` — that's tracked separately in
+  `docs/features/fhir-faker/investigations/uk-core-patient-profile.md` and is out of scope here. This
+  plan only builds and proves the postal-code mechanism (including its alphanumeric-format arms) and
+  fixes the two already-shipping bugs (AU/NL postcodes, Organization country hardcoding).
+
+## Reviewed by Fable (principal-coding-agent), 2026-07-04
+
+Design confirmed sound: `PostalCodeFormat` as plain data on `CityDemographics` (not a 4th
+strategy/registry axis alongside `IPatientProfile` and name-locale mapping) is the right call —
+`SampleAge`/`SampleGender`/`SampleAreaCode` on the same class are already data-driven, not strategy
+objects, and this problem is the same shape. All "current code" quotes verified byte-accurate against
+the real files; `SampleZipCode` has exactly two callers (`PatientBuilder.cs:726`,
+`OrganizationState.cs:349`), both accounted for. Two things called out but deliberately **not**
+changed by this plan:
+
+- After this fix, auto-generated organizations carry ISO alpha-2 country codes (`"US"`, `"AU"`, `"NL"`)
+  while `OrganizationAddress`'s record default and `OrganizationBuilder.WithAddress`'s default
+  parameter stay `"USA"` (the manual-builder path, unaffected by this fix). This asymmetry is
+  intentional — don't "fix" the manual-path default reflexively; it's a different code path with its
+  own, valid default for when no city context exists.
+- `OrganizationState.GeneratePhoneNumber` draws an *independent* random city from the one
+  `GenerateAddress` uses, so a generated organization can carry, e.g., a Melbourne address with a
+  Boston-shaped phone number. Pre-existing, out of scope here — worth a follow-up ticket alongside the
+  UK Core Patient work.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs` (new) | The enum: `NumericSuffix`, `FixedNumeric`, `DutchAlphaNumeric`, `UkAlphaNumeric` |
+| `src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs` (modify) | Add `PostalCodeFormat PostalCodeFormat = PostalCodeFormat.NumericSuffix` as a trailing optional record parameter |
+| `src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs` (modify) | `SampleZipCode` switches on format, using the existing `Bogus.Randomizer.String2` idiom (already used in `CoverageState.cs`/`OrganizationState.cs`) for letter sampling; tag Melbourne/Sydney as `FixedNumeric` and Amsterdam as `DutchAlphaNumeric` in `CreateDefault()` |
+| `src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs` (modify) | `GenerateAddress` uses `city.Country` instead of the `"USA"` literal |
+| `test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs` (new) | Proves the new property's default and explicit-value construction |
+| `test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs` (new) | Proves `SampleZipCode` produces correctly-shaped output for all four formats, including alphanumeric ones, and for the real Melbourne/Sydney/Amsterdam cities |
+| `test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs` (modify) | Updates the one existing assertion that hardcodes `"USA"` to reflect the corrected, city-driven country |
+
+---
+
+### Task 1: Add `PostalCodeFormat` enum and wire it into `CityDemographics`
+
+**Files:**
+- Create: `src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs`
+- Modify: `src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs`
+- Test: `test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs`
+
+**Interfaces:**
+- Produces: `enum PostalCodeFormat { NumericSuffix, FixedNumeric, DutchAlphaNumeric, UkAlphaNumeric }` in namespace `Ignixa.FhirFakes.Population`; `CityDemographics.PostalCodeFormat` property (default `PostalCodeFormat.NumericSuffix`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs`:
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Shouldly;
+using Ignixa.FhirFakes.Population;
+using Xunit;
+
+namespace Ignixa.FhirFakes.Tests.Population;
+
+/// <summary>
+/// Tests for the CityDemographics record, focused on PostalCodeFormat defaulting behavior.
+/// </summary>
+public class CityDemographicsTests
+{
+    [Fact]
+    public void GivenCityDemographics_WhenPostalCodeFormatNotSpecified_ThenDefaultsToNumericSuffix()
+    {
+        // Arrange & Act
+        var city = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "US",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "000",
+            AreaCodes: ["000"]);
+
+        // Assert
+        city.PostalCodeFormat.ShouldBe(PostalCodeFormat.NumericSuffix);
+    }
+
+    [Theory]
+    [InlineData(PostalCodeFormat.NumericSuffix)]
+    [InlineData(PostalCodeFormat.FixedNumeric)]
+    [InlineData(PostalCodeFormat.DutchAlphaNumeric)]
+    [InlineData(PostalCodeFormat.UkAlphaNumeric)]
+    public void GivenCityDemographics_WhenPostalCodeFormatSpecified_ThenUsesThatValue(PostalCodeFormat format)
+    {
+        // Arrange & Act
+        var city = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "US",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "000",
+            AreaCodes: ["000"],
+            PostalCodeFormat: format);
+
+        // Assert
+        city.PostalCodeFormat.ShouldBe(format);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~CityDemographicsTests"`
+Expected: FAIL — build error, `CityDemographics` has no `PostalCodeFormat` parameter and `Ignixa.FhirFakes.Population.PostalCodeFormat` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs`:
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.FhirFakes.Population;
+
+/// <summary>
+/// Describes the shape a city's postal code should be sampled in, so <see cref="DemographicsDataProvider.SampleZipCode"/>
+/// can generate a realistically-shaped value instead of assuming a single (US) format for every country.
+/// </summary>
+public enum PostalCodeFormat
+{
+    /// <summary>US-style: append a 2-digit numeric suffix to <see cref="CityDemographics.ZipCodePrefix"/> (e.g. "021" -&gt; "02105").</summary>
+    NumericSuffix,
+
+    /// <summary>Fixed code, no suffix — the prefix already is the full code (e.g. Australian postcodes: "3000").</summary>
+    FixedNumeric,
+
+    /// <summary>Dutch-style: the prefix, a space, then 2 random uppercase letters (e.g. "1011" -&gt; "1011 AB").</summary>
+    DutchAlphaNumeric,
+
+    /// <summary>UK-style: the prefix (an alphanumeric outward code), a space, then a digit and 2 random uppercase letters (e.g. "SW1A" -&gt; "SW1A 1AA").</summary>
+    UkAlphaNumeric
+}
+```
+
+Modify `src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs` — the record parameter list currently
+ends with:
+
+```csharp
+public record CityDemographics(
+    string Name,
+    string State,
+    string Country,
+    int Population,
+    Dictionary<string, double> AgeGroupDistribution,
+    double MaleRatio,
+    string ZipCodePrefix,
+    IReadOnlyList<string> AreaCodes,
+    IReadOnlyDictionary<string, object>? Attributes = null
+)
+```
+
+Change it to:
+
+```csharp
+public record CityDemographics(
+    string Name,
+    string State,
+    string Country,
+    int Population,
+    Dictionary<string, double> AgeGroupDistribution,
+    double MaleRatio,
+    string ZipCodePrefix,
+    IReadOnlyList<string> AreaCodes,
+    IReadOnlyDictionary<string, object>? Attributes = null,
+    PostalCodeFormat PostalCodeFormat = PostalCodeFormat.NumericSuffix
+)
+```
+
+Also add a `<param>` doc-comment line above the record (next to the existing `<param name="Attributes">`
+line) so the public API stays documented:
+
+```csharp
+/// <param name="PostalCodeFormat">The postal code shape to sample in (default: US-style numeric suffix). See <see cref="Population.PostalCodeFormat"/>.</param>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~CityDemographicsTests"`
+Expected: PASS (5 tests: 1 default + 4 theory cases)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs
+git commit -m "feat(fhir-faker): add PostalCodeFormat to CityDemographics"
+```
+
+---
+
+### Task 2: Make `SampleZipCode` format-aware
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs:458-472`
+- Test: `test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `PostalCodeFormat` enum and `CityDemographics.PostalCodeFormat` from Task 1.
+- Produces: `DemographicsDataProvider.SampleZipCode(CityDemographics, Bogus.Randomizer)` now format-aware — same signature, no callers need to change yet (Task 3 changes what data flows through it).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs`:
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Shouldly;
+using Ignixa.FhirFakes.Population;
+using Xunit;
+
+namespace Ignixa.FhirFakes.Tests.Population;
+
+/// <summary>
+/// Tests for DemographicsDataProvider.SampleZipCode across all PostalCodeFormat shapes.
+/// </summary>
+public class DemographicsDataProviderTests
+{
+    private static CityDemographics MakeCity(string zipCodePrefix, PostalCodeFormat format) =>
+        new(
+            Name: "Testville",
+            State: "Test State",
+            Country: "XX",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: zipCodePrefix,
+            AreaCodes: ["000"],
+            PostalCodeFormat: format);
+
+    [Fact]
+    public void GivenNumericSuffixFormat_WhenSamplingZipCode_ThenAppendsTwoDigitSuffix()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("021", PostalCodeFormat.NumericSuffix);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^021\\d{2}$");
+    }
+
+    [Fact]
+    public void GivenFixedNumericFormat_WhenSamplingZipCode_ThenReturnsPrefixUnchanged()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("3000", PostalCodeFormat.FixedNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldBe("3000");
+    }
+
+    [Fact]
+    public void GivenDutchAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsFourDigitsSpaceTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("1011", PostalCodeFormat.DutchAlphaNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^1011 [A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenUkAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsOutwardCodeSpaceDigitTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^SW1A \\d[A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenSameSeed_WhenSamplingZipCodeTwice_ThenReturnsSameValue()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+
+        // Act
+        var first = provider.SampleZipCode(city, new Bogus.Randomizer(42));
+        var second = provider.SampleZipCode(city, new Bogus.Randomizer(42));
+
+        // Assert
+        first.ShouldBe(second);
+    }
+}
+```
+
+Note: `ShouldMatch` is an ordinary Shouldly string-assertion extension (same package as every other
+`.ShouldBe`/`.ShouldNotBeNullOrEmpty` call in the test suite) — it takes a regex pattern string
+directly, so no `System.Text.RegularExpressions` using is needed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~DemographicsDataProviderTests"`
+Expected: FAIL — `GivenFixedNumericFormat...` gets `"300047"` instead of `"3000"`; `GivenDutchAlphaNumericFormat...`
+and `GivenUkAlphaNumericFormat...` get a numeric-only suffix instead of the letter pattern.
+`GivenNumericSuffixFormat...` and the determinism test should already PASS (current behavior).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs`, replacing the existing
+`SampleZipCode` method **including its XML doc comment** (lines 458-472, from the `/// <summary>` line
+through the method's closing brace):
+
+```csharp
+    /// <summary>
+    /// Samples a postal code from the city's postal code range, shaped according to
+    /// <see cref="CityDemographics.PostalCodeFormat"/>.
+    /// </summary>
+    /// <param name="city">City demographics.</param>
+    /// <param name="randomizer">The seeded randomizer used for postal code sampling.</param>
+    /// <example>
+    /// Boston (prefix "021", NumericSuffix) → "02101", "02142", "02298", etc.
+    /// Melbourne (prefix "3000", FixedNumeric) → "3000".
+    /// Amsterdam (prefix "1011", DutchAlphaNumeric) → "1011 AB", etc.
+    /// London (prefix "SW1A", UkAlphaNumeric) → "SW1A 1AA", etc.
+    /// </example>
+    public string SampleZipCode(CityDemographics city, Bogus.Randomizer randomizer)
+    {
+        ArgumentNullException.ThrowIfNull(randomizer);
+
+        const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        return city.PostalCodeFormat switch
+        {
+            PostalCodeFormat.FixedNumeric => city.ZipCodePrefix,
+            PostalCodeFormat.DutchAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.String2(2, letters)}",
+            PostalCodeFormat.UkAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.Int(0, 9)}{randomizer.String2(2, letters)}",
+            _ => city.ZipCodePrefix + randomizer.Int(0, 99).ToString("D2"),
+        };
+    }
+```
+
+`randomizer.String2(length, chars)` is the existing codebase idiom for sampling a random string from a
+character set — already used identically in `CoverageState.cs:274`
+(`_faker.Random.String2(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")`) and `OrganizationState.cs:190/206`. No new
+private helper method needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~DemographicsDataProviderTests"`
+Expected: PASS (5 tests)
+
+Also re-run the pre-existing zip/area code tests to confirm no regression:
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~PopulationGeneratorTests"`
+Expected: PASS (unchanged — Boston/Massachusetts cities still default to `NumericSuffix`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
+git commit -m "fix(fhir-faker): make SampleZipCode format-aware instead of always US-shaped"
+```
+
+---
+
+### Task 3: Tag Melbourne, Sydney, and Amsterdam with their correct format
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs:339-394` (the `CreateDefault()` `AddCity` calls for Melbourne, Sydney, Amsterdam)
+- Test: extend `test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs`
+
+**Interfaces:**
+- Consumes: `PostalCodeFormat` (Task 1), format-aware `SampleZipCode` (Task 2), `KnownCities.Melbourne` / `KnownCities.Sydney` / `KnownCities.Amsterdam` (existing, `src/Core/Ignixa.FhirFakes/Population/KnownCities.cs`).
+- Produces: nothing new for later tasks — this is a leaf data fix.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs`:
+
+```csharp
+    [Theory]
+    [InlineData("Melbourne")]
+    [InlineData("Sydney")]
+    public void GivenAustralianKnownCity_WhenSamplingZipCode_ThenReturnsExactFourDigitPostcode(string cityName)
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = provider.Cities.First(c => c.Name == cityName);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldBe(city.ZipCodePrefix);
+        zipCode.Length.ShouldBe(4);
+    }
+
+    [Fact]
+    public void GivenAmsterdam_WhenSamplingZipCode_ThenReturnsFourDigitsSpaceTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = provider.Cities.First(c => c.Name == "Amsterdam");
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^1011 [A-Z]{2}$");
+    }
+```
+
+This requires `using System.Linq;` — add it to the file's usings if not already present via implicit
+usings (this project has `<ImplicitUsings>enable</ImplicitUsings>`, so `System.Linq` is already
+available without an explicit `using`; verify by checking the `.csproj` if the build fails on `.First`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~DemographicsDataProviderTests"`
+Expected: FAIL — Melbourne/Sydney get 6-digit output (`PostalCodeFormat` still defaults to
+`NumericSuffix` for these cities); Amsterdam gets a numeric-only 6-digit string instead of the
+letter-suffixed pattern.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs`, the Melbourne `AddCity` call
+currently ends with:
+
+```csharp
+        provider.AddCity(new CityDemographics(
+            Name: "Melbourne",
+            State: "Victoria",
+            Country: "AU",
+            Population: 5_078_000,
+            AgeGroupDistribution: new() {
+                ["0-17"] = 0.195,
+                ["18-44"] = 0.445,
+                ["45-64"] = 0.265,
+                ["65+"] = 0.095
+            },
+            MaleRatio: 0.495,
+            ZipCodePrefix: "3000",
+            AreaCodes: ["03"],
+            Attributes: new Dictionary<string, object>
+            {
+                [AUBasePatientProfile.IndigenousStatusDistributionKey] = australianIndigenousDistribution
+            }
+        ));
+```
+
+Add `PostalCodeFormat: PostalCodeFormat.FixedNumeric` after the `Attributes` argument:
+
+```csharp
+        provider.AddCity(new CityDemographics(
+            Name: "Melbourne",
+            State: "Victoria",
+            Country: "AU",
+            Population: 5_078_000,
+            AgeGroupDistribution: new() {
+                ["0-17"] = 0.195,
+                ["18-44"] = 0.445,
+                ["45-64"] = 0.265,
+                ["65+"] = 0.095
+            },
+            MaleRatio: 0.495,
+            ZipCodePrefix: "3000",
+            AreaCodes: ["03"],
+            Attributes: new Dictionary<string, object>
+            {
+                [AUBasePatientProfile.IndigenousStatusDistributionKey] = australianIndigenousDistribution
+            },
+            PostalCodeFormat: PostalCodeFormat.FixedNumeric
+        ));
+```
+
+Do the same for the Sydney `AddCity` call (same shape, `ZipCodePrefix: "2000"`) — add
+`PostalCodeFormat: PostalCodeFormat.FixedNumeric` as the last named argument.
+
+The Amsterdam `AddCity` call currently ends with:
+
+```csharp
+        provider.AddCity(new CityDemographics(
+            Name: "Amsterdam",
+            State: "North Holland",
+            Country: "NL",
+            Population: 872_680,
+            AgeGroupDistribution: new() {
+                ["0-17"] = 0.165,
+                ["18-44"] = 0.475,
+                ["45-64"] = 0.245,
+                ["65+"] = 0.115
+            },
+            MaleRatio: 0.498,
+            ZipCodePrefix: "1011",
+            AreaCodes: ["020"]
+            // No profile-specific attributes for Amsterdam
+        ));
+```
+
+Change it to:
+
+```csharp
+        provider.AddCity(new CityDemographics(
+            Name: "Amsterdam",
+            State: "North Holland",
+            Country: "NL",
+            Population: 872_680,
+            AgeGroupDistribution: new() {
+                ["0-17"] = 0.165,
+                ["18-44"] = 0.475,
+                ["45-64"] = 0.245,
+                ["65+"] = 0.115
+            },
+            MaleRatio: 0.498,
+            ZipCodePrefix: "1011",
+            AreaCodes: ["020"],
+            PostalCodeFormat: PostalCodeFormat.DutchAlphaNumeric
+        ));
+```
+
+(The pre-existing `// No profile-specific attributes for Amsterdam` comment is dropped rather than
+re-homed — it stated the obvious once `Attributes` is simply absent from the call, and CLAUDE.md's
+comment rule is why-not-what.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~DemographicsDataProviderTests"`
+Expected: PASS (8 tests total in this file)
+
+Run the full FhirFakes test suite to confirm nothing else regressed:
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj`
+Expected: PASS, 0 failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
+git commit -m "fix(fhir-faker): correct Melbourne/Sydney/Amsterdam postal code formats"
+```
+
+---
+
+### Task 4: Fix `OrganizationState` hardcoded `Country: "USA"`
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs:345-364`
+- Modify: `test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs:449-468`
+
+**Interfaces:**
+- Consumes: `CityDemographics.Country` (existing property, unchanged).
+- Produces: nothing new for later tasks — this is a leaf fix, independent of Tasks 1-3 (it does not
+  touch `PostalCodeFormat` at all, only the `Country` field of the same already-in-scope `city`
+  variable in `GenerateAddress`).
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the existing test in `test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs` (currently at
+lines 449-468):
+
+```csharp
+    [Fact]
+    public void GivenOrganization_WhenGenerated_ThenHasAddress()
+    {
+        // Arrange & Act
+        var scenario = new ScenarioBuilder(_schemaProvider)
+            .WithPatient()
+            .AddHospital()
+            .Build();
+
+        // Assert
+        var organization = scenario.Organizations[0];
+        var addresses = organization.MutableNode["address"];
+        addresses.ShouldNotBeNull();
+
+        var address = addresses![0];
+        address!["city"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
+        address["state"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
+        address["postalCode"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
+        address["country"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void GivenOrganization_WhenGeneratedFromKnownCity_ThenCountryMatchesThatCitysCountry()
+    {
+        // Arrange
+        var demographics = DemographicsDataProvider.CreateDefault();
+
+        // Act
+        var scenario = new ScenarioBuilder(_schemaProvider)
+            .WithPatient()
+            .AddHospital()
+            .Build();
+
+        // Assert
+        var organization = scenario.Organizations[0];
+        var address = organization.MutableNode["address"]![0];
+        var cityName = address!["city"]?.GetValue<string>();
+        var country = address["country"]?.GetValue<string>();
+
+        cityName.ShouldNotBeNullOrEmpty();
+        var matchingCity = demographics.Cities.First(c => c.Name == cityName);
+        country.ShouldBe(matchingCity.Country);
+    }
+```
+
+This requires `using Ignixa.FhirFakes.Population;` and `using System.Linq;` in
+`OrganizationStateTests.cs` — add `using Ignixa.FhirFakes.Population;` to the file's using block
+(`System.Linq` is available via implicit usings, same as Task 3).
+
+This test is deterministic in both directions, not probabilistic: `GenerateAddress` always returns the
+literal `"USA"` today, and every `CityDemographics.Country` in `CreateDefault()` is an ISO alpha-2 code
+(`"US"`, `"AU"`, `"NL"`) — `"USA"` never equals any of them, so the assertion fails on every run
+pre-fix regardless of which city gets randomly sampled, not just when an AU/NL city happens to be
+picked. No seeding or loop is needed to make the failure reliable — a straight string-equality check
+already is.
+
+Also update the other pre-existing literal in the same file (line 479,
+`GivenOrganizationWithCustomAddress_WhenGenerated_ThenUsesCustomAddress`) — **no change needed there**:
+that test constructs an explicit `OrganizationAddress` with `Country: "USA"` directly (the manual
+builder path), which is unaffected by this fix (see Step 3 — only the auto-generated path in
+`GenerateAddress` changes).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~GivenOrganization_WhenGeneratedFromKnownCity_ThenCountryMatchesThatCitysCountry"`
+Expected: FAIL, every run — `country` is `"USA"`, `matchingCity.Country` is `"US"`/`"AU"`/`"NL"`
+depending on which city was sampled; `ShouldBe` reports the mismatch regardless of which city that was.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs`, the `GenerateAddress` method
+currently is:
+
+```csharp
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Used for test data generation only")]
+    private OrganizationAddress GenerateAddress()
+    {
+        var city = _demographics.Cities[_faker.Random.Int(0, _demographics.Cities.Count - 1)];
+        var zipCode = _demographics.SampleZipCode(city, _faker.Random);
+        var streetNumber = _faker.Random.Int(100, 9999);
+        var streetName = _faker.Address.StreetName();
+        var streetSuffix = _faker.Random.Bool() ? "Suite " + _faker.Random.Int(100, 999) : null;
+        var line = streetSuffix is not null
+            ? $"{streetNumber} {streetName}, {streetSuffix}"
+            : $"{streetNumber} {streetName}";
+
+        return new OrganizationAddress(
+            Line: line,
+            City: city.Name,
+            State: city.State,
+            PostalCode: zipCode,
+            Country: "USA"
+        );
+    }
+```
+
+Change the `Country:` argument to read from the sampled city:
+
+```csharp
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Used for test data generation only")]
+    private OrganizationAddress GenerateAddress()
+    {
+        var city = _demographics.Cities[_faker.Random.Int(0, _demographics.Cities.Count - 1)];
+        var zipCode = _demographics.SampleZipCode(city, _faker.Random);
+        var streetNumber = _faker.Random.Int(100, 9999);
+        var streetName = _faker.Address.StreetName();
+        var streetSuffix = _faker.Random.Bool() ? "Suite " + _faker.Random.Int(100, 999) : null;
+        var line = streetSuffix is not null
+            ? $"{streetNumber} {streetName}, {streetSuffix}"
+            : $"{streetNumber} {streetName}";
+
+        return new OrganizationAddress(
+            Line: line,
+            City: city.Name,
+            State: city.State,
+            PostalCode: zipCode,
+            Country: city.Country
+        );
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj --filter "FullyQualifiedName~OrganizationStateTests"`
+Expected: PASS, all tests in the file green (including the updated
+`GivenOrganization_WhenGenerated_ThenHasAddress` and the new
+`GivenOrganization_WhenGeneratedFromKnownCity_ThenCountryMatchesThatCitysCountry`) — deterministically,
+regardless of which city the random draw picks, since the assertion now compares against that same
+city's own `Country` rather than a fixed set.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs
+git commit -m "fix(fhir-faker): Organization address country now reflects the sampled city, not a hardcoded USA"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full solution build: `dotnet build All.sln` — expect 0 warnings, 0 errors.
+- [ ] Run the full FhirFakes test project: `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj` — expect 0 failures.
+- [ ] Confirm no other project references `CityDemographics`'s positional constructor in a way that
+  would break from the new trailing parameter (it's optional, so this should be a non-issue, but worth
+  a final `dotnet build All.sln` pass across the whole solution, not just this test project).

--- a/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
@@ -863,9 +863,10 @@ public sealed class PatientBuilder : FhirResourceBuilder<PatientBuilder>
             patientJson["multipleBirthBoolean"] = _multipleBirthBoolean.Value;
         }
 
-        if (HasIdentifiers())
+        var identifiers = BuildIdentifiers();
+        if (identifiers.Count > 0)
         {
-            patientJson["identifier"] = BuildIdentifiers();
+            patientJson["identifier"] = identifiers;
         }
 
         var resource = JsonSourceNodeFactory.Parse<ResourceJsonNode>(patientJson);
@@ -1228,17 +1229,12 @@ public sealed class PatientBuilder : FhirResourceBuilder<PatientBuilder>
         return this;
     }
 
-    private bool HasIdentifiers()
-    {
-        return _identifiers.Count > 0 || _profile.BuildIdentifiers(_profileAttributes) is not null;
-    }
-
     private JsonArray BuildIdentifiers()
     {
         var identifierArray = new JsonArray();
 
         // Profile-specific identifiers (e.g. UK Core NHS Number)
-        var profileIdentifiers = _profile.BuildIdentifiers(_profileAttributes);
+        var profileIdentifiers = _profile.BuildIdentifiers(_profileAttributes, _faker.Random);
         if (profileIdentifiers is not null)
         {
             foreach (var identifier in profileIdentifiers)

--- a/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/PatientBuilder.cs
@@ -1230,12 +1230,22 @@ public sealed class PatientBuilder : FhirResourceBuilder<PatientBuilder>
 
     private bool HasIdentifiers()
     {
-        return _identifiers.Count > 0;
+        return _identifiers.Count > 0 || _profile.BuildIdentifiers(_profileAttributes) is not null;
     }
 
     private JsonArray BuildIdentifiers()
     {
         var identifierArray = new JsonArray();
+
+        // Profile-specific identifiers (e.g. UK Core NHS Number)
+        var profileIdentifiers = _profile.BuildIdentifiers(_profileAttributes);
+        if (profileIdentifiers is not null)
+        {
+            foreach (var identifier in profileIdentifiers)
+            {
+                identifierArray.Add(identifier);
+            }
+        }
 
         foreach (var config in _identifiers)
         {

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/AUBasePatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/AUBasePatientProfile.cs
@@ -108,7 +108,7 @@ public sealed class AUBasePatientProfile : IPatientProfile
     }
 
     /// <inheritdoc />
-    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes)
+    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes, Bogus.Randomizer randomizer)
     {
         // AU Base could include Medicare number, IHI, DVA number, etc.
         // Not implemented in this initial version

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultNameGenerationStrategy.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultNameGenerationStrategy.cs
@@ -38,7 +38,7 @@ public sealed class DefaultNameGenerationStrategy : INameGenerationStrategy
         ["DE"] = "de",        // German
         ["FR"] = "fr",        // French
         ["GB"] = "en_GB",     // English (Great Britain)
-        ["UK"] = "en",        // English
+        ["UK"] = "en_GB",     // English (Great Britain)
         ["IE"] = "en_IE",     // English (Ireland)
         ["BE"] = "nl",        // Dutch (Belgium)
         ["CH"] = "de",        // German (Switzerland)

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultNameGenerationStrategy.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultNameGenerationStrategy.cs
@@ -37,9 +37,9 @@ public sealed class DefaultNameGenerationStrategy : INameGenerationStrategy
         ["NL"] = "nl",        // Dutch
         ["DE"] = "de",        // German
         ["FR"] = "fr",        // French
-        ["GB"] = "en",        // English
+        ["GB"] = "en_GB",     // English (Great Britain)
         ["UK"] = "en",        // English
-        ["IE"] = "en",        // English (Ireland)
+        ["IE"] = "en_IE",     // English (Ireland)
         ["BE"] = "nl",        // Dutch (Belgium)
         ["CH"] = "de",        // German (Switzerland)
         ["AT"] = "de",        // German (Austria)

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultPatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/DefaultPatientProfile.cs
@@ -55,7 +55,7 @@ public sealed class DefaultPatientProfile : IPatientProfile
     }
 
     /// <inheritdoc />
-    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes)
+    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes, Bogus.Randomizer randomizer)
     {
         // Default profile has no specific identifiers
         return null;

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/IPatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/IPatientProfile.cs
@@ -71,8 +71,9 @@ public interface IPatientProfile
     /// Builds profile-specific identifiers from the provided attributes.
     /// </summary>
     /// <param name="attributes">Profile-specific attributes sampled from demographics</param>
+    /// <param name="randomizer">The seeded randomizer that is the sole source of randomness for identifier generation</param>
     /// <returns>Collection of identifier JsonObjects to add to the patient resource, or null if none</returns>
-    IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes);
+    IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes, Bogus.Randomizer randomizer);
 
     /// <summary>
     /// Validates that all required attributes are present.

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/PatientProfileFactory.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/PatientProfileFactory.cs
@@ -19,6 +19,7 @@ public static class PatientProfileFactory
         ["US"] = USCorePatientProfile.Instance,
         ["AU"] = AUBasePatientProfile.Instance,
         ["GB"] = UKCorePatientProfile.Instance,
+        ["UK"] = UKCorePatientProfile.Instance,
     };
 
     /// <summary>

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/PatientProfileFactory.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/PatientProfileFactory.cs
@@ -18,6 +18,7 @@ public static class PatientProfileFactory
     {
         ["US"] = USCorePatientProfile.Instance,
         ["AU"] = AUBasePatientProfile.Instance,
+        ["GB"] = UKCorePatientProfile.Instance,
     };
 
     /// <summary>
@@ -46,6 +47,11 @@ public static class PatientProfileFactory
     /// Gets the AU Base profile.
     /// </summary>
     public static IPatientProfile AUBase => AUBasePatientProfile.Instance;
+
+    /// <summary>
+    /// Gets the UK Core profile.
+    /// </summary>
+    public static IPatientProfile UKCore => UKCorePatientProfile.Instance;
 
     /// <summary>
     /// Gets the default profile (no country-specific extensions).

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCoreNameGenerationStrategy.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCoreNameGenerationStrategy.cs
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.FhirFakes.Population;
+
+namespace Ignixa.FhirFakes.Builders.Profiles;
+
+/// <summary>
+/// Name generation strategy for UK Core Patient Profile.
+/// </summary>
+/// <remarks>
+/// Generates culturally appropriate British names using the LocalBasedNameGenerator.
+/// Uses the English (Great Britain) locale ("en_GB"), which reflects the majority
+/// population in the United Kingdom. The strategy does NOT use US race categories for name generation.
+/// </remarks>
+public sealed class UKCoreNameGenerationStrategy : INameGenerationStrategy
+{
+    private readonly LocalBasedNameGenerator _nameGenerator;
+
+    /// <summary>
+    /// Singleton instance of the UK Core name generation strategy.
+    /// </summary>
+    public static readonly UKCoreNameGenerationStrategy Instance = new(new LocalBasedNameGenerator());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UKCoreNameGenerationStrategy"/> class.
+    /// </summary>
+    /// <param name="nameGenerator">The locale-based name generator to use</param>
+    public UKCoreNameGenerationStrategy(LocalBasedNameGenerator nameGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(nameGenerator);
+        _nameGenerator = nameGenerator;
+    }
+
+    /// <inheritdoc />
+    public (string GivenName, string FamilyName) GenerateName(
+        string gender,
+        IReadOnlyDictionary<string, object> profileAttributes,
+        string? countryCode,
+        Bogus.Randomizer randomizer)
+    {
+        // For UK patients, use the British English locale directly.
+        // This generates appropriate British names which represent
+        // the majority population demographic in the United Kingdom.
+        return _nameGenerator.GenerateName("en_GB", gender, randomizer);
+    }
+}

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCorePatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCorePatientProfile.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json.Nodes;
 using Ignixa.FhirFakes.Population;
@@ -22,9 +21,8 @@ namespace Ignixa.FhirFakes.Builders.Profiles;
 /// Ethnic category codes follow the ONS 2011 census / NHS Data Dictionary "ETHNIC CATEGORY" data element.
 ///
 /// Required attributes from demographics:
-/// - "ethnicCategory": ONS ethnic category code ("A".."S", "Z")
+/// - "ethnicCategory": one of the <see cref="EthnicCategory"/> codes (letters A-S skip I, O, and Q; plus Z for "Not stated")
 /// </remarks>
-[SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Random is used for test data generation only")]
 public sealed class UKCorePatientProfile : IPatientProfile
 {
     /// <summary>
@@ -175,12 +173,12 @@ public sealed class UKCorePatientProfile : IPatientProfile
     }
 
     /// <inheritdoc />
-    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes)
+    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes, Bogus.Randomizer randomizer)
     {
         yield return new JsonObject
         {
             ["system"] = "https://fhir.nhs.uk/Id/nhs-number",
-            ["value"] = GenerateNhsNumber(),
+            ["value"] = GenerateNhsNumber(randomizer),
             ["extension"] = new JsonArray
             {
                 new JsonObject
@@ -207,7 +205,9 @@ public sealed class UKCorePatientProfile : IPatientProfile
     public bool ValidateAttributes(IReadOnlyDictionary<string, object> attributes)
     {
         // Ethnic category is required for UK Core
-        return attributes.ContainsKey(EthnicCategoryAttribute);
+        return attributes.TryGetValue(EthnicCategoryAttribute, out var value)
+            && value is string code
+            && !string.IsNullOrEmpty(code);
     }
 
     /// <inheritdoc />
@@ -229,7 +229,7 @@ public sealed class UKCorePatientProfile : IPatientProfile
     /// </summary>
     /// <param name="city">City demographics containing an ethnic category distribution</param>
     /// <param name="randomizer">The seeded randomizer used for weighted sampling</param>
-    /// <returns>Ethnic category code ("A".."S", "Z")</returns>
+    /// <returns>One of the <see cref="EthnicCategory"/> codes</returns>
     /// <remarks>
     /// Uses weighted random sampling based on the city's ethnic category distribution from Attributes.
     /// If no distribution is provided, falls back to <see cref="EthnicCategory.British"/>.
@@ -269,7 +269,7 @@ public sealed class UKCorePatientProfile : IPatientProfile
     /// the products are summed, and the check digit is <c>11 - (sum mod 11)</c>. A result of 11 becomes
     /// 0; a result of 10 is invalid, so the base is regenerated.
     /// </remarks>
-    private static string GenerateNhsNumber()
+    private static string GenerateNhsNumber(Bogus.Randomizer randomizer)
     {
         while (true)
         {
@@ -278,7 +278,7 @@ public sealed class UKCorePatientProfile : IPatientProfile
 
             for (var i = 0; i < 9; i++)
             {
-                digits[i] = Random.Shared.Next(0, 10);
+                digits[i] = randomizer.Int(0, 9);
                 sum += digits[i] * (10 - i);
             }
 

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCorePatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/UKCorePatientProfile.cs
@@ -1,0 +1,301 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Ignixa.FhirFakes.Population;
+
+namespace Ignixa.FhirFakes.Builders.Profiles;
+
+/// <summary>
+/// UK Core Patient Profile implementation.
+/// </summary>
+/// <remarks>
+/// Implements the HL7 UK Core FHIR Patient profile with:
+/// - Ethnic Category extension (https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory)
+/// - NHS Number identifier (https://fhir.nhs.uk/Id/nhs-number) with verification-status extension
+/// - BMI extension (if provided)
+///
+/// Ethnic category codes follow the ONS 2011 census / NHS Data Dictionary "ETHNIC CATEGORY" data element.
+///
+/// Required attributes from demographics:
+/// - "ethnicCategory": ONS ethnic category code ("A".."S", "Z")
+/// </remarks>
+[SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Random is used for test data generation only")]
+public sealed class UKCorePatientProfile : IPatientProfile
+{
+    /// <summary>
+    /// Singleton instance of the UK Core profile.
+    /// </summary>
+    public static readonly UKCorePatientProfile Instance = new();
+
+    /// <summary>
+    /// Attribute key for ethnic category distribution in city attributes.
+    /// </summary>
+    public const string EthnicCategoryDistributionKey = "ethnicCategoryDistribution";
+
+    /// <summary>
+    /// Attribute key for ethnic category.
+    /// </summary>
+    public const string EthnicCategoryAttribute = "ethnicCategory";
+
+    /// <summary>
+    /// ONS / NHS Data Dictionary ethnic category codes (maps to FHIR Extension-UKCore-EthnicCategory).
+    /// </summary>
+    public static class EthnicCategory
+    {
+        /// <summary>British, White.</summary>
+        public const string British = "A";
+
+        /// <summary>Irish.</summary>
+        public const string Irish = "B";
+
+        /// <summary>Any other White background.</summary>
+        public const string OtherWhite = "C";
+
+        /// <summary>White and Black Caribbean.</summary>
+        public const string WhiteAndBlackCaribbean = "D";
+
+        /// <summary>White and Black African.</summary>
+        public const string WhiteAndBlackAfrican = "E";
+
+        /// <summary>White and Asian.</summary>
+        public const string WhiteAndAsian = "F";
+
+        /// <summary>Any other Mixed background.</summary>
+        public const string OtherMixed = "G";
+
+        /// <summary>Indian.</summary>
+        public const string Indian = "H";
+
+        /// <summary>Pakistani.</summary>
+        public const string Pakistani = "J";
+
+        /// <summary>Bangladeshi.</summary>
+        public const string Bangladeshi = "K";
+
+        /// <summary>Any other Asian background.</summary>
+        public const string OtherAsian = "L";
+
+        /// <summary>Caribbean.</summary>
+        public const string Caribbean = "M";
+
+        /// <summary>African.</summary>
+        public const string African = "N";
+
+        /// <summary>Any other Black background.</summary>
+        public const string OtherBlack = "P";
+
+        /// <summary>Chinese.</summary>
+        public const string Chinese = "R";
+
+        /// <summary>Any other ethnic group.</summary>
+        public const string OtherEthnicGroup = "S";
+
+        /// <summary>Not stated.</summary>
+        public const string NotStated = "Z";
+    }
+
+    /// <summary>
+    /// Ethnic category display values by code.
+    /// </summary>
+    private static readonly Dictionary<string, string> EthnicCategoryDisplay = new()
+    {
+        ["A"] = "British, White",
+        ["B"] = "Irish",
+        ["C"] = "Any other White background",
+        ["D"] = "White and Black Caribbean",
+        ["E"] = "White and Black African",
+        ["F"] = "White and Asian",
+        ["G"] = "Any other Mixed background",
+        ["H"] = "Indian",
+        ["J"] = "Pakistani",
+        ["K"] = "Bangladeshi",
+        ["L"] = "Any other Asian background",
+        ["M"] = "Caribbean",
+        ["N"] = "African",
+        ["P"] = "Any other Black background",
+        ["R"] = "Chinese",
+        ["S"] = "Any other ethnic group",
+        ["Z"] = "Not stated"
+    };
+
+    /// <inheritdoc />
+    public INameGenerationStrategy NameGenerationStrategy => UKCoreNameGenerationStrategy.Instance;
+
+    /// <inheritdoc />
+    public string ProfileUrl => "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient";
+
+    /// <inheritdoc />
+    public string CountryCode => "GB";
+
+    /// <inheritdoc />
+    public IEnumerable<string> RequiredAttributes => [EthnicCategoryAttribute];
+
+    /// <inheritdoc />
+    public IEnumerable<JsonObject> BuildExtensions(
+        IReadOnlyDictionary<string, object> attributes,
+        decimal? bmi)
+    {
+        // UK Core Ethnic Category Extension
+        if (attributes.TryGetValue(EthnicCategoryAttribute, out var categoryValue) && categoryValue is string code && !string.IsNullOrEmpty(code))
+        {
+            var display = EthnicCategoryDisplay.TryGetValue(code, out var d) ? d : "Unknown";
+
+            yield return new JsonObject
+            {
+                ["url"] = "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory",
+                ["valueCodeableConcept"] = new JsonObject
+                {
+                    ["coding"] = new JsonArray
+                    {
+                        new JsonObject
+                        {
+                            ["system"] = "https://fhir.hl7.org.uk/CodeSystem/UKCore-EthnicCategory",
+                            ["code"] = code,
+                            ["display"] = display
+                        }
+                    }
+                }
+            };
+        }
+
+        // BMI Extension (if provided)
+        if (bmi.HasValue)
+        {
+            yield return new JsonObject
+            {
+                ["url"] = "http://ignixa.dev/StructureDefinition/patient-bmi",
+                ["valueDecimal"] = bmi.Value
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes)
+    {
+        yield return new JsonObject
+        {
+            ["system"] = "https://fhir.nhs.uk/Id/nhs-number",
+            ["value"] = GenerateNhsNumber(),
+            ["extension"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["url"] = "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus",
+                    ["valueCodeableConcept"] = new JsonObject
+                    {
+                        ["coding"] = new JsonArray
+                        {
+                            new JsonObject
+                            {
+                                ["system"] = "https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus",
+                                ["code"] = "01",
+                                ["display"] = "Number present and verified"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    /// <inheritdoc />
+    public bool ValidateAttributes(IReadOnlyDictionary<string, object> attributes)
+    {
+        // Ethnic category is required for UK Core
+        return attributes.ContainsKey(EthnicCategoryAttribute);
+    }
+
+    /// <inheritdoc />
+    public Dictionary<string, object> SampleProfileAttributes(CityDemographics city, Bogus.Randomizer randomizer)
+    {
+        ArgumentNullException.ThrowIfNull(city);
+        ArgumentNullException.ThrowIfNull(randomizer);
+
+        var attributes = new Dictionary<string, object>();
+
+        // Sample ethnic category from city's distribution
+        attributes[EthnicCategoryAttribute] = SampleEthnicCategory(city, randomizer);
+
+        return attributes;
+    }
+
+    /// <summary>
+    /// Samples an ONS ethnic category code from the city's distribution.
+    /// </summary>
+    /// <param name="city">City demographics containing an ethnic category distribution</param>
+    /// <param name="randomizer">The seeded randomizer used for weighted sampling</param>
+    /// <returns>Ethnic category code ("A".."S", "Z")</returns>
+    /// <remarks>
+    /// Uses weighted random sampling based on the city's ethnic category distribution from Attributes.
+    /// If no distribution is provided, falls back to <see cref="EthnicCategory.British"/>.
+    /// If the distribution probabilities don't sum to 1.0, falls back to the first key.
+    /// </remarks>
+    private static string SampleEthnicCategory(CityDemographics city, Bogus.Randomizer randomizer)
+    {
+        if (city.Attributes.TryGetValue(EthnicCategoryDistributionKey, out var data)
+            && data is Dictionary<string, double> distribution
+            && distribution.Count > 0)
+        {
+            var random = randomizer.Double();
+            var cumulative = 0.0;
+
+            foreach (var (code, probability) in distribution)
+            {
+                cumulative += probability;
+                if (random < cumulative)
+                {
+                    return code;
+                }
+            }
+
+            // Fallback if distribution doesn't sum to 1.0
+            return distribution.Keys.First();
+        }
+
+        // Fallback to majority UK ethnic category if no distribution provided
+        return EthnicCategory.British;
+    }
+
+    /// <summary>
+    /// Generates a valid 10-digit NHS Number (9-digit base plus a Modulus 11 check digit).
+    /// </summary>
+    /// <remarks>
+    /// Standard NHS algorithm: each of the 9 base digits is multiplied by a weight of 10 down to 2,
+    /// the products are summed, and the check digit is <c>11 - (sum mod 11)</c>. A result of 11 becomes
+    /// 0; a result of 10 is invalid, so the base is regenerated.
+    /// </remarks>
+    private static string GenerateNhsNumber()
+    {
+        while (true)
+        {
+            var digits = new int[9];
+            var sum = 0;
+
+            for (var i = 0; i < 9; i++)
+            {
+                digits[i] = Random.Shared.Next(0, 10);
+                sum += digits[i] * (10 - i);
+            }
+
+            var checkDigit = 11 - (sum % 11);
+
+            if (checkDigit == 11)
+            {
+                checkDigit = 0;
+            }
+            else if (checkDigit == 10)
+            {
+                // Invalid check digit - regenerate the base.
+                continue;
+            }
+
+            return string.Concat(digits.Select(d => d.ToString(CultureInfo.InvariantCulture)))
+                + checkDigit.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Core/Ignixa.FhirFakes/Builders/Profiles/USCorePatientProfile.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/Profiles/USCorePatientProfile.cs
@@ -169,7 +169,7 @@ public sealed class USCorePatientProfile : IPatientProfile
     }
 
     /// <inheritdoc />
-    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes)
+    public IEnumerable<JsonObject>? BuildIdentifiers(IReadOnlyDictionary<string, object> attributes, Bogus.Randomizer randomizer)
     {
         // US Core does not require specific identifiers in this implementation
         // Could be extended to generate SSN-like identifiers if needed

--- a/src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/CityDemographics.cs
@@ -19,6 +19,7 @@ namespace Ignixa.FhirFakes.Population;
 /// <param name="ZipCodePrefix">Zip/Postal code prefix range for the city (e.g., "021" for Boston 02101-02298, "3000" for Melbourne)</param>
 /// <param name="AreaCodes">Phone area codes for the city (e.g., ["617", "857"] for Boston, ["03"] for Melbourne)</param>
 /// <param name="Attributes">Optional profile-specific attributes for this city (e.g., ethnicity distribution for US, indigenous status distribution for AU)</param>
+/// <param name="PostalCodeFormat">The postal code shape to sample in (default: US-style numeric suffix). See <see cref="Population.PostalCodeFormat"/>.</param>
 public record CityDemographics(
     string Name,
     string State,
@@ -28,7 +29,8 @@ public record CityDemographics(
     double MaleRatio,
     string ZipCodePrefix,
     IReadOnlyList<string> AreaCodes,
-    IReadOnlyDictionary<string, object>? Attributes = null
+    IReadOnlyDictionary<string, object>? Attributes = null,
+    PostalCodeFormat PostalCodeFormat = PostalCodeFormat.NumericSuffix
 )
 {
     /// <summary>

--- a/src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs
@@ -434,7 +434,7 @@ public class DemographicsDataProvider
                     ["Z"] = 0.005
                 }
             },
-            PostalCodeFormat: PostalCodeFormat.UkAlphaNumeric
+            PostalCodeFormat: PostalCodeFormat.UKAlphaNumeric
         ));
 
         return provider;
@@ -509,10 +509,11 @@ public class DemographicsDataProvider
     /// Boston (prefix "021", NumericSuffix) → "02101", "02142", "02298", etc.
     /// Melbourne (prefix "3000", FixedNumeric) → "3000".
     /// Amsterdam (prefix "1011", DutchAlphaNumeric) → "1011 AB", etc.
-    /// London (prefix "SW1A", UkAlphaNumeric) → "SW1A 1AA", etc.
+    /// London (prefix "SW1A", UKAlphaNumeric) → "SW1A 1AA", etc.
     /// </example>
     public string SampleZipCode(CityDemographics city, Bogus.Randomizer randomizer)
     {
+        ArgumentNullException.ThrowIfNull(city);
         ArgumentNullException.ThrowIfNull(randomizer);
 
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -521,8 +522,9 @@ public class DemographicsDataProvider
         {
             PostalCodeFormat.FixedNumeric => city.ZipCodePrefix,
             PostalCodeFormat.DutchAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.String2(2, letters)}",
-            PostalCodeFormat.UkAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.Int(0, 9)}{randomizer.String2(2, letters)}",
-            _ => city.ZipCodePrefix + randomizer.Int(0, 99).ToString("D2"),
+            PostalCodeFormat.UKAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.Int(0, 9)}{randomizer.String2(2, letters)}",
+            PostalCodeFormat.NumericSuffix => city.ZipCodePrefix + randomizer.Int(0, 99).ToString("D2"),
+            _ => throw new NotSupportedException($"Unsupported PostalCodeFormat: {city.PostalCodeFormat}"),
         };
     }
 

--- a/src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/DemographicsDataProvider.cs
@@ -353,7 +353,8 @@ public class DemographicsDataProvider
             Attributes: new Dictionary<string, object>
             {
                 [AUBasePatientProfile.IndigenousStatusDistributionKey] = australianIndigenousDistribution
-            }
+            },
+            PostalCodeFormat: PostalCodeFormat.FixedNumeric
         ));
 
         provider.AddCity(new CityDemographics(
@@ -373,7 +374,8 @@ public class DemographicsDataProvider
             Attributes: new Dictionary<string, object>
             {
                 [AUBasePatientProfile.IndigenousStatusDistributionKey] = australianIndigenousDistribution
-            }
+            },
+            PostalCodeFormat: PostalCodeFormat.FixedNumeric
         ));
 
         provider.AddCity(new CityDemographics(
@@ -389,8 +391,50 @@ public class DemographicsDataProvider
             },
             MaleRatio: 0.498,
             ZipCodePrefix: "1011",
-            AreaCodes: ["020"]
-            // No profile-specific attributes for Amsterdam
+            AreaCodes: ["020"],
+            PostalCodeFormat: PostalCodeFormat.DutchAlphaNumeric
+        ));
+
+        // International cities - United Kingdom
+        // Data source: ONS 2021 Census (Greater London)
+        provider.AddCity(new CityDemographics(
+            Name: "London",
+            State: "Greater London",
+            Country: "GB",
+            Population: 8_799_800,
+            AgeGroupDistribution: new() {
+                ["0-17"] = 0.190,
+                ["18-44"] = 0.460,
+                ["45-64"] = 0.230,
+                ["65+"] = 0.120
+            },
+            MaleRatio: 0.495,
+            ZipCodePrefix: "SW1A",
+            AreaCodes: ["020"],
+            Attributes: new Dictionary<string, object>
+            {
+                [UKCorePatientProfile.EthnicCategoryDistributionKey] = new Dictionary<string, double>
+                {
+                    ["A"] = 0.372,
+                    ["B"] = 0.016,
+                    ["C"] = 0.170,
+                    ["D"] = 0.010,
+                    ["E"] = 0.008,
+                    ["F"] = 0.020,
+                    ["G"] = 0.019,
+                    ["H"] = 0.070,
+                    ["J"] = 0.030,
+                    ["K"] = 0.030,
+                    ["L"] = 0.077,
+                    ["M"] = 0.042,
+                    ["N"] = 0.079,
+                    ["P"] = 0.014,
+                    ["R"] = 0.017,
+                    ["S"] = 0.021,
+                    ["Z"] = 0.005
+                }
+            },
+            PostalCodeFormat: PostalCodeFormat.UkAlphaNumeric
         ));
 
         return provider;
@@ -456,19 +500,30 @@ public class DemographicsDataProvider
     }
 
     /// <summary>
-    /// Samples a zip code from the city's zip code range.
+    /// Samples a postal code from the city's postal code range, shaped according to
+    /// <see cref="CityDemographics.PostalCodeFormat"/>.
     /// </summary>
     /// <param name="city">City demographics.</param>
-    /// <param name="randomizer">The seeded randomizer used for zip code sampling.</param>
+    /// <param name="randomizer">The seeded randomizer used for postal code sampling.</param>
     /// <example>
-    /// Boston (prefix "021") → "02101", "02142", "02298", etc.
+    /// Boston (prefix "021", NumericSuffix) → "02101", "02142", "02298", etc.
+    /// Melbourne (prefix "3000", FixedNumeric) → "3000".
+    /// Amsterdam (prefix "1011", DutchAlphaNumeric) → "1011 AB", etc.
+    /// London (prefix "SW1A", UkAlphaNumeric) → "SW1A 1AA", etc.
     /// </example>
     public string SampleZipCode(CityDemographics city, Bogus.Randomizer randomizer)
     {
         ArgumentNullException.ThrowIfNull(randomizer);
 
-        var suffix = randomizer.Int(0, 99).ToString("D2");
-        return city.ZipCodePrefix + suffix;
+        const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        return city.PostalCodeFormat switch
+        {
+            PostalCodeFormat.FixedNumeric => city.ZipCodePrefix,
+            PostalCodeFormat.DutchAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.String2(2, letters)}",
+            PostalCodeFormat.UkAlphaNumeric => $"{city.ZipCodePrefix} {randomizer.Int(0, 9)}{randomizer.String2(2, letters)}",
+            _ => city.ZipCodePrefix + randomizer.Int(0, 99).ToString("D2"),
+        };
     }
 
     /// <summary>

--- a/src/Core/Ignixa.FhirFakes/Population/KnownCities.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/KnownCities.cs
@@ -161,6 +161,16 @@ public sealed class KnownCities
     public static CityDemographics Amsterdam => DefaultProvider.Cities.First(c => c.Name == "Amsterdam");
 
     /// <summary>
+    /// London, Greater London, United Kingdom (Population: 8,799,800)
+    /// </summary>
+    /// <remarks>
+    /// - Postal Code Prefix: SW1A (illustrative — London spans dozens of outward postcodes)
+    /// - Area Code: 020
+    /// - Demographics: approximate 2021 Census ethnicity breakdown across ONS ethnic category codes
+    /// </remarks>
+    public static CityDemographics London => DefaultProvider.Cities.First(c => c.Name == "London");
+
+    /// <summary>
     /// Gets all available cities.
     /// </summary>
     public static IReadOnlyList<CityDemographics> All => DefaultProvider.Cities;

--- a/src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.FhirFakes.Population;
+
+/// <summary>
+/// Describes the shape a city's postal code should be sampled in, so <see cref="DemographicsDataProvider.SampleZipCode"/>
+/// can generate a realistically-shaped value instead of assuming a single (US) format for every country.
+/// </summary>
+public enum PostalCodeFormat
+{
+    /// <summary>US-style: append a 2-digit numeric suffix to <see cref="CityDemographics.ZipCodePrefix"/> (e.g. "021" -&gt; "02105").</summary>
+    NumericSuffix,
+
+    /// <summary>Fixed code, no suffix — the prefix already is the full code (e.g. Australian postcodes: "3000").</summary>
+    FixedNumeric,
+
+    /// <summary>Dutch-style: the prefix, a space, then 2 random uppercase letters (e.g. "1011" -&gt; "1011 AB").</summary>
+    DutchAlphaNumeric,
+
+    /// <summary>UK-style: the prefix (an alphanumeric outward code), a space, then a digit and 2 random uppercase letters (e.g. "SW1A" -&gt; "SW1A 1AA").</summary>
+    UkAlphaNumeric
+}

--- a/src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs
+++ b/src/Core/Ignixa.FhirFakes/Population/PostalCodeFormat.cs
@@ -21,5 +21,5 @@ public enum PostalCodeFormat
     DutchAlphaNumeric,
 
     /// <summary>UK-style: the prefix (an alphanumeric outward code), a space, then a digit and 2 random uppercase letters (e.g. "SW1A" -&gt; "SW1A 1AA").</summary>
-    UkAlphaNumeric
+    UKAlphaNumeric
 }

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/OrganizationState.cs
@@ -359,7 +359,7 @@ public sealed class OrganizationState : ScenarioState
             City: city.Name,
             State: city.State,
             PostalCode: zipCode,
-            Country: "USA"
+            Country: city.Country
         );
     }
 

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderDeterminismTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderDeterminismTests.cs
@@ -132,6 +132,25 @@ public class PatientBuilderDeterminismTests
         Canonicalize(first).ShouldBe(Canonicalize(second));
     }
 
+    [Fact]
+    public void GivenSameSeed_WhenBuildingUKCorePatientTwice_ThenNhsNumberIsIdentical()
+    {
+        // Arrange & Act
+        var patient1 = PatientBuilderFactory.Create(_schemaProvider, seed: 42)
+            .FromCity(KnownCities.London)
+            .Build();
+        var patient2 = PatientBuilderFactory.Create(_schemaProvider, seed: 42)
+            .FromCity(KnownCities.London)
+            .Build();
+
+        // Assert
+        var nhsNumber1 = patient1.MutableNode["identifier"]?.AsArray()?[0]?["value"]?.GetValue<string>();
+        var nhsNumber2 = patient2.MutableNode["identifier"]?.AsArray()?[0]?["value"]?.GetValue<string>();
+
+        nhsNumber1.ShouldNotBeNullOrEmpty();
+        nhsNumber1.ShouldBe(nhsNumber2);
+    }
+
     private JsonNode BuildAutoNamedPatient(int seed) =>
         PatientBuilderFactory.Create(_schemaProvider, seed)
             .WithAge(35)

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
@@ -1007,14 +1007,80 @@ public class PatientBuilderTests
         var attributes = new Dictionary<string, object>();
 
         // Act & Assert - generate a batch and independently validate each check digit
+        var randomizer = new Bogus.Randomizer();
         for (var n = 0; n < 100; n++)
         {
-            var identifiers = UKCorePatientProfile.Instance.BuildIdentifiers(attributes)!.ToList();
+            var identifiers = UKCorePatientProfile.Instance.BuildIdentifiers(attributes, randomizer)!.ToList();
+            identifiers.ShouldNotBeEmpty();
             var nhsNumber = identifiers[0]["value"]!.GetValue<string>();
 
             nhsNumber.Length.ShouldBe(10);
             IsValidNhsNumber(nhsNumber).ShouldBeTrue($"'{nhsNumber}' should have a valid Modulus 11 check digit");
         }
+    }
+
+    [Fact]
+    public void GivenCityWithNoEthnicCategoryDistribution_WhenSamplingProfileAttributes_ThenFallsBackToBritish()
+    {
+        // Arrange
+        var cityWithoutDistribution = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "GB",
+            Population: 1000,
+            AgeGroupDistribution: new Dictionary<string, double> { ["18-44"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "AB1",
+            AreaCodes: ["000"]);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var attributes = UKCorePatientProfile.Instance.SampleProfileAttributes(cityWithoutDistribution, randomizer);
+
+        // Assert
+        attributes[UKCorePatientProfile.EthnicCategoryAttribute].ShouldBe(UKCorePatientProfile.EthnicCategory.British);
+    }
+
+    [Fact]
+    public void GivenDistributionNotSummingToOne_WhenSamplingProfileAttributes_ThenFallsBackToFirstKey()
+    {
+        // Arrange
+        var cityWithBadDistribution = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "GB",
+            Population: 1000,
+            AgeGroupDistribution: new Dictionary<string, double> { ["18-44"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "AB1",
+            AreaCodes: ["000"],
+            Attributes: new Dictionary<string, object>
+            {
+                [UKCorePatientProfile.EthnicCategoryDistributionKey] = new Dictionary<string, double>
+                {
+                    [UKCorePatientProfile.EthnicCategory.Indian] = 0.05,
+                    [UKCorePatientProfile.EthnicCategory.Pakistani] = 0.05
+                }
+            });
+        // Seed 0 draws randomizer.Double() ~= 0.726, well past the 0.1 cumulative sum of the
+        // distribution, so this only passes via the distribution.Keys.First() fallback - a proper
+        // weighted sample over {0.05, 0.05} would never pick Indian for a draw >= 0.1.
+        var randomizer = new Bogus.Randomizer(0);
+
+        // Act
+        var attributes = UKCorePatientProfile.Instance.SampleProfileAttributes(cityWithBadDistribution, randomizer);
+
+        // Assert
+        attributes[UKCorePatientProfile.EthnicCategoryAttribute].ShouldBe(UKCorePatientProfile.EthnicCategory.Indian);
+    }
+
+    [Theory]
+    [InlineData("9434765919", true)]   // valid: base 943476591, computed check digit 9
+    [InlineData("9434765910", false)]  // same base, wrong check digit (9 corrupted to 0)
+    [InlineData("1234567895", false)]  // base 123456789 sums to a remainder of 1 -> required check digit is 10, which is invalid for ANY last digit
+    public void GivenKnownNhsNumber_WhenValidatingCheckDigit_ThenMatchesExpectedValidity(string nhsNumber, bool expectedValid)
+    {
+        IsValidNhsNumber(nhsNumber).ShouldBe(expectedValid);
     }
 
     // Independent reimplementation of the NHS Modulus 11 validation used to verify generated numbers.

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
@@ -1074,6 +1074,41 @@ public class PatientBuilderTests
         attributes[UKCorePatientProfile.EthnicCategoryAttribute].ShouldBe(UKCorePatientProfile.EthnicCategory.Indian);
     }
 
+    [Fact]
+    public void GivenValidDistribution_WhenSamplingProfileAttributes_ThenReturnsCodeMatchingCumulativeWeight()
+    {
+        // Arrange
+        var cityWithValidDistribution = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "GB",
+            Population: 1000,
+            AgeGroupDistribution: new Dictionary<string, double> { ["18-44"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "AB1",
+            AreaCodes: ["000"],
+            Attributes: new Dictionary<string, object>
+            {
+                [UKCorePatientProfile.EthnicCategoryDistributionKey] = new Dictionary<string, double>
+                {
+                    [UKCorePatientProfile.EthnicCategory.British] = 0.1,
+                    [UKCorePatientProfile.EthnicCategory.Irish] = 0.2,
+                    [UKCorePatientProfile.EthnicCategory.Indian] = 0.3,
+                    [UKCorePatientProfile.EthnicCategory.Chinese] = 0.4
+                }
+            });
+        // Seed 1 draws randomizer.Double() ~= 0.2487, which falls in the cumulative range
+        // (0.1, 0.3] - past British's slice and into Irish's - proving the loop walks the
+        // cumulative sum rather than always returning the first or last key.
+        var randomizer = new Bogus.Randomizer(1);
+
+        // Act
+        var attributes = UKCorePatientProfile.Instance.SampleProfileAttributes(cityWithValidDistribution, randomizer);
+
+        // Assert
+        attributes[UKCorePatientProfile.EthnicCategoryAttribute].ShouldBe(UKCorePatientProfile.EthnicCategory.Irish);
+    }
+
     [Theory]
     [InlineData("9434765919", true)]   // valid: base 943476591, computed check digit 9
     [InlineData("9434765910", false)]  // same base, wrong check digit (9 corrupted to 0)

--- a/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PatientBuilderTests.cs
@@ -739,6 +739,51 @@ public class PatientBuilderTests
     }
 
     [Fact]
+    public void GivenRealisticBuilder_WhenBuildingFromLondon_ThenUsesUKCoreProfile()
+    {
+        // Arrange & Act
+        var builder = PatientBuilderFactory.Create(_schemaProvider)
+            .FromCity(KnownCities.London);
+
+        // Assert - Check profile is UK Core
+        builder.Profile.ShouldBe(UKCorePatientProfile.Instance);
+        builder.Profile.ProfileUrl.ShouldBe("https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient");
+        builder.Profile.CountryCode.ShouldBe("GB");
+    }
+
+    [Fact]
+    public void GivenRealisticBuilder_WhenBuildingFromLondon_ThenIncludesEthnicCategoryExtensionAndNhsNumber()
+    {
+        // Arrange & Act
+        var patient = PatientBuilderFactory.Create(_schemaProvider)
+            .FromCity(KnownCities.London)
+            .Build();
+
+        // Assert
+        patient.ShouldNotBeNull();
+        patient.ResourceType.ShouldBe("Patient");
+
+        // Should have address in London, GB
+        var address = patient.MutableNode["address"]?.AsArray()?[0]?.AsObject();
+        address?["city"]?.GetValue<string>().ShouldBe("London");
+        address?["country"]?.GetValue<string>().ShouldBe("GB");
+
+        // Should have UK Core ethnic category extension
+        var extensions = patient.MutableNode["extension"]?.AsArray();
+        extensions.ShouldNotBeNull();
+
+        var ethnicCategoryUrl = "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory";
+        extensions!.Any(e => e?["url"]?.GetValue<string>() == ethnicCategoryUrl)
+            .ShouldBeTrue("UK patients should have ethnic category extension");
+
+        // Should have an NHS Number identifier
+        var identifiers = patient.MutableNode["identifier"]?.AsArray();
+        identifiers.ShouldNotBeNull();
+        identifiers!.Any(i => i?["system"]?.GetValue<string>() == "https://fhir.nhs.uk/Id/nhs-number")
+            .ShouldBeTrue("UK patients should have an NHS Number identifier");
+    }
+
+    [Fact]
     public void GivenSimpleBuilder_WhenUsingWithProfile_ThenUsesSpecifiedProfile()
     {
         // Arrange & Act
@@ -887,6 +932,137 @@ public class PatientBuilderTests
         extensionsWithBMI.Count.ShouldBe(1);
         extensionsWithBMI[0]["url"]?.GetValue<string>().ShouldBe("http://ignixa.dev/StructureDefinition/patient-bmi");
         extensionsWithBMI[0]["valueDecimal"]?.GetValue<decimal>().ShouldBe(25.5m);
+    }
+
+    [Fact]
+    public void GivenPatientProfileFactory_WhenGettingGBProfile_ThenReturnsUKCoreProfile()
+    {
+        // Assert
+        PatientProfileFactory.GetProfile("GB").ShouldBe(UKCorePatientProfile.Instance);
+        UKCorePatientProfile.Instance.ProfileUrl.ShouldBe("https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient");
+        UKCorePatientProfile.Instance.CountryCode.ShouldBe("GB");
+    }
+
+    [Fact]
+    public void GivenUKCoreProfile_WhenBuildingWithEthnicCategory_ThenIncludesEthnicCategoryExtension()
+    {
+        // Arrange & Act
+        var patient = PatientBuilderFactory.Create(_schemaProvider)
+            .WithProfile(UKCorePatientProfile.Instance)
+            .WithAttribute(UKCorePatientProfile.EthnicCategoryAttribute, UKCorePatientProfile.EthnicCategory.British)
+            .WithGender("female")
+            .WithAge(30)
+            .Build();
+
+        // Assert
+        var extensions = patient.MutableNode["extension"]?.AsArray();
+        extensions.ShouldNotBeNull();
+
+        var ethnicCategoryExtension = extensions!
+            .FirstOrDefault(e => e?["url"]?.GetValue<string>() == "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory");
+        ethnicCategoryExtension.ShouldNotBeNull();
+
+        var coding = ethnicCategoryExtension!["valueCodeableConcept"]?["coding"]?.AsArray()?[0]?.AsObject();
+        coding.ShouldNotBeNull();
+        coding!["system"]?.GetValue<string>().ShouldBe("https://fhir.hl7.org.uk/CodeSystem/UKCore-EthnicCategory");
+        coding["code"]?.GetValue<string>().ShouldBe("A");
+        coding["display"]?.GetValue<string>().ShouldBe("British, White");
+    }
+
+    [Fact]
+    public void GivenUKCoreProfile_WhenBuildingPatient_ThenIncludesNhsNumberIdentifierWithVerificationStatus()
+    {
+        // Arrange & Act
+        var patient = PatientBuilderFactory.Create(_schemaProvider)
+            .WithProfile(UKCorePatientProfile.Instance)
+            .WithAttribute(UKCorePatientProfile.EthnicCategoryAttribute, UKCorePatientProfile.EthnicCategory.British)
+            .WithGender("male")
+            .WithAge(50)
+            .Build();
+
+        // Assert
+        var identifiers = patient.MutableNode["identifier"]?.AsArray();
+        identifiers.ShouldNotBeNull();
+
+        var nhsIdentifier = identifiers!
+            .FirstOrDefault(i => i?["system"]?.GetValue<string>() == "https://fhir.nhs.uk/Id/nhs-number");
+        nhsIdentifier.ShouldNotBeNull();
+
+        var value = nhsIdentifier!["value"]?.GetValue<string>();
+        value.ShouldNotBeNull();
+        value!.Length.ShouldBe(10);
+        value.ShouldAllBe(c => char.IsDigit(c));
+
+        var verificationStatus = nhsIdentifier["extension"]?.AsArray()?[0]?.AsObject();
+        verificationStatus.ShouldNotBeNull();
+        verificationStatus!["url"]?.GetValue<string>()
+            .ShouldBe("https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus");
+        verificationStatus["valueCodeableConcept"]?["coding"]?.AsArray()?[0]?["code"]?.GetValue<string>().ShouldBe("01");
+    }
+
+    [Fact]
+    public void GivenUKCoreProfile_WhenGeneratingNhsNumbers_ThenEachHasValidModulus11CheckDigit()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, object>();
+
+        // Act & Assert - generate a batch and independently validate each check digit
+        for (var n = 0; n < 100; n++)
+        {
+            var identifiers = UKCorePatientProfile.Instance.BuildIdentifiers(attributes)!.ToList();
+            var nhsNumber = identifiers[0]["value"]!.GetValue<string>();
+
+            nhsNumber.Length.ShouldBe(10);
+            IsValidNhsNumber(nhsNumber).ShouldBeTrue($"'{nhsNumber}' should have a valid Modulus 11 check digit");
+        }
+    }
+
+    // Independent reimplementation of the NHS Modulus 11 validation used to verify generated numbers.
+    private static bool IsValidNhsNumber(string nhsNumber)
+    {
+        if (nhsNumber.Length != 10 || !nhsNumber.All(char.IsDigit))
+        {
+            return false;
+        }
+
+        var sum = 0;
+        for (var i = 0; i < 9; i++)
+        {
+            sum += (nhsNumber[i] - '0') * (10 - i);
+        }
+
+        var remainder = sum % 11;
+        var checkDigit = 11 - remainder;
+
+        if (checkDigit == 11)
+        {
+            checkDigit = 0;
+        }
+        else if (checkDigit == 10)
+        {
+            return false;
+        }
+
+        return checkDigit == nhsNumber[9] - '0';
+    }
+
+    [Theory]
+    [InlineData("GB")]
+    [InlineData("IE")]
+    public void GivenDefaultNameStrategy_WhenGeneratingForUkOrIrelandLocale_ThenDoesNotThrow(string countryCode)
+    {
+        // Bogus throws on an unknown locale, so a successful call proves en_GB / en_IE are valid.
+        var randomizer = new Bogus.Randomizer(42);
+
+        var act = () => DefaultNameGenerationStrategy.Instance.GenerateName(
+            "female",
+            new Dictionary<string, object>(),
+            countryCode,
+            randomizer);
+
+        var (given, family) = act.ShouldNotThrow();
+        given.ShouldNotBeNullOrEmpty();
+        family.ShouldNotBeNullOrEmpty();
     }
 
     #endregion

--- a/test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs
@@ -487,7 +487,7 @@ public class OrganizationStateTests
         var country = address["country"]?.GetValue<string>();
 
         cityName.ShouldNotBeNullOrEmpty();
-        var matchingCity = demographics.Cities.First(c => c.Name == cityName);
+        var matchingCity = demographics.Cities.Single(c => c.Name == cityName);
         country.ShouldBe(matchingCity.Country);
     }
 

--- a/test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/OrganizationStateTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Shouldly;
+using Ignixa.FhirFakes.Population;
 using Ignixa.FhirFakes.Scenarios;
 using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Specification.Generated;
@@ -464,7 +465,30 @@ public class OrganizationStateTests
         address!["city"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
         address["state"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
         address["postalCode"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
-        address["country"]?.GetValue<string>().ShouldBe("USA");
+        address["country"]?.GetValue<string>().ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void GivenOrganization_WhenGeneratedFromKnownCity_ThenCountryMatchesThatCitysCountry()
+    {
+        // Arrange
+        var demographics = DemographicsDataProvider.CreateDefault();
+
+        // Act
+        var scenario = new ScenarioBuilder(_schemaProvider)
+            .WithPatient()
+            .AddHospital()
+            .Build();
+
+        // Assert
+        var organization = scenario.Organizations[0];
+        var address = organization.MutableNode["address"]![0];
+        var cityName = address!["city"]?.GetValue<string>();
+        var country = address["country"]?.GetValue<string>();
+
+        cityName.ShouldNotBeNullOrEmpty();
+        var matchingCity = demographics.Cities.First(c => c.Name == cityName);
+        country.ShouldBe(matchingCity.Country);
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs
@@ -36,7 +36,7 @@ public class CityDemographicsTests
     [InlineData(PostalCodeFormat.NumericSuffix)]
     [InlineData(PostalCodeFormat.FixedNumeric)]
     [InlineData(PostalCodeFormat.DutchAlphaNumeric)]
-    [InlineData(PostalCodeFormat.UkAlphaNumeric)]
+    [InlineData(PostalCodeFormat.UKAlphaNumeric)]
     public void GivenCityDemographics_WhenPostalCodeFormatSpecified_ThenUsesThatValue(PostalCodeFormat format)
     {
         // Arrange & Act

--- a/test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/CityDemographicsTests.cs
@@ -1,0 +1,57 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Shouldly;
+using Ignixa.FhirFakes.Population;
+using Xunit;
+
+namespace Ignixa.FhirFakes.Tests.Population;
+
+/// <summary>
+/// Tests for the CityDemographics record, focused on PostalCodeFormat defaulting behavior.
+/// </summary>
+public class CityDemographicsTests
+{
+    [Fact]
+    public void GivenCityDemographics_WhenPostalCodeFormatNotSpecified_ThenDefaultsToNumericSuffix()
+    {
+        // Arrange & Act
+        var city = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "US",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "000",
+            AreaCodes: ["000"]);
+
+        // Assert
+        city.PostalCodeFormat.ShouldBe(PostalCodeFormat.NumericSuffix);
+    }
+
+    [Theory]
+    [InlineData(PostalCodeFormat.NumericSuffix)]
+    [InlineData(PostalCodeFormat.FixedNumeric)]
+    [InlineData(PostalCodeFormat.DutchAlphaNumeric)]
+    [InlineData(PostalCodeFormat.UkAlphaNumeric)]
+    public void GivenCityDemographics_WhenPostalCodeFormatSpecified_ThenUsesThatValue(PostalCodeFormat format)
+    {
+        // Arrange & Act
+        var city = new CityDemographics(
+            Name: "Testville",
+            State: "Test State",
+            Country: "US",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: "000",
+            AreaCodes: ["000"],
+            PostalCodeFormat: format);
+
+        // Assert
+        city.PostalCodeFormat.ShouldBe(format);
+    }
+}

--- a/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
@@ -88,6 +88,18 @@ public class DemographicsDataProviderTests
     }
 
     [Fact]
+    public void GivenUnsupportedPostalCodeFormat_WhenSamplingZipCode_ThenThrowsNotSupportedException()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("XX", (PostalCodeFormat)99);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => provider.SampleZipCode(city, randomizer));
+    }
+
+    [Fact]
     public void GivenSameSeed_WhenSamplingZipCodeTwice_ThenReturnsSameValue()
     {
         // Arrange

--- a/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
@@ -73,11 +73,11 @@ public class DemographicsDataProviderTests
     }
 
     [Fact]
-    public void GivenUkAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsOutwardCodeSpaceDigitTwoLetters()
+    public void GivenUKAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsOutwardCodeSpaceDigitTwoLetters()
     {
         // Arrange
         var provider = DemographicsDataProvider.CreateDefault();
-        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+        var city = MakeCity("SW1A", PostalCodeFormat.UKAlphaNumeric);
         var randomizer = new Bogus.Randomizer();
 
         // Act
@@ -92,7 +92,7 @@ public class DemographicsDataProviderTests
     {
         // Arrange
         var provider = DemographicsDataProvider.CreateDefault();
-        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+        var city = MakeCity("SW1A", PostalCodeFormat.UKAlphaNumeric);
 
         // Act
         var first = provider.SampleZipCode(city, new Bogus.Randomizer(42));
@@ -157,7 +157,8 @@ public class DemographicsDataProviderTests
         var city = KnownCities.London;
 
         // Act
-        var distribution = (Dictionary<string, double>)city.Attributes[UKCorePatientProfile.EthnicCategoryDistributionKey];
+        city.Attributes.TryGetValue(UKCorePatientProfile.EthnicCategoryDistributionKey, out var raw).ShouldBeTrue();
+        var distribution = raw.ShouldBeOfType<Dictionary<string, double>>();
 
         // Assert
         distribution.Values.Sum().ShouldBe(1.0, 0.001);

--- a/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/DemographicsDataProviderTests.cs
@@ -1,0 +1,165 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Shouldly;
+using Ignixa.FhirFakes.Builders.Profiles;
+using Ignixa.FhirFakes.Population;
+using Xunit;
+
+namespace Ignixa.FhirFakes.Tests.Population;
+
+/// <summary>
+/// Tests for DemographicsDataProvider.SampleZipCode across all PostalCodeFormat shapes.
+/// </summary>
+public class DemographicsDataProviderTests
+{
+    private static CityDemographics MakeCity(string zipCodePrefix, PostalCodeFormat format) =>
+        new(
+            Name: "Testville",
+            State: "Test State",
+            Country: "XX",
+            Population: 1000,
+            AgeGroupDistribution: new() { ["0-17"] = 1.0 },
+            MaleRatio: 0.5,
+            ZipCodePrefix: zipCodePrefix,
+            AreaCodes: ["000"],
+            PostalCodeFormat: format);
+
+    [Fact]
+    public void GivenNumericSuffixFormat_WhenSamplingZipCode_ThenAppendsTwoDigitSuffix()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("021", PostalCodeFormat.NumericSuffix);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^021\\d{2}$");
+    }
+
+    [Fact]
+    public void GivenFixedNumericFormat_WhenSamplingZipCode_ThenReturnsPrefixUnchanged()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("3000", PostalCodeFormat.FixedNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldBe("3000");
+    }
+
+    [Fact]
+    public void GivenDutchAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsFourDigitsSpaceTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("1011", PostalCodeFormat.DutchAlphaNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^1011 [A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenUkAlphaNumericFormat_WhenSamplingZipCode_ThenReturnsOutwardCodeSpaceDigitTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^SW1A \\d[A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenSameSeed_WhenSamplingZipCodeTwice_ThenReturnsSameValue()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = MakeCity("SW1A", PostalCodeFormat.UkAlphaNumeric);
+
+        // Act
+        var first = provider.SampleZipCode(city, new Bogus.Randomizer(42));
+        var second = provider.SampleZipCode(city, new Bogus.Randomizer(42));
+
+        // Assert
+        first.ShouldBe(second);
+    }
+
+    [Theory]
+    [InlineData("Melbourne")]
+    [InlineData("Sydney")]
+    public void GivenAustralianKnownCity_WhenSamplingZipCode_ThenReturnsExactFourDigitPostcode(string cityName)
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = provider.Cities.First(c => c.Name == cityName);
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldBe(city.ZipCodePrefix);
+        zipCode.Length.ShouldBe(4);
+    }
+
+    [Fact]
+    public void GivenAmsterdam_WhenSamplingZipCode_ThenReturnsFourDigitsSpaceTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = provider.Cities.First(c => c.Name == "Amsterdam");
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^1011 [A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenLondon_WhenSamplingZipCode_ThenReturnsOutwardCodeSpaceDigitTwoLetters()
+    {
+        // Arrange
+        var provider = DemographicsDataProvider.CreateDefault();
+        var city = provider.Cities.First(c => c.Name == "London");
+        var randomizer = new Bogus.Randomizer();
+
+        // Act
+        var zipCode = provider.SampleZipCode(city, randomizer);
+
+        // Assert
+        zipCode.ShouldMatch("^SW1A \\d[A-Z]{2}$");
+    }
+
+    [Fact]
+    public void GivenLondon_WhenReadingEthnicCategoryDistribution_ThenProbabilitiesSumToOne()
+    {
+        // Arrange
+        var city = KnownCities.London;
+
+        // Act
+        var distribution = (Dictionary<string, double>)city.Attributes[UKCorePatientProfile.EthnicCategoryDistributionKey];
+
+        // Assert
+        distribution.Values.Sum().ShouldBe(1.0, 0.001);
+    }
+}

--- a/test/Ignixa.FhirFakes.Tests/Population/PopulationGeneratorTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Population/PopulationGeneratorTests.cs
@@ -332,7 +332,7 @@ public class PopulationGeneratorTests
         var allCities = KnownCities.All;
 
         // Assert
-        allCities.Count.ShouldBe(14);
+        allCities.Count.ShouldBe(15);
         allCities.ShouldContain(c => c.Name == "Boston");
         allCities.ShouldContain(c => c.Name == "Seattle");
         allCities.ShouldContain(c => c.Name == "New York");
@@ -340,6 +340,7 @@ public class PopulationGeneratorTests
         allCities.ShouldContain(c => c.Name == "Melbourne");
         allCities.ShouldContain(c => c.Name == "Sydney");
         allCities.ShouldContain(c => c.Name == "Amsterdam");
+        allCities.ShouldContain(c => c.Name == "London");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fixes `DemographicsDataProvider.SampleZipCode`, which always appended a US-shaped numeric suffix — already producing invalid postal codes for Melbourne/Sydney (6 digits instead of 4) and Amsterdam (numeric-only instead of `"1234 AB"`-shaped) in cities shipping today. Fixed via a new `PostalCodeFormat` enum on `CityDemographics` (`NumericSuffix`/`FixedNumeric`/`DutchAlphaNumeric`/`UkAlphaNumeric`).
- Fixes `OrganizationState.GenerateAddress` hardcoding `Country: "USA"` regardless of which city was actually sampled.
- Adds `UKCorePatientProfile`: NHS Number identifier (with a correct Modulus 11 check digit) + verification-status extension, ONS/NHS Data Dictionary ethnic-category extension, and `UKCoreNameGenerationStrategy` (`en_GB` locale), registered for country code `"GB"`.
- Fixes a pre-existing gap where `IPatientProfile.BuildIdentifiers()` was defined but never actually called by `PatientBuilder` — profile-specific identifiers (like the new NHS Number) wouldn't have appeared in generated patients without this.
- Fixes `DefaultNameGenerationStrategy` mapping `GB`/`IE` to generic `en` instead of the more accurate `en_GB`/`en_IE` Bogus locales.
- Adds London as a supported city (`KnownCities.London`), with a 2021-Census-derived ethnic category distribution.

Design decisions were investigated and documented in `docs/features/fhir-faker/investigations/` before implementation, and the postal-code fix plan (`docs/superpowers/plans/2026-07-04-postal-code-format-fix.md`) went through two rounds of review by a Fable-tier agent.

## Test plan
- [x] `dotnet build All.sln` — 0 warnings, 0 errors
- [x] `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj` — 1319/1319 passing (net9.0 and net10.0)
- [x] New tests cover: all four `PostalCodeFormat` shapes (including alphanumeric), Melbourne/Sydney/Amsterdam's corrected postal codes, Organization country now matching its sampled city, UK Core profile extension/identifier shape, an independent reimplementation of the NHS number check-digit validation, `en_GB`/`en_IE` locale wiring, and London's ethnicity distribution summing to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)