### PR TITLE
fix(fhirpath): add AsString() extension for spec-conformant scalar stringification

### DIFF
--- a/docs/site/docs/core-sdk/fhirpath.md
+++ b/docs/site/docs/core-sdk/fhirpath.md
@@ -94,6 +94,25 @@ var age = element.Scalar("age()");
 var count = element.Scalar("name.count()");
 ```
 
+:::warning
+`Scalar()` returns the raw boxed .NET value. Don't call `.ToString()` on it to get display
+text — a boolean gives `"True"` instead of FhirPath's `"true"`, and decimals format per the
+current culture. Use `Select(expr).AsString()` for spec-conformant strings.
+:::
+
+### AsString
+
+Converts a single-result expression to its FhirPath string representation (the spec's
+`toString()` rules — lowercase booleans, invariant-culture decimals):
+
+```csharp
+var hasAddress = element.Select("address.exists()").AsString();  // "false", not "False"
+var birthDate = element.Select("birthDate").AsString();
+```
+
+Returns `null` if the expression yields empty, multiple values, or a non-convertible value —
+matching `Scalar()`'s empty/multiple contract.
+
 ### IsTrue / IsBoolean
 
 Returns boolean evaluation:
@@ -417,7 +436,7 @@ IEnumerable<IElement> results = compiled != null
 ```
 
 :::note
-Most applications should use the `Select()`, `Scalar()`, `IsTrue()` extension methods which handle caching automatically. Direct API access is only needed for custom caching strategies or AST inspection.
+Most applications should use the `Select()`, `Scalar()`, `AsString()`, `IsTrue()` extension methods which handle caching automatically. Direct API access is only needed for custom caching strategies or AST inspection.
 :::
 
 ## Performance Tips

--- a/docs/site/docs/core-sdk/fhirpath.md
+++ b/docs/site/docs/core-sdk/fhirpath.md
@@ -110,8 +110,8 @@ var hasAddress = element.Select("address.exists()").AsString();  // "false", not
 var birthDate = element.Select("birthDate").AsString();
 ```
 
-Returns `null` if the expression yields empty, multiple values, or a non-convertible value —
-matching `Scalar()`'s empty/multiple contract.
+Returns `null` if the expression yields empty, multiple values, or the single result has no
+primitive value (e.g. a complex/backbone element) — matching `Scalar()`'s empty/multiple contract.
 
 ### IsTrue / IsBoolean
 

--- a/docs/site/docs/core-sdk/overview.md
+++ b/docs/site/docs/core-sdk/overview.md
@@ -151,8 +151,8 @@ var names = element.Select("name.given");
 // Boolean check
 var isActive = element.IsTrue("active = true");
 
-// Scalar value
-var birthDate = element.Scalar("birthDate")?.ToString();
+// Scalar value as its FhirPath string representation
+var birthDate = element.Select("birthDate").AsString();
 ```
 
 ### Validate Resources

--- a/src/Core/Ignixa.FhirPath/Evaluation/Functions/TypeConversionFunctions.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/Functions/TypeConversionFunctions.cs
@@ -160,8 +160,8 @@ internal static class TypeConversionFunctions
         if (value is bool b)
             return [FunctionHelpers.CreateString(b ? "true" : "false")];
 
-        // All other types use their standard ToString()
-        return [FunctionHelpers.CreateString(value.ToString()!)];
+        // All other types: use invariant culture so numeric/date formatting doesn't vary by server locale
+        return [FunctionHelpers.CreateString(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture)!)];
     }
 
     /// <summary>

--- a/src/Core/Ignixa.FhirPath/Evaluation/Functions/TypeConversionFunctions.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/Functions/TypeConversionFunctions.cs
@@ -160,6 +160,10 @@ internal static class TypeConversionFunctions
         if (value is bool b)
             return [FunctionHelpers.CreateString(b ? "true" : "false")];
 
+        // Strings are the most common case; skip the Convert.ToString interface dispatch for them
+        if (value is string s)
+            return [FunctionHelpers.CreateString(s)];
+
         // All other types: use invariant culture so numeric/date formatting doesn't vary by server locale
         return [FunctionHelpers.CreateString(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture)!)];
     }

--- a/src/Core/Ignixa.FhirPath/Evaluation/TypedElementExtensions.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/TypedElementExtensions.cs
@@ -6,6 +6,7 @@
  */
 
 using System.Collections.Concurrent;
+using Ignixa.FhirPath.Evaluation.Functions;
 using Ignixa.FhirPath.Expressions;
 using Ignixa.Abstractions;
 using Ignixa.FhirPath.Parser;
