### PR TITLE
Support semver-granular FHIR version gating in TestScript matching

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,6 +98,8 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <!-- SearchParameter Conflict Resolution -->
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
+    <!-- Semantic version parsing (TestScript FHIR version gating) -->
+    <PackageVersion Include="Semver" Version="3.0.0" />
     <!-- gRPC (for Sidecar.Contracts) -->
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -11,6 +11,7 @@ using Ignixa.TestScript.Fixtures;
 using Ignixa.TestScript.Model;
 using Ignixa.TestScript.Reporting;
 using Ignixa.TestScript.Validation;
+using Semver;
 
 namespace Ignixa.TestScript.Evaluation;
 
@@ -164,11 +165,75 @@ public sealed class TestScriptEvaluator(
         return recorder.Build(definition.Metadata.Name, startTime, DateTimeOffset.UtcNow);
     }
 
+    /// <summary>
+    /// Matches a test's declared <c>fhirVersions</c> spec tokens against the actual FHIR version
+    /// being targeted. Each spec token is checked two ways: an exact case-insensitive string match
+    /// (preserving today's behavior for existing suites, e.g. "4.0" == "4.0"), or a granular
+    /// numeric Major/Minor/Patch comparison that supports "4.*" (major-only), "4.0" (major.minor),
+    /// and "4.0.1" (exact) against a semver-parsed <paramref name="fhirVersion"/>. Prerelease and
+    /// build metadata are ignored by the granular comparison. Unparseable input fails safe (no
+    /// match via that path) rather than throwing.
+    /// </summary>
     private static bool IsVersionCompatible(IReadOnlyList<string> fhirVersions, string? fhirVersion)
     {
         if (fhirVersions.Count == 0) return true;
         if (fhirVersion is null) return true;
-        return fhirVersions.Contains(fhirVersion, StringComparer.OrdinalIgnoreCase);
+
+        var parsedActual = SemVersion.TryParse(fhirVersion, SemVersionStyles.Any, out var actual) ? actual : null;
+
+        foreach (var spec in fhirVersions)
+        {
+            if (string.Equals(spec, fhirVersion, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (parsedActual is not null && MatchesVersionSpec(spec, parsedActual))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool MatchesVersionSpec(string spec, SemVersion actual)
+    {
+        if (!TryParseVersionSpec(spec, out var major, out var minor, out var patch))
+            return false;
+
+        if (actual.Major != major) return false;
+        if (minor is not null && actual.Minor != minor) return false;
+        if (patch is not null && actual.Patch != patch) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a spec token such as "4", "4.*", "4.0", or "4.0.1" into 1-3 numeric components.
+    /// A trailing "*" segment is dropped (it's the major-only wildcard marker). Returns false for
+    /// anything that isn't 1-3 non-negative integer segments, so malformed tokens simply don't
+    /// match via the granular path rather than throwing.
+    /// </summary>
+    private static bool TryParseVersionSpec(string spec, out int major, out int? minor, out int? patch)
+    {
+        major = 0;
+        minor = null;
+        patch = null;
+
+        var segments = spec.Split('.');
+        if (segments.Length > 0 && segments[^1] == "*")
+            segments = segments[..^1];
+
+        if (segments.Length is 0 or > 3) return false;
+
+        var values = new int?[3];
+        for (var i = 0; i < segments.Length; i++)
+        {
+            if (!int.TryParse(segments[i], NumberStyles.None, CultureInfo.InvariantCulture, out var value))
+                return false;
+            values[i] = value;
+        }
+
+        major = values[0]!.Value;
+        minor = values[1];
+        patch = values[2];
+        return true;
     }
 
     /// <summary>

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -106,8 +106,7 @@ public sealed class TestScriptEvaluator(
             {
                 if (!IsVersionCompatible(test.FhirVersions, fhirVersion))
                 {
-                    RecordSkippedTest(recorder, test,
-                        $"Test targets FHIR version(s) [{string.Join(", ", test.FhirVersions)}] but execution requested '{fhirVersion}'");
+                    RecordSkippedTest(recorder, test, VersionMismatchReason(test.FhirVersions, fhirVersion));
                     continue;
                 }
 
@@ -172,7 +171,10 @@ public sealed class TestScriptEvaluator(
     /// numeric Major/Minor/Patch comparison that supports "4.*" (major-only), "4.0" (major.minor),
     /// and "4.0.1" (exact) against a semver-parsed <paramref name="fhirVersion"/>. Prerelease and
     /// build metadata are ignored by the granular comparison. Unparseable input fails safe (no
-    /// match via that path) rather than throwing.
+    /// match via that path) rather than throwing. An empty <paramref name="fhirVersions"/> list or
+    /// a <see langword="null"/> <paramref name="fhirVersion"/> short-circuits to a match (the test
+    /// runs) rather than a mismatch, so gating never turns into a silent skip when either side of
+    /// the comparison is unknown.
     /// </summary>
     private static bool IsVersionCompatible(IReadOnlyList<string> fhirVersions, string? fhirVersion)
     {
@@ -193,7 +195,23 @@ public sealed class TestScriptEvaluator(
         return false;
     }
 
-    private static bool MatchesVersionSpec(string spec, SemVersion actual)
+    /// <summary>
+    /// Builds the skip reason for a version mismatch, distinguishing a legitimate scoping mismatch
+    /// (at least one <paramref name="fhirVersions"/> token parses as a recognizable version spec,
+    /// it just doesn't match <paramref name="fhirVersion"/>) from every token being unrecognizable
+    /// (likely an authoring typo, e.g. "4,0" or "r4") — mirroring how
+    /// <see cref="EvaluateCapabilityRequirement"/> already distinguishes "not met" from "malformed"
+    /// so a typo doesn't read identically to an intentional version restriction.
+    /// </summary>
+    private static string VersionMismatchReason(IReadOnlyList<string> fhirVersions, string? fhirVersion)
+    {
+        var anyTokenRecognized = fhirVersions.Any(spec => TryParseVersionSpec(spec, out _, out _, out _));
+        return anyTokenRecognized
+            ? $"Test targets FHIR version(s) [{string.Join(", ", fhirVersions)}] but execution requested '{fhirVersion}'"
+            : $"Test's fhirVersions [{string.Join(", ", fhirVersions)}] contain no recognizable version spec — check for a typo";
+    }
+
+    private static bool MatchesVersionSpec(string? spec, SemVersion actual)
     {
         if (!TryParseVersionSpec(spec, out var major, out var minor, out var patch))
             return false;
@@ -207,14 +225,16 @@ public sealed class TestScriptEvaluator(
     /// <summary>
     /// Parses a spec token such as "4", "4.*", "4.0", or "4.0.1" into 1-3 numeric components.
     /// A trailing "*" segment is dropped (it's the major-only wildcard marker). Returns false for
-    /// anything that isn't 1-3 non-negative integer segments, so malformed tokens simply don't
-    /// match via the granular path rather than throwing.
+    /// <see langword="null"/> or anything that isn't 1-3 non-negative integer segments, so
+    /// malformed tokens simply don't match via the granular path rather than throwing.
     /// </summary>
-    private static bool TryParseVersionSpec(string spec, out int major, out int? minor, out int? patch)
+    private static bool TryParseVersionSpec(string? spec, out int major, out int? minor, out int? patch)
     {
         major = 0;
         minor = null;
         patch = null;
+
+        if (spec is null) return false;
 
         var segments = spec.Split('.');
         if (segments.Length > 0 && segments[^1] == "*")

--- a/src/Core/Ignixa.TestScript/Ignixa.TestScript.csproj
+++ b/src/Core/Ignixa.TestScript/Ignixa.TestScript.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Semver" />
     <ProjectReference Include="..\Ignixa.Abstractions\Ignixa.Abstractions.csproj" />
     <ProjectReference Include="..\Ignixa.FhirPath\Ignixa.FhirPath.csproj" />
     <ProjectReference Include="..\Ignixa.Serialization\Ignixa.Serialization.csproj" />

--- a/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
@@ -295,10 +295,12 @@ public class TestScriptEvaluatorTests
 
     [Theory]
     [InlineData("4.*", "4.0.1")]
+    [InlineData("4", "4.0.1")]
     [InlineData("4.0", "4.0.1")]
     [InlineData("4.0.1", "4.0.1")]
     [InlineData("6.0.0", "6.0.0-ballot3")]
     [InlineData("4.0", "4.0")]
+    [InlineData("R4", "R4")]
     public async Task GivenVersionSpec_WhenActualVersionMatchesGranularity_ThenTestRuns(string spec, string fhirVersion)
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
@@ -334,6 +336,9 @@ public class TestScriptEvaluatorTests
     [InlineData("4.0", "4.3.0")]
     [InlineData("4.0.1", "4.0.2")]
     [InlineData("not-a-version", "4.0.1")]
+    [InlineData("4.0.1.2", "4.0.1")]
+    [InlineData("*", "4.0.1")]
+    [InlineData("4.-1", "4.0.1")]
     public async Task GivenVersionSpec_WhenActualVersionDoesNotMatchGranularity_ThenTestIsSkipped(string spec, string fhirVersion)
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
@@ -362,6 +367,95 @@ public class TestScriptEvaluatorTests
         report.TestResults.Count.ShouldBe(1);
         report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
         await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenFhirVersionsContainsNullElement_WhenExecuting_ThenTestIsSkippedWithoutThrowing()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionNullElement" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "NullSpecEntry",
+                    FhirVersions = [null!],
+                    Actions =
+                    [
+                        new OperationExpression { Type = "search", Resource = "Patient", Params = "?identifier:of-type=x" }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, fhirVersion: "4.0.1");
+
+        report.TestResults.Count.ShouldBe(1);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenFhirVersionsHasMultipleEntries_WhenAnyEntryMatchesActualVersion_ThenTestRuns()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionMultiEntry" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "MultiEntry",
+                    // First entry is unparseable, second doesn't match the actual minor - only the
+                    // third entry matches. Proves the loop keeps trying entries past a bad/mismatched
+                    // one instead of short-circuiting on the first.
+                    FhirVersions = ["not-a-version", "5.0", "4.0"],
+                    Actions =
+                    [
+                        new OperationExpression { Type = "search", Resource = "Patient", Params = "?identifier:of-type=x" }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, fhirVersion: "4.0.1");
+
+        report.TestResults.Count.ShouldBe(1);
+        report.TestResults[0].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenAllFhirVersionsTokensAreUnrecognizable_WhenExecuting_ThenSkipReasonFlagsPossibleTypo()
+    {
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionAllUnrecognizable" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "TypoedVersion",
+                    FhirVersions = ["4,0"],
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, fhirVersion: "4.0.1");
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("no recognizable version spec");
     }
 
     private static ResourceJsonNode CapabilityStatementWithPatientEverything() => ResourceJsonNode.Parse("""

--- a/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
@@ -293,6 +293,77 @@ public class TestScriptEvaluatorTests
         await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData("4.*", "4.0.1")]
+    [InlineData("4.0", "4.0.1")]
+    [InlineData("4.0.1", "4.0.1")]
+    [InlineData("6.0.0", "6.0.0-ballot3")]
+    [InlineData("4.0", "4.0")]
+    public async Task GivenVersionSpec_WhenActualVersionMatchesGranularity_ThenTestRuns(string spec, string fhirVersion)
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionGranularityMatch" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "GranularVersion",
+                    FhirVersions = [spec],
+                    Actions =
+                    [
+                        new OperationExpression { Type = "search", Resource = "Patient", Params = "?identifier:of-type=x" }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, fhirVersion: fhirVersion);
+
+        report.TestResults.Count.ShouldBe(1);
+        report.TestResults[0].Outcome.ShouldNotBe(TestScriptOutcome.Skip);
+        await _mockProvider.Received(1).ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("4.*", "5.0.0")]
+    [InlineData("4.0", "4.3.0")]
+    [InlineData("4.0.1", "4.0.2")]
+    [InlineData("not-a-version", "4.0.1")]
+    public async Task GivenVersionSpec_WhenActualVersionDoesNotMatchGranularity_ThenTestIsSkipped(string spec, string fhirVersion)
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "VersionGranularityMismatch" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "GranularVersion",
+                    FhirVersions = [spec],
+                    Actions =
+                    [
+                        new OperationExpression { Type = "search", Resource = "Patient", Params = "?identifier:of-type=x" }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None, fhirVersion: fhirVersion);
+
+        report.TestResults.Count.ShouldBe(1);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        await _mockProvider.DidNotReceive().ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>());
+    }
+
     private static ResourceJsonNode CapabilityStatementWithPatientEverything() => ResourceJsonNode.Parse("""
         {
           "resourceType": "CapabilityStatement",


### PR DESCRIPTION
## What

`TestScriptEvaluator.IsVersionCompatible` matched a test's declared `fhirVersions` (from the `http://ignixa.io/testscript/fhirVersions` extension) against the caller-supplied version with an exact, case-insensitive string comparison. This PR adds a granular alternative alongside it:

- `"4.*"` (or bare `"4"`) — matches any version with Major == 4
- `"4.0"` — matches any version with Major == 4 and Minor == 0 (patch ignored)
- `"4.0.1"` — matches only the exact Major.Minor.Patch

Comparison is on numeric Major/Minor/Patch only — prerelease/build metadata (e.g. `"6.0.0-ballot3"`) is ignored, so an exact-granularity spec of `"6.0.0"` still matches a ballot build of that release.

The actual/requested version is parsed with [`Semver`](https://www.nuget.org/packages/Semver) (`SemVersion.TryParse(..., SemVersionStyles.Any, ...)`) for robust handling of real-world version strings. Spec tokens (`"4.*"`, `"4.0"`, `"4.0.1"`) aren't valid semver on their own, so those are parsed with simple segment-splitting instead.

**Backward compatible**: the old exact-string match is kept as a fallback alongside the new granular comparison — a spec matches if either check succeeds. Existing suites declaring exact tokens (e.g. `"4.0"`, `"4.3"`, `"5.0"`) and existing callers keep working unchanged. Malformed spec tokens fail safe (don't match, don't throw) rather than breaking evaluation of other tokens.

## Why

Downstream in `ignixa-lab`, the FHIR version passed to this engine has no reliable way to line up with what a target server actually declares in its CapabilityStatement — an exact-match-only comparison means version gating either matches by coincidence or systematically skips everything. This lays the groundwork for `ignixa-lab` to detect a target's real patch-level FHIR version (e.g. `"4.0.1"`) from its `/metadata` and gate tests against it deterministically, with suites able to choose the precision they actually need instead of being forced into exact numeric strings.

## Testing

`dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj` — 235/235 passing (net9.0 + net10.0), including all pre-existing version-gating tests plus new coverage for the wildcard/major-minor/exact/prerelease/malformed-token/backward-compat cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)