### PR TITLE
docs: add codegen feature investigation on dropping fhir-codegen dependency

### DIFF
--- a/docs/features/codegen/investigations/absorb-parsing-drop-fhir-codegen-dependency.md
+++ b/docs/features/codegen/investigations/absorb-parsing-drop-fhir-codegen-dependency.md
@@ -1,0 +1,65 @@
+# Investigation: Absorb Parsing, Drop `fhir-codegen` Dependency
+
+**Feature**: codegen
+**Status**: In Progress
+**Created**: 2026-07-05
+
+## Approach
+
+Replace the vendored `fhir-codegen` submodule's FHIR-package-parsing responsibility with a small, purpose-built loader we own, so our 9 `ILanguage` generator implementations (`codegen/Ignixa.Specification.Generators/CSharp*.cs`) no longer depend on `fhir-codegen`'s `PackageLoader`/`DefinitionCollection`, and — transitively — no longer depend on the vendored Firely SDK's typed, enum-backed FHIR model at all.
+
+Concretely: write a loader that reads a `hl7.fhir.{version}.core` package's `StructureDefinition`, `SearchParameter`, `ValueSet`, `CodeSystem`, and `CompartmentDefinition` JSON files directly (via `System.Text.Json`, no Firely SDK POCOs in the path), extracting exactly the fields our generators actually consume (name, cardinality, type references, binding strength/valueset URL, search parameter type/base/target/expression, compartment resource/code lists, code system concepts) into a small internal model shaped like — but not the same type as — `fhir-codegen`'s `DefinitionCollection`. Each `CSharp*Language.cs` generator would then read from our own model instead of `fhir-codegen`'s. Once every generator is migrated and cross-checked against current output (see Alignment below), drop the `third-party/fhir-codegen` submodule entirely.
+
+This does **not** propose reimplementing FHIR validation, StructureMap/conversion, or anything beyond what today's 9 generators actually read.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Eliminates the recurring "Firely SDK's baked-in enum predates the current ballot" crash class permanently — confirmed root cause of 4 separate `InvalidCastException`s during the R6 ballot4 upgrade (`docs/adr/adr-2607-fhir-r6-ballot4-upgrade.md`), and the reason `SearchParameter.aliasCode` is silently unrepresentable today | Real, non-trivial engineering effort: a working (if narrowly-scoped) FHIR package parser, migrated across all 9 generator languages, cross-validated against 5 FHIR versions |
+| Drops the `third-party/fhir-codegen` submodule dependency entirely — no more submodule staleness (this upgrade found it 432 commits behind), no more personal-fork CI-availability risk (this upgrade's accepted, documented trade-off) | Loses `fhir-codegen`'s general-purpose robustness for anything outside this repo's actual usage (arbitrary IGs, non-core packages, StructureMap-based conversion) — acceptable per this repo's actual scope (only ever runs against `hl7.fhir.{version}.core`), but a real boundary to respect going forward |
+| Strong, proven prior art already exists in this exact codebase to build on (see Evidence) — this is not starting from zero | `fhir-codegen` genuinely does more than our generators use (compartment inheritance resolution, cross-version StructureMap conversion, etc.) — a naive read of "what do we use today" risks under-scoping if generator requirements grow later |
+| Removes the entire class of "Firely SDK enum vs. this ballot's codes" bugs, since our own model has no enum at all — every FHIR code becomes a plain string, matching the `*Element`/`ObjectValue` raw-string fix pattern this upgrade already proved out, just applied from the start instead of patched in reactively | Any future FHIR structural change our generators DO need to react to (e.g. a new element kind) becomes our own parsing bug to fix, not an upstream tool's — full ownership, full responsibility |
+| No `extern alias`/multi-SDK-version juggling ever needed — we're not carrying any versioned Firely SDK dependency for parsing at all | Need genuine confidence the snapshot-generation gap (see Evidence) never bites — verified true today, but is a standing constraint on scope (core packages only), not a permanent guarantee |
+
+## Alignment
+
+- [x] Follows architectural layering rules — codegen is already a separate solution (`codegen/IgnixaCodegen.sln`) isolated from the main solution's Central Package Management specifically to avoid dependency conflicts (`codegen/README.md`); replacing its parsing internals doesn't change that boundary.
+- [x] Developer Experience — a from-scratch, purpose-built parser with no enum-casting can only be *simpler* to reason about for contributors than debugging `InvalidCastException`s inside a vendored SDK's generated model, which is what this upgrade repeatedly required.
+- [x] Specification compliance — no change to what's generated (same 9 output languages, same public artifact shapes), only how the input package is read.
+- [x] Consistent with existing patterns — directly extends the `ISourceNavigator`/`JsonNodeSourceNode` pattern this repo already uses at runtime for exactly the same "avoid Firely SDK's typed model" reason (see Evidence). This is not a novel direction for this codebase; it's applying an already-adopted, already-proven pattern to a place that hasn't gotten it yet.
+
+## Evidence
+
+### Prior art already in this codebase for exactly this problem
+
+This repo has already solved the "don't couple to Firely SDK's typed model" problem once, at the **runtime** layer:
+
+- `src/Ignixa.SourceNodeSerialization/ElementModel/JsonNodeSourceNode.cs` implements `ISourceNavigator` as a schema-less, pure-`System.Text.Json.Nodes` FHIR resource navigator — no Firely SDK POCOs, no enum casts, no per-version model coupling. It already handles the FHIR-JSON-specific quirks a naive `JsonNode` walk would miss: shadow-property pairing (`birthDate`/`_birthDate`), choice-type suffix matching (`value[x]` → `valueString`/`valueCode`/etc.), and primitive content-vs-value distinction.
+- `docs/features/architecture/investigations/jsonobject-based.md` (**Status: Complete**, fully implemented) documents this exact migration — moving resource manipulation off Firely SDK POCOs onto `JsonObject`-based traversal — for the runtime request-handling path.
+- `docs/features/fhir-compatibility/investigations/isourcenode-consolidation.md` (**Status: Complete**) documents `ISourceNode` → `ISourceNavigator` renaming with an explicit parsing-vs-semantics separation, the same conceptual split this investigation's proposed loader needs (parse raw JSON → hand generators a small semantic model, no Firely types in between).
+- `docs/features/architecture/investigations/core-shims.md` (**Status: Viable**, not yet implemented) proposes the general architectural direction — a zero-Firely-dependency `Ignixa.Abstractions.Core` with SDK interop pushed into an opt-in shim layer — of which this investigation would be a codegen-specific instance.
+
+**Implication:** a build-time replacement parser should mirror or directly reuse `JsonNodeSourceNode`'s approach (and, where the exact same FHIR-JSON quirks apply, potentially the class itself or a shared helper) rather than write a JSON walker from scratch. This is proven-in-production code in this exact codebase, not an unproven approach.
+
+### Actual parsing surface required (scoping the effort honestly)
+
+`fhir-codegen`'s `DefinitionCollection` (`codegen/fhir-codegen/src/Fhir.CodeGen.Lib/Models/DefinitionCollection.cs`, ~3300 lines) parses `StructureDefinition`, `SearchParameter`, `ValueSet`, `CodeSystem`, and `CompartmentDefinition` from a package. The 9 generator languages under `codegen/Ignixa.Specification.Generators/` mostly do straightforward field extraction (element name/cardinality/type references, binding strength + valueset URL, search-parameter type/base/target/expression, compartment resource/code lists, code-system concepts) — not deep semantic processing.
+
+**One genuine risk, confirmed and scoped:** `DefinitionCollection.TryGenerateMissingSnapshots()` invokes Firely SDK's `SnapshotGenerator` to compute a `StructureDefinition`'s flattened "snapshot" from its "differential" when a snapshot is absent — a real algorithm (type-hierarchy resolution, constraint merging), not simple field extraction. **Verified directly:** `hl7.fhir.r6.core`'s own `StructureDefinition-Patient.json` (and core-package StructureDefinitions generally) ships **both** `snapshot` and `differential` already populated. Since this codegen pipeline only ever runs against `hl7.fhir.{version}.core` — never third-party IG/profile packages, which more commonly omit snapshots — `TryGenerateMissingSnapshots()` is very likely a no-op for every case this repo's codegen actually exercises today.
+
+**This must be an explicit, stated scope boundary of any implementation**, not an assumption baked in silently: a replacement parser is safe to skip snapshot generation entirely *as long as* this pipeline stays scoped to base FHIR core specs. If this codegen pipeline is ever extended to generate from third-party IGs/profiles (not part of any current plan), snapshot generation would need to be revisited.
+
+Not yet audited (worth a closer pass before committing to an implementation plan, not blocking for this investigation): field-by-field depth of `ValueSet`/`CodeSystem`/`CompartmentDefinition` parsing beyond what's listed above.
+
+## Verdict
+
+*Pending evaluation.*
+
+## Other approaches worth investigating (noted, not yet written up)
+
+This is the first investigation for the `codegen` feature area; three cheaper or differently-scoped alternatives are worth their own investigations before a final ADR:
+
+1. **Status quo, patch reactively.** Keep depending on `fhir-codegen`, open the pending upstream PR for the tolerant-parsing fix (`brendankowitz/fhir-codegen#r6-tolerant-parsing`), and keep fixing our own generator code's `Code<T>` accesses one crash at a time as future ballots exercise new enum-backed properties. Cheapest option; the recurring-toil and silent-content-gap risks (`SearchParameter.aliasCode`-style) remain.
+2. **Build a real `R6→R5` converter inside `fhir-codegen`**, mirroring the existing `Converter_43_50` family, so R6 content flows through the same R5-canonical pipeline every other version uses. Investigated and rejected as a first response during the ballot4 upgrade (dozens of files, and down-conversion still can't represent genuinely-new R6 content) — but still a smaller commitment than this investigation's full parser replacement, if the goal is "make `fhir-codegen` itself R6-correct" rather than "stop depending on it."
+3. **Make `fhir-codegen` genuinely R6-model-aware via `extern alias`**, threading real R6 POCOs through `DefinitionCollection` and every generator instead of R5-canonicalizing. The architecturally "correct" fix within `fhir-codegen`'s own design, and the largest of the three — full ballot-fidelity without ever dropping the tool, but the most invasive change to third-party code we'd need to maintain indefinitely.

--- a/docs/features/codegen/readme.md
+++ b/docs/features/codegen/readme.md
@@ -1,0 +1,34 @@
+# Feature: Codegen
+
+**Status**: Exploring
+**Created**: 2026-07-05
+
+## Problem Statement
+
+This repo's build-time code generation (`codegen/Ignixa.Specification.Generators/`) — which produces the per-FHIR-version core schema, reference metadata, value set provider, search parameter, compartment, and code system artifacts under `src/Core/Ignixa.Specification/Generated/` and `src/Core/Ignixa.Search/Generated/` — depends on a vendored third-party tool, [fhir-codegen](https://github.com/FHIR/fhir-codegen) (git submodule `third-party/fhir-codegen`), to parse official FHIR packages into a `DefinitionCollection` our own `ILanguage` implementations then read from.
+
+The FHIR R6 ballot2→ballot4 upgrade (`docs/adr/adr-2607-fhir-r6-ballot4-upgrade.md`) found this dependency is a real, recurring source of friction:
+
+- The submodule's parsing pipeline is **R5-canonical throughout** — every FHIR version's package content gets parsed into R5 concrete POCO types (Firely SDK `Hl7.Fhir.Model.*`), with converters bridging STU3/R4/R4B up to R5. **There is no R6→R5 converter and no native R6 model support**, so R6 content parses only as far as R5's shape tolerates it.
+- The vendored Firely SDK version (`Hl7.Fhir.R5` 5.13.1) bakes several FHIR code enums (`VersionIndependentResourceTypesAll`, `SearchParamType`, etc.) as fixed C# enum members at the SDK's release time. Any FHIR ballot that adds a new code value to one of these enums (confirmed 4 separate times during the ballot4 upgrade: `DeviceAlert`, `SearchParamType`'s `resource` value, and by extension any future new code) causes an `InvalidCastException` the first time our generator code touches that property, in a codebase we don't control.
+- Fixing this today means either (a) patching a personal fork of the vendored submodule (temporary, not upstreamed, a CI-availability risk — see the ADR), or (b) reactively patching our own generator code's property access one crash at a time as each new ballot exercises a previously-untouched enum-backed property.
+- This is not a one-time cost: R6 is pre-normative and will keep changing shape across ballots until it stabilizes, so this exact class of friction is expected to recur on every future ballot bump absent a structural change.
+
+**What this feature investigates:** whether to absorb the FHIR-package-parsing responsibility currently delegated to `fhir-codegen` into code we own — reading each package's raw JSON directly (e.g. via `System.Text.Json`) for exactly the fields our 9 generator languages actually need (element definitions, search parameter fields, compartment definitions, code system concepts), with no dependency on a versioned Firely SDK's typed/enum model — with the eventual goal of dropping the `fhir-codegen` submodule dependency entirely.
+
+## Constraints
+
+- Must not regress any of the 5 FHIR versions currently generated (STU3, R4, R4B, R5, R6).
+- Must not change the public shape/API of the generated artifacts consumed elsewhere in the repo (`R{Version}CoreSchemaProvider`, `R{Version}ReferenceMetadata`, `R{Version}ValueSetProvider`, `R{Version}SearchParameterDefinitions`, `R{Version}CompartmentDefinitions`, `R{Version}CodeSystemMappings`) unless a deliberate, separately-decided migration accompanies the change.
+- Any replacement must be verifiable against the same official FHIR packages already used (`hl7.fhir.{version}.core`), ideally with a way to diff old-generator-output vs new-generator-output for a known-good version (e.g. R5) before cutting over.
+- Should not block future ballot bumps in the interim — this is exploratory; the current fork-based approach remains in place until a decision is made and implemented.
+
+## Investigations
+
+| Investigation | Status | Summary |
+|--------------|--------|---------|
+| [absorb-parsing-drop-fhir-codegen-dependency](investigations/absorb-parsing-drop-fhir-codegen-dependency.md) | In Progress | Replace `fhir-codegen`'s FHIR-package parsing with our own JSON-based loader (mirroring the existing `ISourceNavigator`/`JsonNodeSourceNode` runtime pattern), eliminating the recurring Firely-SDK-enum-vs-current-ballot crash class and the vendored submodule dependency entirely |
+
+## Decision
+
+*No ADR yet - investigations in progress*


### PR DESCRIPTION
## Summary

- Adds a new `codegen` feature area (`docs/features/codegen/`) for investigations about this repo's build-time code generation tooling itself — a topic not covered by any existing feature area (search/validation/package-management cover downstream *consumers* of codegen output, not the tooling's own architecture).
- Adds the first investigation: whether to absorb FHIR-package parsing (currently delegated to the vendored `fhir-codegen` submodule and its Firely-SDK-typed model) into our own JSON-based loader, with the eventual goal of dropping the submodule dependency entirely.

## Why now

The R6 ballot2→ballot4 upgrade (`docs/adr/adr-2607-fhir-r6-ballot4-upgrade.md`, #305) found this dependency is a recurring source of friction: `fhir-codegen`'s vendored Firely SDK bakes FHIR codes as fixed enums tied to whatever ballot was current at the SDK's release, causing an `InvalidCastException` every time a later ballot introduces a new code — hit 4 separate times during that one upgrade. This investigation explores a structural fix rather than continuing to patch reactively.

Key finding: this repo already solved the equivalent problem at the *runtime* layer (`JsonNodeSourceNode`/`ISourceNavigator`, a schema-less JSON-based FHIR navigator with no Firely SDK POCOs) — a build-time replacement would extend an already-proven pattern, not invent a new one.

## Test plan

- [x] Docs-only change, no code touched
- [x] Follows this repo's established `/fn-feature` + `/fn-investigation` workflow and template conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2FiTMJYW18kySsq3io9di