@@ -102,6 +103,13 @@ public static class TypedElementExtensions
     /// <param name="expression">FhirPath expression string</param>
     /// <param name="context">Optional evaluation context</param>
     /// <returns>Single scalar value, or null if expression returns empty/multiple values</returns>
+    /// <remarks>
+    /// Returns the raw boxed value (bool, decimal, string, ...). Calling <c>.ToString()</c> on it
+    /// produces CLR formatting, not FhirPath formatting — a boolean renders as "True", not the
+    /// spec's "true", and decimals are culture-sensitive. To get the FhirPath string representation
+    /// of a result, use <see cref="AsString"/> on <see cref="Select"/> instead, e.g.
+    /// <c>input.Select(expression).AsString()</c>.
+    /// </remarks>
     public static object? Scalar(this IElement input, string expression, EvaluationContext? context = null)
     {
         var results = input.Select(expression, context).ToList();
@@ -112,6 +120,23 @@ public static class TypedElementExtensions
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Converts a single-item element collection to its FhirPath string representation
+    /// (the spec's <c>toString()</c> rules: lowercase booleans, invariant-culture decimals).
+    /// </summary>
+    /// <param name="elements">The element collection to convert, typically the result of <see cref="Select"/></param>
+    /// <returns>The FhirPath string representation, or null if the collection is empty, has multiple items, or is not convertible</returns>
+    /// <example>
+    /// <code>
+    /// var hasAddress = element.Select("address.exists()").AsString(); // "false", not "False"
+    /// </code>
+    /// </example>
+    public static string? AsString(this IEnumerable<IElement> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        return TypeConversionFunctions.ToString(elements).SingleOrDefault()?.Value as string;
     }
 
     /// <summary>

--- a/src/Core/Ignixa.FhirPath/Evaluation/TypedElementExtensions.cs
+++ b/src/Core/Ignixa.FhirPath/Evaluation/TypedElementExtensions.cs
@@ -127,7 +127,12 @@ public static class TypedElementExtensions
     /// (the spec's <c>toString()</c> rules: lowercase booleans, invariant-culture decimals).
     /// </summary>
     /// <param name="elements">The element collection to convert, typically the result of <see cref="Select"/></param>
-    /// <returns>The FhirPath string representation, or null if the collection is empty, has multiple items, or is not convertible</returns>
+    /// <returns>The FhirPath string representation, or null if the collection is empty, has multiple items, or the single element has no primitive value (e.g. a complex/backbone element)</returns>
+    /// <remarks>
+    /// Use this instead of <see cref="Scalar"/> followed by <c>.ToString()</c>, which produces CLR
+    /// formatting rather than the spec's — see the warning on <see cref="Scalar"/>.
+    /// </remarks>
+    /// <seealso cref="Scalar"/>
     /// <example>
     /// <code>
     /// var hasAddress = element.Select("address.exists()").AsString(); // "false", not "False"

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -621,7 +621,7 @@ public sealed class TestScriptEvaluator(
 
         var resolvedExpr = VariableResolver.Resolve(c.Expression, context);
         var resolvedValue = VariableResolver.Resolve(c.Value ?? string.Empty, context);
-        var actual = body.ToElement(schemaProvider).Scalar(resolvedExpr)?.ToString();
+        var actual = body.ToElement(schemaProvider).Select(resolvedExpr).AsString();
 
         var passed = EvaluateWithOperator(actual, resolvedValue, c.Operator);
         return (passed, passed

--- a/src/Core/Ignixa.TestScript/Evaluation/VariableExtractor.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/VariableExtractor.cs
@@ -79,7 +79,7 @@ internal static class VariableExtractor
         if (body is null) return null;
         try
         {
-            return body.ToElement(schema).Scalar(expression)?.ToString();
+            return body.ToElement(schema).Select(expression).AsString();
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex) when (ex is FormatException or InvalidOperationException or NotSupportedException or ArgumentException)

--- a/test/Ignixa.FhirPath.Tests/Evaluation/ConversionAndStringFunctionTests.cs
+++ b/test/Ignixa.FhirPath.Tests/Evaluation/ConversionAndStringFunctionTests.cs
@@ -4,6 +4,7 @@
  * Unit tests for FhirPath type conversion, string manipulation, and utility functions (Phase 3).
  */
 
+using System.Globalization;
 using Ignixa.FhirPath;
 using Ignixa.FhirPath.Evaluation;
 using Ignixa.Abstractions;
@@ -239,6 +240,108 @@ public class ConversionAndStringFunctionTests
 
         // Assert
         Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region AsString Extension Tests
+
+    [Fact]
+    public void GivenBooleanTrue_WhenAsString_ThenReturnsLowercaseTrue()
+    {
+        // Arrange
+        var expr = _parser.Parse("true");
+        var root = CreateIntegerElement(0);
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Equal("true", result);
+    }
+
+    [Fact]
+    public void GivenBooleanFalse_WhenAsString_ThenReturnsLowercaseFalse()
+    {
+        // Arrange - this is the bug PR #294 fixed: Scalar()?.ToString() gave "False", not "false"
+        var expr = _parser.Parse("false");
+        var root = CreateIntegerElement(0);
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Equal("false", result);
+    }
+
+    [Fact]
+    public void GivenString_WhenAsString_ThenReturnsSameValue()
+    {
+        // Arrange
+        var expr = _parser.Parse("'hello'");
+        var root = CreateIntegerElement(0);
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public void GivenEmptyCollection_WhenAsString_ThenReturnsNull()
+    {
+        // Arrange
+        var expr = _parser.Parse("{}");
+        var root = CreateIntegerElement(0);
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GivenMultipleValues_WhenAsString_ThenReturnsNull()
+    {
+        // Arrange
+        var expr = _parser.Parse("1 | 2");
+        var root = CreateIntegerElement(0);
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GivenDecimal_WhenAsStringUnderNonInvariantCulture_ThenUsesInvariantFormatting()
+    {
+        // Arrange - parse/evaluate under the default culture first (FHIRPath literal parsing
+        // is a separate, pre-existing concern not covered by this fix). Only the AsString()
+        // conversion itself needs to be culture-invariant, so switch culture just for that call.
+        var expr = _parser.Parse("1.5");
+        var root = CreateIntegerElement(0);
+        var elements = _evaluator.Evaluate(root, expr).ToList();
+
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // de-DE uses ',' as the decimal separator; FHIRPath toString() must still render "1.5".
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            // Act
+            var result = elements.AsString();
+
+            // Assert
+            Assert.Equal("1.5", result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     #endregion

--- a/test/Ignixa.FhirPath.Tests/Evaluation/ConversionAndStringFunctionTests.cs
+++ b/test/Ignixa.FhirPath.Tests/Evaluation/ConversionAndStringFunctionTests.cs
@@ -317,6 +317,21 @@ public class ConversionAndStringFunctionTests
     }
 
     [Fact]
+    public void GivenComplexElement_WhenAsString_ThenReturnsNull()
+    {
+        // Arrange - a complex/backbone element has Value == null; AsString() must report this
+        // as "not convertible" (null), not leak a CLR type name or throw.
+        var expr = _parser.Parse("name");
+        var root = CreatePatientWithName();
+
+        // Act
+        var result = _evaluator.Evaluate(root, expr).AsString();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void GivenDecimal_WhenAsStringUnderNonInvariantCulture_ThenUsesInvariantFormatting()
     {
         // Arrange - parse/evaluate under the default culture first (FHIRPath literal parsing

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
@@ -477,6 +477,38 @@ public class AssertionEvaluatorTests
     }
 
     [Fact]
+    public async Task GivenFhirPathValueCriteria_WhenExpressionReturnsDecimal_ThenComparesAsString()
+    {
+        // Arrange - proves the AsString() path (not just bool) flows correctly through the
+        // TestScriptEvaluator assertion pipeline end-to-end.
+        //
+        // Deliberately NOT forcing a non-invariant CurrentCulture here: SchemaAwareElement.Value
+        // (src/Core/Ignixa.Serialization/SourceNodes/SchemaAwareElement.cs:185) parses the JSON
+        // decimal text via decimal.TryParse(text) with no NumberStyles/CultureInfo, so under e.g.
+        // de-DE "1.5" is misparsed as 15 (the decimal VALUE, not just its later string rendering) -
+        // that's a separate, pre-existing bug in JSON->IElement materialization, out of scope for
+        // this PR's AsString()/toString() fix and not reproducible in isolation at this level.
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse
+            {
+                StatusCode = 200,
+                Body = JsonSourceNodeFactory.Parse("""{"resourceType": "Observation", "id": "1", "valueQuantity": {"value": 1.5, "unit": "mg"}}""")
+            });
+
+        var definition = BuildDefinition(
+            new OperationExpression { Type = "read", Resource = "Observation", Params = "/1" },
+            new AssertExpression
+            {
+                Criteria = new FhirPathValueCriteria("Observation.valueQuantity.value", "1.5", AssertOperator.Equals)
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _r4Schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
     public async Task GivenFhirPathValueCriteria_WhenValueDoesNotMatch_ThenFails()
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionEvaluatorTests.cs
@@ -454,6 +454,29 @@ public class AssertionEvaluatorTests
     }
 
     [Fact]
+    public async Task GivenFhirPathValueCriteria_WhenExpressionReturnsBoolean_ThenComparesAsLowercaseString()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse
+            {
+                StatusCode = 200,
+                Body = JsonSourceNodeFactory.Parse("""{"resourceType": "Patient", "id": "abc"}""")
+            });
+
+        var definition = BuildDefinition(
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/abc" },
+            new AssertExpression
+            {
+                Criteria = new FhirPathValueCriteria("Patient.address.exists()", "false", AssertOperator.Equals)
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _r4Schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
     public async Task GivenFhirPathValueCriteria_WhenValueDoesNotMatch_ThenFails()
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())

--- a/test/Ignixa.TestScript.Tests/Evaluation/VariableExtractorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/VariableExtractorTests.cs
@@ -64,6 +64,47 @@ public class VariableExtractorTests
     }
 
     [Fact]
+    public async Task GivenExpressionExtractionOfBooleanValue_WhenExtracting_ThenSubstitutesLowercaseString()
+    {
+        // Same bug class as the fhirpath-value assertion evaluator: a Scalar()?.ToString()
+        // would render boolean extractions as "True", not the FhirPath-spec "true".
+        var responses = new Queue<TestResponse>(new[]
+        {
+            new TestResponse
+            {
+                StatusCode = 200,
+                Body = JsonSourceNodeFactory.Parse("""{"resourceType":"Patient","id":"1","active":true}""")
+            },
+            new TestResponse { StatusCode = 200 }
+        });
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => responses.Dequeue());
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "BooleanExpression" },
+            Variables = [new VariableDefinition { Name = "isActive", Extraction = new ExpressionExtraction("Patient.active") }],
+            Setup = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }],
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "UseIsActive",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/${isActive}" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _r4Schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+        await _mockProvider.Received().ExecuteAsync(
+            Arg.Is<TestRequest>(r => r.Url == "Patient/true"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GivenExpressionExtractionWithBadSyntax_WhenExtracting_ThenRecordsErrorNotSilentlyIgnored()
     {
         _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary
- Supersedes #294. That PR fixed `TestScriptEvaluator.EvaluateFhirPathValue` calling `.Scalar(expr)?.ToString()` on a FHIRPath result — a boxed `bool` renders as .NET's `"True"`/`"False"` instead of the spec's lowercase `"true"`/`"false"`, causing `fhirpath-value` assertions on boolean-returning expressions (e.g. `Patient.address.exists() = 'false'`) to fail even when the server is correct.
- #294's fix special-cased `bool` with an inline ternary at the call site, duplicating logic already owned by `TypeConversionFunctions.ToString()` (the actual FHIRPath `toString()` function), and it missed the **identical** bug in `VariableExtractor.ExtractFromBodyByExpression` — a boolean-valued expression used for TestScript variable extraction has the same problem, unfixed by #294.
- This PR adds a shared `AsString()` extension on `IEnumerable<IElement>` (`TypedElementExtensions.cs`, next to `Select`/`Scalar`/`IsTrue`) that routes through `TypeConversionFunctions.ToString()` for *any* value type, not just `bool`. Both `TestScriptEvaluator.cs` and `VariableExtractor.cs` now call `Select(expr).AsString()` instead of `Scalar(expr)?.ToString()`.
- Also fixes `TypeConversionFunctions.ToString()`'s fallback for non-bool types to use invariant culture — `Convert.ToString(value)` is otherwise locale-sensitive (a `decimal` renders `"1,5"` on a de-DE server), the same bug class one type over from the original bool-casing bug.
- Compared against Firely's SDK (`Hl7.Fhir.Base/FhirPath/CompiledExpression.cs`): their `Scalar()` also returns a raw boxed `object?` with no spec-conformant string helper, so `AsString()` fills a gap the reference implementation leaves open rather than deviating from it. The boolean-assert path (`FhirPathCriteria` → `IsTrue`) already used the correct predicate function and needed no change.

## Test plan
- [x] Added `AsString()` unit tests (`ConversionAndStringFunctionTests.cs`): bool → lowercase, empty → null, multiple → null, string passthrough, decimal under a forced de-DE `CurrentCulture` → `"1.5"`
- [x] Added `GivenFhirPathValueCriteria_WhenExpressionReturnsBoolean_ThenComparesAsLowercaseString` (`AssertionEvaluatorTests.cs`) — the assertion-path regression #294 also covered
- [x] Added `GivenExpressionExtractionOfBooleanValue_WhenExtracting_ThenSubstitutesLowercaseString` (`VariableExtractorTests.cs`) — the variable-extraction path #294 missed
- [x] `dotnet build All.sln` — 0 warnings, 0 errors
- [x] `dotnet test test/Ignixa.FhirPath.Tests` and `dotnet test test/Ignixa.TestScript.Tests` — all green on net9.0 + net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)