### PR TITLE
feat(validation): conformance harness + invariant/reference correctness fixes

### DIFF
--- a/docs/adr/adr-2607-forward-only-validation-context.md
+++ b/docs/adr/adr-2607-forward-only-validation-context.md
@@ -1,0 +1,110 @@
+# ADR 2607: Forward-Only Nodes with Descending Context Scopes
+
+## Status
+
+Accepted
+
+> Implemented via PR #286 (tree-context scoping) and the element-scoped invariant altitude fix on
+> `feat/validation-implementation`. Validated against the official HL7 FHIR validator conformance
+> suite (see [validation roadmap](../features/validation/roadmap.md)).
+
+## Context
+
+A recurring claim — heard again at FHIR DevDays 2026 — is that FHIR resource validation *requires
+bidirectional tree navigation*: the parsed data nodes must carry parent pointers so validation can
+walk upward. Firely's SDK embodies this with `ScopedNode`, a parent-aware wrapper over
+`ITypedElement`.
+
+The claim is motivated by real needs that appear to require reaching "up" from a deep element:
+
+- Invariants that reference `%resource` / `%rootResource` (e.g. `dom-*`, `bdl-*`).
+- `resolve()` — following a `Reference` to a contained resource or another Bundle entry.
+- Slicing discriminators that inspect sibling elements.
+- Error-path reporting (`Patient.contact[2].name`) which names ancestors.
+
+Ignixa's `IElement` model is deliberately **forward-only**: immutable, no parent pointer, navigation
+only downward via `Children()`. That model is cheaper, thread-safe, and avoids the lifecycle and
+allocation cost of parent-linked nodes — but it appears to conflict with the needs above.
+
+## Decision
+
+**We reject bidirectional node navigation. Nodes stay forward-only; the information that would
+otherwise be reached by walking up is instead *carried down* with the traversal in a context scope.**
+
+Navigation and information flow are separate axes. Navigation is always forward. What flows "up" is a
+*bounded, enumerable* set of context, threaded through descent and pushed at the boundaries where it
+is known:
+
+- `ValidationState` carries the descending context: a `Global`/`Instance`/`Location` chain plus a
+  `Scope` (`ResourceScope`).
+- `ResourceScope` carries `%resource`, `%rootResource`, and a `resolve()` delegate (backed by
+  `ReferenceIndex`: contained `#id` + intra-Bundle `fullUrl` / `Type/id`).
+- Scope is forked at the two resource boundaries — `EnterRootResource` (handler entry) and
+  `EnterContainedResource` (contained recursion). `FhirPathInvariantCheck.BuildEvaluationContext`
+  materializes a `FhirEvaluationContext { Resource, RootResource, ElementResolver }` from the scope;
+  when scope is unseeded it falls back to context-free evaluation.
+- Element-scoped constraints (e.g. `pat-1` on `Patient.contact`) are evaluated at the altitude of
+  their owning element — injected into that element's nested schema and run per-occurrence by
+  `NestedComplexTypeCheck` — never hoisted to the resource root.
+
+The load-bearing reason this is sufficient: **standard FHIRPath has no upward operator.** There is no
+`parent()` and no `..`. Every expression navigates forward from a defined context, and the only
+external references it can make are the finite set above. Because the set is known in advance,
+threading it exactly is complete — a parent pointer's value is answering questions you did not know
+you would ask, and validation is a known algorithm that does not ask them.
+
+## Rationale
+
+- **FHIRPath is downward-only.** The context needed (`%resource`, `%rootResource`, `resolve()`,
+  current node, and the location path for error reporting) is bounded and can be carried.
+- **The reference implementations agree.** The HL7 Java reference validator threads a `NodeStack`
+  through its walk (carried context, not parent-pointed data nodes). The Rust `rh-validator` we
+  benchmark against evaluates invariants over untyped `serde_json::Value` with an explicit
+  `EvaluationContext(root, current)`. Only Firely's `ScopedNode` is the parent-pointer camp — a lazy
+  reconstruction convenience, not a fundamental requirement.
+- **Forward-only nodes are cheaper and safer:** immutable, thread-safe, no parent-link lifecycle, no
+  wrapper allocation per node.
+- **YAGNI.** Parent pointers buy ad-hoc upward queries that validation never issues.
+
+## Consequences
+
+**Positive**
+
+- No parent pointers on `IElement`; the model stays immutable and thread-safe.
+- The two "hard" cases that supposedly need backward navigation — `resolve()`/`%resource` invariants
+  and slicing — are handled as carried context and parent-altitude forward checks respectively.
+- Conformance evidence: across the invariant fixes, over-strict cases (valid resources we wrongly
+  reject — a validator's worst failure mode) fell from **54 to 19** on the R4 clean-base slice, with
+  no case requiring a back-pointer.
+
+**Negative — the cost, and what reviewers must check**
+
+Correctness moves from "guaranteed by the data structure" to "guaranteed by discipline." Two failure
+modes replace the ones parent pointers would prevent:
+
+1. **Missed boundary push.** `%resource` is only correct if a scope was forked at *every* resource
+   root — the outer resource, each `contained`, each Bundle entry. Miss one `EnterContainedResource`
+   and `%resource` is silently wrong, with no node to walk up from to self-correct.
+2. **Wrong constraint altitude.** A constraint must run at the element it is defined on. Hoisting a
+   nested-element constraint to the root (the original `pat-1` bug) evaluates it against the wrong
+   node. Reviewers of new checks must confirm element-scoped constraints descend to their owner.
+
+Any code that seeds validation (handlers, the conformance runner, tests) must seed the scope the same
+way (`new ValidationState().EnterRootResource(element)`) or the context features silently no-op.
+
+## Alternatives considered
+
+- **Parent pointers on `IElement` (Firely `ScopedNode` style).** Rejected: mutable/heavier nodes,
+  thread-safety hazards, and generality the algorithm never uses.
+- **Lazy parent reconstruction (walk up on demand).** Rejected: same node-model downsides; only
+  advantage is tolerating missed boundary pushes, which we address by convention + tests instead.
+
+## References
+
+- PR #286 — tree-context scoping (`ValidationState`, `ResourceScope`, `ReferenceIndex`,
+  `ReferenceResolutionCheck`).
+- [tree-context-scoping investigation](../features/validation/investigations/tree-context-scoping.md)
+- [slicing-discriminators investigation](../features/validation/investigations/slicing-discriminators.md)
+  — slicing as a parent-altitude forward check.
+- [Validation roadmap](../features/validation/roadmap.md) — conformance measurement.
+- [ADR 2510: Three-Tier Validation Architecture](adr-2510-validation-architecture.md)

--- a/docs/features/validation/investigations/differential-snapshot-generation.md
+++ b/docs/features/validation/investigations/differential-snapshot-generation.md
@@ -1,0 +1,127 @@
+# Investigation: Differential → Snapshot Generation (own ElementMerger)
+
+**Feature**: validation
+**Status**: Planned (decision locked — build our own `ElementMerger`)
+**Created**: 2026-07-06
+
+## Problem Statement
+
+Ignixa cannot validate against profiles that ship **differential-only** StructureDefinitions. The
+adapter that turns a raw StructureDefinition into the validator's `IType` is snapshot-only:
+
+- `StructureDefinitionTypeAdapter` (`src/Core/Ignixa.PackageManagement/Infrastructure/`) requires
+  `snapshot.element`; its own doc-comment says *"Differential resolution is not performed —
+  StructureDefinitions without a snapshot return null. (Snapshot generation is a separate concern.)"*
+- `ProfileLayeredSchemaProvider` consequently **drops** any *"differential-only definition with no
+  snapshot"*.
+- Profile composition in `ProfileAwareValidationSchemaResolver.ResolveForElement` concatenates base +
+  profile schemas; it never merges a differential onto a base.
+
+Consequence: any IG or custom profile authored without a pre-built snapshot validates as base-spec
+only (constraints silently not enforced). The conformance suite's `profile`/package cases — currently
+excluded from the clean-base slice — cannot be run at all.
+
+## Decision (locked)
+
+Build our **own `ElementMerger`** (not Firely's `SnapshotGenerator`). Rationale: no `Hl7.Fhir.*`
+coupling in the Core/package layers, full control, idiomatic to the existing snapshot-element model,
+and directly informed by the Rust `rh-foundation` merger we studied. Firely's generator remains
+available in the **test layer only** as a differential oracle to grade our output against.
+
+## Key Insight — the seam is already isolated
+
+`StructureDefinitionTypeAdapter` already consumes a flat `snapshot.element` list. We do **not** need to
+touch the schema builder, the checks, or the resolver. We insert a generation step *upstream* of the
+adapter: given a StructureDefinition with only `differential`, produce a `snapshot.element` list, then
+hand it to the existing adapter. Everything downstream is unchanged.
+
+```
+raw SD (differential + baseDefinition)
+      │
+      ▼  NEW: SnapshotGenerator.Generate(sd)  ──resolves base, merges differential──►  snapshot.element
+      │
+      ▼  StructureDefinitionTypeAdapter.Adapt(snapshot)  (unchanged)
+      │
+      ▼  IType → StructureDefinitionSchemaBuilder → ValidationSchema  (unchanged)
+```
+
+## Reference design (Rust `rh-foundation`)
+
+`C:\Src\rh\crates\rh-foundation\src\snapshot\{generator,merger}.rs`:
+
+- `generate_snapshot_internal`: if the SD already carries a `snapshot`, use it as-is; else resolve
+  `baseDefinition` recursively to a snapshot and call `ElementMerger::merge_elements(base, diff)`.
+- Circular-dependency detection via a `visited` set.
+- `merger.rs`: matches differential elements to base by path/id, overrides constrained facets,
+  inserts new elements (extensions, slices).
+
+## Plan
+
+### Component
+
+New: `src/Core/Ignixa.PackageManagement/Infrastructure/Snapshot/SnapshotGenerator.cs` +
+`ElementMerger.cs` (one type per file). Operates on `System.Text.Json` `JsonElement`/`JsonNode` (same
+representation the adapter already consumes) — no new object model, no Firely types.
+
+Public surface:
+```
+JsonNode? GenerateSnapshotElements(JsonElement structureDefinition);  // returns snapshot.element array, or null
+```
+
+Base resolution uses the existing `IPackageResourceProvider` / embedded core definitions to fetch the
+`baseDefinition` SD; core R4 types resolve to their shipped snapshots.
+
+### Milestones (each measured by the conformance runner)
+
+**M1 — Base merge, constraint tightening (no slicing).** Resolve `baseDefinition` → base snapshot;
+walk it; for each `differential.element` matched by `path`, override the constrainable facets:
+`min`, `max`, `type`, `binding`, `fixed[x]`, `pattern[x]`, `short`, `definition`, `mustSupport`,
+`constraint`. Preserve base elements not in the differential. Recurse `baseDefinition` chain with
+cycle detection. This alone handles the bulk of US Core / AU Core constraint profiles.
+
+**M2 — Slicing + extension element insertion.** Insert differential elements that don't exist in the
+base: named slices (`elementId` with `:sliceName`), sliced extensions (`extension:foo`), and the
+`slicing` discriminator metadata on the sliced element. Feeds the in-progress
+[slicing-discriminators](slicing-discriminators.md) work (which needs the sliced elements present in
+the snapshot to enforce per-slice cardinality).
+
+**M3 — Type expansion + edge cases.** `contentReference`, expanding a complex datatype's children
+when a profile constrains into it, choice-type `[x]` narrowing, re-slicing, and `baseDefinition`
+pointing at another profile (profile-on-profile). Cycle/`visited` guard throughout.
+
+### Wiring
+
+1. `ProfileLayeredSchemaProvider` / `StructureDefinitionTypeAdapter` entry: when `snapshot` is absent
+   but `differential` + `baseDefinition` are present, call `SnapshotGenerator.GenerateSnapshotElements`
+   and adapt the result. When a snapshot is already present, use it as-is (parity with Rust; no
+   regeneration).
+2. Cache generated snapshots (keyed by canonical URL, version-stripped) — the resolver layer already
+   caches schemas via `CachedValidationSchemaResolver`; add snapshot-level caching in the provider to
+   avoid re-merging on every resolve.
+
+### Guardrails
+
+- **Compatibility depth** unchanged — snapshot generation only affects *which* elements exist; the
+  depth gating in `ValidationSchema.Validate` is untouched.
+- Generated snapshots must be **byte-comparable in intent** to package-shipped snapshots. Firely's
+  `SnapshotGenerator` (test-only) is the oracle: for profiles that ship *both* differential and
+  snapshot, generate from the differential and diff our element list against the shipped snapshot
+  (and against Firely's regeneration) — any divergence is a merger bug.
+
+## Verification
+
+- **Unit**: per-facet merge tests (min tighten 0→1, type restriction, fixed/pattern injection, slice
+  insertion), cycle detection, base-on-base recursion. AAA + Shouldly.
+- **Oracle diff**: for US Core / AU Core / CARIN profiles that ship snapshots, assert our generated
+  `snapshot.element` matches the shipped one (path set, cardinalities, bindings).
+- **Conformance**: enable the currently-deferred `profile`/package slice in `ValidatorConformanceRunner`
+  (extend `ConformanceCaseLoader` to load `packages`/`supporting`/`profile` cases). This is the real
+  scoreboard — Phase 2's payoff shows up here, not on clean-base. Track over-strict/under-strict on the
+  new slice.
+
+## References
+
+- [roadmap.md](../roadmap.md) — Phase 2.
+- [slicing-discriminators.md](slicing-discriminators.md) — consumer of M2 (needs sliced elements).
+- Rust: `C:\Src\rh\crates\rh-foundation\src\snapshot\{generator,merger}.rs`.
+- FHIR spec: [Snapshot Generation](https://hl7.org/fhir/R4/profiling.html#snapshot).

--- a/docs/features/validation/investigations/slicing-discriminators.md
+++ b/docs/features/validation/investigations/slicing-discriminators.md
@@ -1,0 +1,280 @@
+# Investigation: Slicing & Discriminator Validation
+
+**Feature**: validation
+**Status**: In Progress
+**Created**: 2026-06-17
+
+## Problem Statement
+
+`SlicingMetadata` is captured from every `ElementDefinition.slicing` during code-gen
+(`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs`) but the comment in that file is
+explicit: *"Slicing support is not yet implemented but metadata is captured for future use."*
+`StructureDefinitionSchemaBuilder` builds cardinality, type, shape, invariant, and binding checks
+for every tier (Minimal / Spec / Full — `ValidationDepth.cs`) but produces no `SlicingCheck` in
+`profileChecks` (`StructureDefinitionSchemaBuilder.cs:301-318`). The `ValidationSchema` doc-comment
+at line 29 acknowledges this: *"Profile checks (Full depth) — Slicing, advanced terminology, etc."*
+
+The practical consequence:
+
+- `Extension.extension` is sliced by `url` in every R4 StructureDefinition (the canonical example in
+  `reference-implementations.md`). Without slice assignment, ignixa cannot enforce that two
+  extensions with the same URL do not exceed their per-slice `max`.
+- Profile slicing (e.g., `us-core-patient.name` sliced into `official` / `nickname`) is completely
+  invisible to the validator.
+- Closed/`openAtEnd` slice rules — which must reject unmatched elements — are never applied.
+
+## Key Insight
+
+Slicing is not backward navigation. It is a **parent-altitude check**.
+
+The element *owning* the sliced array — e.g., the `Patient` node owning `name[*]` — already has
+all candidates available through `Children("name")`. The forward-only `IElement` model handles this
+natively: there is no need for a parent pointer, a `ScopedNode` wrapper, or any upward traversal.
+This is the same conclusion the [tree-context-scoping investigation](tree-context-scoping.md) reached
+when it classified slicing as *"not backward navigation at all … a parent-altitude check over
+`Children()`, which the forward-only model already supports"* (tree-context-scoping.md, Key Insight
+section).
+
+What slicing actually requires is a two-responsibility split:
+
+1. **Imperative shell** — slice *assignment*, per-slice cardinality accounting, closed/open rule
+   enforcement, and error reporting. This must be imperative code so diagnostics can say *"you have
+   2 elements matching slice 'official', expected at most 1, at Patient.name[3]"* rather than a
+   single boolean assertion.
+2. **FHIRPath predicate engine** — evaluate the per-element discriminator condition. Only this piece
+   delegates to the existing FhirPath engine. The discriminator `path` is itself restricted
+   FHIRPath: simple property navigation plus `resolve()`, `extension(url)`, and `ofType()`.
+
+This is the accurate reading of the phrase "HAPI compiles checks to FHIRPath" (confirmed in the
+[reference-implementations](reference-implementations.md) SliceValidator section): the FHIRPath
+engine evaluates the *discriminator predicate per candidate element*, not the whole-profile check.
+Firely's `SliceValidator` (`reference-implementations.md:458-506`) does exactly this — `Condition`
+per `SliceCase` is evaluated via `ValidateOne`, assignment is tracked imperatively in `buckets`,
+then per-slice cardinality is enforced over each bucket.
+
+### Discriminator Type Mapping
+
+The FHIR spec defines five discriminator types. Each maps cleanly to existing engine primitives:
+
+| Discriminator `type` | Discriminator `path` evaluates to | Engine primitive | Status |
+|---|---|---|---|
+| `value` | concrete scalar/code | FHIRPath equality: `path = 'literal'` | Fully implemented |
+| `pattern` | element matching a Pattern | FHIRPath `~` (equivalence) or `subsetOf()` | Implemented (`subsetOf`, `supersetOf` in `CollectionFunctions.cs`) |
+| `exists` | presence/absence | `path.exists()` | Implemented (`exists()` in `CollectionFunctions.cs`) |
+| `type` | FHIR type of the element | `ofType(T)` / `is T` | Implemented (`ofType` in `CollectionFunctions.cs`; `is`/`as` in `TypeConversionFunctions.cs`) |
+| `profile` | element conforms to a profile canonical | `conformsTo('url')` | **Stub** — throws `NotSupportedException` (`FhirSpecificFunctions.cs:404-411`); requires tree-context-scoping Solution 1 first |
+
+The most common discriminators in base R4 profiles (`value` on `url` for extensions, `value` on
+`system`/`code` for identifiers) require only equality — already working. `type` discriminators
+require `ofType` — already working. `profile` discriminators are the only case blocked on a
+prerequisite (see Dependency section below).
+
+## Approach
+
+A `SlicingCheck : IValidationCheck` at the **Full tier** (`ValidationDepth.Full`), registered in
+`_profileChecks` of `ValidationSchema`.
+
+The check owns the sliced element path (e.g., `"name"`), the `SlicingMetadata` captured by
+code-gen, and a per-slice list of `(discriminatorPredicate: string, min: int, max: int?)` compiled
+at schema-build time.
+
+Pseudocode of the core algorithm:
+
+```
+SlicingCheck.Validate(element, depth, state):
+    if depth < Full → return success  // guard: slicing is Full-tier only
+
+    candidates = element.Children(slicedPath)   // O(n) — one forward pass
+    if candidates.IsEmpty → check per-slice minimum cardinality for mandatory slices; return
+
+    // Assignment pass — O(slices × candidates) but slices are typically 2-5
+    buckets = Dictionary<sliceName, List<(IElement, int index)>>
+    defaultBucket = List<(IElement, int index)>
+    lastMatchedSliceIndex = -1
+
+    for (i, candidate) in candidates.WithIndex():
+        matched = false
+        for (s, slice) in slices.WithIndex():
+            predicateResult = fhirPathEngine.Evaluate(candidate, slice.DiscriminatorExpression, context)
+            if predicateResult.IsTrue():
+                if metadata.Ordered && s < lastMatchedSliceIndex:
+                    report Issue(OUT_OF_ORDER, "name[{i}] matches slice '{slice.Name}' out of order")
+                buckets[slice.Name].Add((candidate, i))
+                lastMatchedSliceIndex = s
+                matched = true
+                break  // first match wins; FHIR slicing is deterministic
+
+        if !matched:
+            if metadata.Rules == "closed":
+                report Issue(UNMATCHED_SLICE, "name[{i}] matches no slice in a closed slicing")
+            elif metadata.Rules == "openAtEnd" && lastMatchedSliceIndex >= 0:
+                report Issue(UNMATCHED_SLICE, "name[{i}] appears before end in an openAtEnd slicing")
+            else:
+                defaultBucket.Add((candidate, i))
+
+    // Cardinality pass — O(slices)
+    for slice in slices:
+        count = buckets[slice.Name].Count
+        if count < slice.Min:
+            report Issue(CARDINALITY_TOO_FEW, "slice '{slice.Name}': {count} < min {slice.Min}")
+        if slice.Max != null && count > slice.Max:
+            report Issue(CARDINALITY_TOO_MANY, "slice '{slice.Name}': {count} > max {slice.Max}")
+            for (elem, i) in buckets[slice.Name][slice.Max..]:
+                annotate Issue with "at name[{i}]"  // precise per-element location
+```
+
+`StructureDefinitionSchemaBuilder.BuildSchema` plugs this in where slicing metadata is present on
+an element. The builder already has access to `ITypeExtended`, which carries `SlicingMetadata` via
+code-gen.
+
+The `FhirEvaluationContext` passed to the discriminator evaluations must be built from
+`ValidationState.Scope` (the resource-scope populated by Solution 1 of the
+tree-context-scoping investigation) so that `%resource`, `resolve()`, and — once unblocked —
+`conformsTo()` are available.
+
+## Dependency on Tree-Context Scoping
+
+This investigation builds directly on [tree-context-scoping](tree-context-scoping.md) Solutions 1
+and 2:
+
+- **Solution 1 (resource scope threading)** is required for `profile` and `type` discriminators
+  whose `conformsTo()` predicate must be evaluated against the correctly-scoped `%resource`. Without
+  Solution 1, `conformsTo` would evaluate against an unscoped element (wrong), even after its
+  stub is replaced with a real implementation.
+- **Solution 2 (scoped reference index)** is required for reference discriminators that navigate
+  through `resolve()` to reach the target element. `resolve()` already returns empty when no
+  resolver is configured (`FhirSpecificFunctions.cs:94-96`), so without Solution 2, any
+  discriminator path containing `resolve()` silently produces no match and assigns all candidates
+  to the default bucket.
+
+For `value` and `exists` discriminators (the vast majority of base R4 usage), neither tree-context
+dependency is needed — `SlicingCheck` can be delivered as a partial implementation before
+tree-context-scoping lands, with `profile`-type discriminator support gated behind a capability
+flag.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Fits the existing `IValidationCheck` / `_profileChecks` slot without any new abstractions | O(slices × candidates) assignment pass; for rare deeply-nested slicings with many slices this is not O(n) |
+| Precise per-element diagnostics: reports `name[3]` not just "slicing failed" | Discriminator predicate evaluation re-walks the candidate for each slice until a match is found; early-exit on first match mitigates this significantly |
+| Forward-only `IElement` model is sufficient — no `ScopedNode`, no parent pointer | Nested slicing (reslicing within a slice) requires a recursive `SlicingCheck` per sub-slice; compiler complexity grows with nesting depth |
+| Delegate-injection pattern for `conformsTo` is already established (`ElementResolver` on `FhirEvaluationContext`) — clean seam, no new mechanism | `profile` discriminators blocked until tree-context-scoping Solution 1 lands and `conformsTo` stub is replaced |
+| `SlicingMetadata` already captures discriminators, rules, and ordered flag — code-gen work already done | A single-pass assignment (produce O(1) FHIRPath expression collapsing all predicates) would be faster but loses per-element location in error messages |
+| Aligns with Firely `SliceValidator` (bucket-based, condition per slice case) and HAPI's imperative assignment; no novel pattern to justify | `conformsTo()` injection adds a FHIRPath→Validation callback that must be wired carefully to avoid re-entrant validation cycles (same risk as the `ElementResolver` cycle, which is already managed) |
+| Closed/openAtEnd enforcement is straightforward boolean state on the assignment loop | `ordered` slicing requires tracking `lastMatchedSliceIndex`, which means unordered slicings cannot short-circuit early within a candidate's slice loop — minor |
+
+## Alignment
+
+- [x] Follows architectural layering rules — `SlicingCheck` lives in `Ignixa.Validation.Checks`,
+      consumes `IElement` (forward-only), delegates discriminator evaluation to `Ignixa.FhirPath`
+      via the context boundary; no `Hl7.Fhir.*` dependency introduced
+- [x] Developer Experience — plugs into the existing `_profileChecks` list; schema-builder already
+      has the slicing metadata; consumers see the same `IValidationIssue` shape as today
+- [x] Specification compliance — implements FHIR R4 `ElementDefinition.slicing` rules: ordered,
+      closed/open/openAtEnd, per-slice min/max cardinality, five discriminator types
+- [x] Consistent with existing patterns — `IValidationCheck`, `ValidationDepth.Full` gate,
+      `FhirEvaluationContext` from `ValidationState.Scope`, delegate-injection for `conformsTo`
+      mirroring the `ElementResolver` seam
+
+## Weakest-Link Analysis
+
+1. **`conformsTo()` re-entrancy.** Implementing `conformsTo` as a `Func<IElement, string, bool>`
+   delegate on `FhirEvaluationContext` (mirroring `ElementResolver`) means the FHIRPath engine
+   calls back into the validation pipeline for each `profile` discriminator. If a discriminator
+   predicate triggers further slicing which triggers further `conformsTo` calls, a cycle is
+   possible. Mitigation: the same per-resource cycle guard already used by
+   `ContainedResourceCheck` can be reused; `conformsTo` should not itself run Full-depth
+   validation (a Spec-depth structural check is sufficient for slice assignment).
+
+2. **Silent no-match on missing resolver.** A `profile` discriminator before tree-context-scoping
+   lands will cause `conformsTo` to throw `NotSupportedException`
+   (`FhirSpecificFunctions.cs:410`). The check must catch this and either skip the discriminator
+   (treating assignment as indeterminate — unsafe for closed slicings) or report a warning and
+   skip. The safer choice is to gate `profile`-discriminator slices with an explicit capability
+   flag rather than silently assigning all candidates to the default bucket.
+
+3. **`SlicingMetadata.Discriminators` is `string[]` without type annotation.** The current model
+   stores raw strings (`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs:22`) with no
+   separate `type` field — the discriminator type (value/pattern/exists/type/profile) is not
+   captured. Code-gen must be extended to emit a structured discriminator record (type + path)
+   before `SlicingCheck` can construct the correct FHIRPath predicate per discriminator. This is a
+   prerequisite schema-builder change, not a runtime change.
+
+4. **O(slices × candidates) for large arrays.** Patient bundles with hundreds of entries each
+   containing many sliced identifiers could make this quadratic in practice. Mitigation: a
+   single-pass trie-like pre-index over the discriminator values (for pure `value` discriminators)
+   can reduce this to O(candidates + slices); implement as an optimization after correctness is
+   established.
+
+## Evidence
+
+- **Metadata captured, logic absent.** `SlicingMetadata` constructor confirms discriminators,
+  rules, and ordered are all captured (`SlicingMetadata.cs:14-18`). The file-level comment *"not
+  yet implemented"* is unambiguous.
+- **Correct plug-in point.** `ValidationSchema._profileChecks` is explicitly documented as
+  *"Slicing, advanced terminology, etc."* (`ValidationSchema.cs:29`). `StructureDefinitionSchemaBuilder`
+  builds `profileChecks` (line 301) and currently populates it only with `invariantChecks` (line 308).
+  Adding `SlicingCheck` here follows the exact same pattern.
+- **FHIRPath primitives are ready.** `ofType` exists in `CollectionFunctions.cs:575`; `exists` at
+  line 27; `subsetOf`/`supersetOf` for pattern matching present. `is`/`as` type-testing operators
+  are in `TypeConversionFunctions.cs`. The only missing primitive is `conformsTo`
+  (`FhirSpecificFunctions.cs:397-411`), which throws `NotSupportedException` and is explicitly
+  flagged as needing *"profile validation infrastructure"*.
+- **Reference prior art.** Firely's `SliceValidator` in `reference-implementations.md:458-506`
+  uses bucket-based assignment with a `Condition.ValidateOne(candidate, vc, state)` discriminator
+  call — directly analogous to the proposed approach. HAPI's StructureDefinition XML shows the
+  canonical `Extension.extension` sliced-by-`url` example (`reference-implementations.md:579-598`),
+  confirming `value` discriminator on `url` is the single most important case to get right.
+- **GraphQL directive is not reusable.** `FhirSliceDirectiveType.cs` declares a `@slice(path:)`
+  GraphQL directive for HotChocolate query slicing — a completely different concept
+  (splitting a list result in a query response). It contains no slice-matching logic and shares
+  only the name.
+- **`ValidationDepth.Full` is the correct tier.** `ValidationDepth.cs:22` defines Full as
+  *"structure + required and extensible bindings, display checks, invariants/slicing"* — the
+  comment already names slicing explicitly.
+- **ADR-2510** (`docs/adr/adr-2510-validation-architecture.md`) established the three-tier schema
+  architecture that `SlicingCheck` slots into without revision.
+
+## Open Questions
+
+1. **`SlicingMetadata` schema gap.** The current `Discriminators: string[]` captures the
+   discriminator `path` but not the `type` (value/pattern/exists/type/profile). Should code-gen
+   emit a `DiscriminatorDefinition(string Type, string Path)` record, or should `SlicingCheck`
+   parse the type from a convention in the path string? The former is cleaner; it requires a
+   code-gen change and a new type in `Ignixa.Abstractions`.
+
+2. **Partial delivery.** Is it acceptable to ship `SlicingCheck` with `value`, `exists`, and `type`
+   discriminators working (no tree-context dependency) and `profile`/`resolve()` discriminators
+   gated behind a capability flag, before tree-context-scoping lands? Or should slicing wait for
+   the full foundation?
+
+3. **Nested / resliced slices.** When a slice itself contains a further sliced element (reslicing),
+   `SlicingCheck` must be applied recursively. Is the correct approach to emit a nested
+   `SlicingCheck` inside a `NestedComplexTypeCheck`, or to flatten the slice hierarchy at
+   schema-build time?
+
+4. **`conformsTo` cycle guard depth.** The re-entrant validation triggered by `profile`
+   discriminators should run at what depth — Minimal or Spec? Spec is sufficient to establish
+   profile conformance for slice assignment and avoids triggering further Full-depth slicing checks
+   recursively.
+
+## Verdict
+
+*Pending evaluation.* The hybrid approach — imperative assignment + FHIRPath discriminator
+predicate — is the clearly right direction: it matches Firely's `SliceValidator`, HAPI's design,
+and fits the existing `IValidationCheck` / `_profileChecks` slot without new abstractions.
+
+The strongest constraint on sequencing is the `SlicingMetadata` schema gap (Open Question 1): the
+current `string[]` for discriminators cannot distinguish discriminator `type` from `path`, so code-gen
+must emit a structured record before `SlicingCheck` can correctly choose between `value =`,
+`ofType()`, and `conformsTo()` predicates.
+
+Recommended sequencing once that gap is resolved:
+1. Extend code-gen to emit `DiscriminatorDefinition(Type, Path)` in `SlicingMetadata`.
+2. Implement `SlicingCheck` with `value`, `exists`, and `type` discriminators (no tree-context
+   dependency). Gate `profile`-discriminator paths with a capability flag that degrades to
+   open-slicing semantics.
+3. Land [tree-context-scoping](tree-context-scoping.md) Solutions 1 and 2.
+4. Implement `conformsTo()` injection via `FhirEvaluationContext` delegate; wire into
+   `SlicingCheck` for `profile` discriminators; remove the capability flag.

--- a/docs/features/validation/investigations/terminology-completeness.md
+++ b/docs/features/validation/investigations/terminology-completeness.md
@@ -1,0 +1,120 @@
+# Investigation: Terminology Completeness
+
+**Feature**: validation
+**Status**: Planned (decision locked — local valuesets + severity semantics + remote TX API)
+**Created**: 2026-07-06
+
+## Problem Statement
+
+Terminology is the single largest conformance gap on the R4 clean-base slice — it dominates both
+error directions:
+
+- **Over-strict (~9 cases):** we emit `IssueSeverity.Error` for codes whose system/valueset we cannot
+  resolve locally (unknown SNOMED/LOINC/example codes). The Java reference **warns** ("cannot verify")
+  rather than errors. We are wrong to fail these.
+- **Under-strict (~16 cases, `tx`/`tx-advanced`):** bindings we cannot verify at all because the
+  valueset isn't available locally and there is no terminology service.
+
+Current state:
+
+- `InMemoryTerminologyService` (`src/Core/Ignixa.Validation/Services/`) is **membership-only**;
+  `$lookup`/`$expand`/`$translate`/`$subsumes` are stubs.
+- `BindingCheck` depth-gates (Spec: required bindings only; Full: + extensible) and calls the async
+  service via blocking `.GetAwaiter().GetResult()`.
+- `ITerminologyService` already declares the full surface (`ValidateCode`, `ValidateBinding`,
+  `Lookup`, `Expand`, `Translate`, `Subsumes`).
+
+## Decision (locked)
+
+Three complementary pieces, in priority order:
+
+1. **Error-vs-warn severity semantics** — never error on a binding we cannot *verify*; only error when
+   we can positively determine a code is **not** in a **required** valueset.
+2. **Expanded local valuesets** — ship/load more valueset expansions so more bindings resolve locally
+   (offline, deterministic — matches the project's determinism goal and the Rust "local-first" model).
+3. **Remote terminology server API** — an optional `ITerminologyService` backed by a FHIR TX endpoint,
+   used as a fallback for what local data cannot decide.
+
+This mirrors the Rust `rh-validator` terminology model: **local-first, remote as fallback**, cached.
+
+## Plan
+
+### T1 — Severity semantics (immediate; no new dependencies)
+
+The over-strict fix, and a prerequisite for the other two so they don't regress.
+
+Binding outcome must distinguish three states, not two:
+
+| Local knowledge | Required binding | Extensible binding |
+|---|---|---|
+| Code **verified in** valueset | pass | pass |
+| Code **verified not in** valueset | **error** | warning |
+| Valueset/system **unresolvable** (can't verify) | **warning** (not error) | info/none |
+
+- Extend the binding path (`BindingCheck` + `InMemoryTerminologyService.ValidateBindingAsync` +
+  `BindingValidationResult`) to return `Unverifiable` distinctly from `NotInValueSet`.
+- `TerminologyFailureMode` (already on `ValidationSettings`) governs whether `Unverifiable` on a
+  required binding is Warning (default) or Error.
+- **Guardrail:** `ValidationDepth.Compatibility` keeps current leniency — no new errors at that depth.
+- Verify: the ~9 over-strict terminology cases flip to pass; no new over-strict. Add `BindingCheck`
+  tests for the three states.
+
+### T2 — Expanded local valuesets
+
+Close under-strict bindings without a network dependency.
+
+- Load valueset **expansions** and **code systems** from the FHIR core package + configured IG
+  packages via the existing `IValueSetProvider` / package layer (the code-system data is already
+  partly present for required bindings).
+- Precedence: IG valuesets override core (the provider already supports layering).
+- Cache membership by `(valueSet, system, code)` — this was the single biggest perf win in the Rust
+  validator (≈−99%); adopt the same LRU key.
+- Handle `compose.include` with enumerated concepts and simple system-wide includes locally; mark
+  `filter`-based includes as *unverifiable* (→ T1 warning, or T3 remote), matching Rust's
+  "not locally decidable" behavior.
+- Verify: `tx` under-strict cases with locally-available valuesets flip to caught; the split moves
+  from under-strict toward matched.
+
+### T3 — Remote terminology server API
+
+Fallback for what local data cannot decide (SNOMED/LOINC/large valuesets, `filter` includes).
+
+- New `HttpTerminologyService : ITerminologyService` (`src/Core/Ignixa.Validation/Services/`) calling
+  a FHIR TX endpoint: `$validate-code` (CodeSystem + ValueSet), `$expand`, `$lookup`, `$subsumes`,
+  `$translate`. `HttpClient` + `CancellationToken` (name it `cancellationToken`), typed Parameters
+  in/out.
+- `CachedTerminologyService` decorator: in-memory LRU + optional disk persistence (mirror Rust's
+  `CachedTerminologyService`), so repeated codes don't re-hit the server.
+- **Local-first composition:** a `LayeredTerminologyService` tries local (T2) first, remote only when
+  local is `Unverifiable`. Required-binding remote failures surface per `TerminologyFailureMode`;
+  remote unavailability degrades to Warning, never a hard error (server outage ≠ invalid resource).
+- Configuration: `TerminologyConfig` (endpoint URL, cache dir, on/off) wired through
+  `ValidationServicesRegistration`. Off by default — deterministic offline validation stays the
+  baseline; remote is opt-in.
+- Verify: conformance `tx`/`tx-advanced` cases against a configured `tx.fhir.org/r4` (in a
+  network-gated, non-CI test category — the offline suite must not depend on it).
+
+## Sequencing
+
+T1 first (fixes over-strict now, unblocks the rest), then T2 (offline coverage), then T3 (remote
+fallback). T1 and T2 move the offline conformance number; T3 is measured separately behind a network
+gate so the default suite stays deterministic.
+
+## Guardrails
+
+- **Compatibility depth** semantics unchanged throughout (MS FHIR Server / legacy Firely parity).
+- Offline determinism preserved — remote TX is opt-in; the default validator never requires network.
+- No `Hl7.Fhir.*` in Core — the TX client speaks FHIR JSON over HTTP directly.
+
+## Verification
+
+- Unit: three-state binding severity (T1); local membership incl. `compose.include` handling (T2);
+  HTTP client request/response shaping with a mock handler + cache decorator (T3).
+- Conformance: offline `tx` cases via `ValidatorConformanceRunner` (T1/T2); network-gated `tx` +
+  `tx-advanced` category (T3).
+
+## References
+
+- [roadmap.md](../roadmap.md) — Phase 3.
+- Rust: `C:\Src\rh\crates\rh-validator\src\terminology.rs` (local-first, cached, HTTP fallback).
+- Current: `InMemoryTerminologyService`, `BindingCheck`, `ITerminologyService`, `ValidationSettings.TerminologyFailureMode`.

--- a/docs/features/validation/investigations/tree-context-scoping.md
+++ b/docs/features/validation/investigations/tree-context-scoping.md
@@ -1,0 +1,269 @@
+# Investigation: Tree-Context Scoping (%resource, %rootResource, resolve())
+
+**Feature**: validation
+**Status**: Viable
+**Created**: 2026-06-17
+
+## Problem Statement
+
+ignixa's runtime element model (`IElement`) is **forward-only**: it exposes `Children()` and
+nothing else. There is no `Parent`, no `Ancestors()`, no enclosing-resource pointer. This is a
+deliberate contrast with the Firely SDK, whose `ScopedNode` wraps every `ITypedElement` with
+`Parent` / `ParentResource` pointers and lazily computes `%resource`, `resolve()`, and `Location`
+by walking *up* the tree (`firely-net-sdk/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs`).
+
+Three FHIR validation behaviours appear to need that upward/sideways navigation:
+
+1. **`%resource` / `%rootResource` in invariants** — e.g. `dom-1`, `bdl-*`. A constraint evaluated
+   deep inside a resource needs `%resource` to point back at the enclosing resource.
+2. **`resolve()` across Bundle entries and contained resources** — a `Reference` must find a
+   *sibling* `entry.resource` (by `fullUrl`) or a `#id` contained resource.
+3. **Slicing discriminators** — partition a sibling array into slices.
+
+Today the gap is real and silent. `FhirPathInvariantCheck.Validate` calls
+`_evaluator.Evaluate(element, expression)` with **no context**
+(`src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs:168`), so `%resource` auto-inits to
+*the constrained element itself* (`TypedElementExtensions.Select` defaults `Resource`/`RootResource`
+to the input). For a nested element `%resource` points at the wrong node, and `resolve()` returns
+empty because no resolver is wired. The existing test suite acknowledges this:
+*"Real dom-1 requires %resource variable ... not yet implemented."*
+
+## Key Insight: FHIRPath has no `parent()` operator
+
+The FHIRPath spec exposes exactly two "backward" capabilities — root-ward variables
+(`%resource`/`%rootResource`) and reference resolution (`resolve()`). There is **no** standard way
+for an expression to navigate to an arbitrary parent element. Firely's `ScopedNode.Parent` is
+internal plumbing used to *compute* those two things plus `Location`; it is never surfaced as a
+FHIRPath navigation step.
+
+Therefore ignixa does **not** need a parent pointer on the node. Both backward needs are computable
+**on the way down**: the traversal that descends the tree *is* the ancestor chain, so the walker's
+call stack already holds everything a `Parent` field would store. Storing parent pointers on the
+node would duplicate state the traversal already has — the wrong tool for this codebase.
+
+Slicing is not backward navigation at all (see *Related future work*): it is a parent-altitude check
+over `Children()`, which the forward-only model already supports.
+
+## Approach
+
+Two complementary changes, both staying on the current "dumb node + injected context" pathway. No
+change to `IElement`.
+
+### Solution 1 — Thread resource scope through `ValidationState`
+
+`ValidationState` is already an immutable record threaded through the validation pipeline with three
+levels (Global / Instance / Location) and a `with`-based fluent API
+(`src/Core/Ignixa.Validation/ValidationState.cs`). Add a fourth concern — the resource scope — and
+fork it at resource boundaries during descent.
+
+```csharp
+public record ValidationState
+{
+    public ResourceScope Scope { get; init; } = new();
+
+    // A standalone resource, or an independent Bundle entry: %resource == %rootResource == itself.
+    public ValidationState EnterRootResource(IElement resource) => this with
+    {
+        Scope = new ResourceScope
+        {
+            Resource     = resource,
+            RootResource = resource,
+            Resolver     = BuildResolver(resource, parent: null),  // see Solution 2
+        }
+    };
+
+    // A contained resource C inside parent P: %resource = C, %rootResource = P (the container).
+    public ValidationState EnterContainedResource(IElement contained) => this with
+    {
+        Scope = Scope with
+        {
+            Resource     = contained,
+            RootResource = Scope.Resource,                          // the containing resource
+            Resolver     = BuildResolver(contained, parent: Scope), // contained #ids chain to parent/bundle
+        }
+    };
+}
+
+public record ResourceScope
+{
+    public IElement? Resource { get; init; }       // %resource     = nearest containing resource
+    public IElement? RootResource { get; init; }   // %rootResource = container resource (parent), else == Resource
+    public Func<string, IElement?>? Resolver { get; init; }
+}
+```
+
+The fix at the consumer — `FhirPathInvariantCheck.Validate` stops evaluating context-free:
+
+```csharp
+var context = new FhirEvaluationContext
+{
+    Resource       = state.Scope.Resource,
+    RootResource   = state.Scope.RootResource,
+    ElementResolver = state.Scope.Resolver,
+};
+var result = _evaluator.Value.Evaluate(element, expression, context);
+```
+
+**`%resource` / `%rootResource` semantics (FHIR rule, encoded above):**
+- Standalone resource, or an independent **Bundle entry**: `%resource == %rootResource ==` that resource.
+  A Bundle entry's resource is *not* contained in the Bundle in the FHIRPath sense, so neither variable
+  points at the Bundle.
+- **Contained** resource C inside parent P: `%resource = C`, `%rootResource = P` (the containing resource).
+- The Bundle's own constraints (`bdl-*`): `%resource == %rootResource ==` the Bundle.
+
+Firely reaches the same result by scanning up `ParentResource` and stopping before a Bundle
+(`ScopedNode.ResourceContext` — "do not go past a root resource into a bundle"); we encode it directly
+at the two seed points instead of scanning.
+
+### Solution 2 — Scoped reference index injected as the `ElementResolver`
+
+`resolve()` is already a delegated `Func<string, IElement?>` on `FhirEvaluationContext`
+(`FhirEvaluationContext.cs:35`); the search indexer already wires one
+(`ElementSearchIndexer.cs:65`). The gap is only that validation never builds one with knowledge of
+the enclosing Bundle/contained set. Build that index — Firely's `ReferencedResourceCache`
+equivalent — by the walker, and inject the closure. Do **not** attach it to the node.
+
+```csharp
+sealed class ReferenceIndex
+{
+    readonly Dictionary<string, IElement> _byFullUrl;     // urn:uuid:.., Type/id, Type/id/_history/v
+    readonly Dictionary<string, IElement> _byContainedId; // "#p1"
+    public IElement? Resolve(string r) =>
+        r.StartsWith('#') ? _byContainedId.GetValueOrDefault(r[1..])
+                          : _byFullUrl.GetValueOrDefault(r);
+}
+```
+
+- Built **lazily and cached in `ValidationState.Global.Cache`**, keyed on the owner's
+  `Meta<JsonNode>()` identity — O(entries) once per Bundle, not once per reference.
+- The injected resolver chains **contained-of-current-`%resource` → bundle-of-root**, the correct
+  FHIR resolution order.
+- **Reference integrity** becomes a small new `IValidationCheck`: resolve each `Reference` through
+  the index, report unresolved (respecting external/logical references that legitimately do not
+  resolve).
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| No change to `IElement`; stays on the forward-only model | Each site where a resource becomes a validation root must seed scope (only 2 today) |
+| Reuses existing primitives: `ValidationState` threading + `ElementResolver` delegate | Future nested-root sites (bundle-entry validation) must remember to seed |
+| Functional-core / imperative-shell aligned: node stays pure, shell supplies context | `%resource`/`%rootResource` contained-vs-standalone rule must be encoded correctly |
+| Unblocks `dom-1`, `bdl-*`, and all `%resource`-referencing invariants | Reference index adds O(entries) build cost per Bundle (mitigated by caching) |
+| Cheaper than Firely on the hot path — no per-child `ScopedNode` allocation | Does not by itself solve evaluation of *context-free* deep nodes handed in via a public API (see Open Question) |
+| Same delegate-injection pattern already proven by `resolve()` breaking the FhirPath→storage cycle | |
+
+## Alignment
+
+- [x] Follows architectural layering rules — `Ignixa.FhirPath` stays dependency-free; validation
+      injects context at the boundary (same inversion as `ElementResolver`)
+- [x] Developer Experience — no new public surface; checks read scope from the state they already receive
+- [x] Specification compliance — implements FHIRPath `%resource`/`%rootResource` and `resolve()`
+      semantics including the Bundle-boundary rule
+- [x] Consistent with existing patterns — immutable `with`-based state, injected delegates, lazy caches
+
+## Weakest-Link Analysis
+
+1. **Scope must be seeded at every nested-root site, and only there.** There is no per-element
+   descent in the engine — `ValidationSchema.Validate` runs all checks against one root `element`,
+   so scope changes *only* when a resource becomes a new validation root (handler entry +
+   `ContainedResourceCheck` today; bundle-entry validation in future). Two failure modes:
+   (a) a new nested-root site forgets to call `Enter*Resource` → `%resource` stays stale/null
+   **silently**; (b) if element-level invariants are later wired (evaluating a constraint against a
+   sub-element like `Patient.contact`), a developer might "helpfully" re-point `%resource` per
+   element — wrong: `%resource` must stay the enclosing *resource*. *Mitigation:* expose seeding only
+   as `EnterRootResource` / `EnterContainedResource` on `ValidationState` (no per-element variant),
+   so the invariant "scope forks at resource boundaries, nowhere else" is structurally enforced.
+2. **Silent `resolve()`.** Today `resolve()` returns empty both when *no resolver is configured*
+   (a wiring bug) and when *a reference legitimately does not resolve* (correct per spec)
+   (`FhirSpecificFunctions.cs:94`). In the validation path the resolver should be non-null, so a
+   missing resolver surfaces instead of vanishing. Only genuine misses return empty.
+3. **Index cost.** Eager per-reference rebuild would be O(refs × entries). Lazy build + cache keyed
+   on Bundle identity makes it O(entries) once.
+
+## Evidence
+
+- **Forward-only node, by design.** `IElement` has no parent
+  (`src/Core/Ignixa.Abstractions/Structure/IElement.cs`). The Firely adapter
+  (`Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs`) deliberately does not expose `Parent`. A
+  parent link *does* exist at the substrate (`System.Text.Json` `JsonNode.Parent`) and is used as an
+  escape hatch for mutation only (`Ignixa.DeId/Extensions/ElementMutationExtensions.cs`).
+- **Context is already the carrier.** `EvaluationContext.Resource` / `RootResource` and
+  `GetEnvironmentVariable` resolve `%resource`/`%rootResource` as plain lookups
+  (`EvaluationContext.cs:122-127, 328-336`). `FhirEvaluationContext.ElementResolver` carries
+  `resolve()` (`FhirEvaluationContext.cs:35`).
+- **The seam is confirmed.** `FhirPathInvariantCheck.Validate` evaluates with no context
+  (`FhirPathInvariantCheck.cs:168`); `ValidationState` already threads immutable per-level context
+  (`ValidationState.cs`).
+- **Prior art — Firely.** `ScopedNode.ResourceContext` walks up `ParentResource` until it hits a
+  Bundle; `BundledResources()` / `ContainedResources()` build a `ReferencedResourceCache` of sibling
+  entries. We replicate the *behaviour* (root scope + reference index) without the *mechanism*
+  (per-node parent pointers). See [reference-implementations](reference-implementations.md).
+- **Prior art — HAPI / org.hl7.fhir validator.** Keeps slice assignment + cardinality + reporting
+  imperative for diagnostic granularity, and treats only the discriminator *predicate* as FHIRPath.
+  Confirms scope/resolution belongs in the traversal, not the node.
+- **Injection seam is pre-built.** `conformsTo`, `memberOf`, `validateVS` are registered FhirPath
+  functions that currently `throw NotSupportedException("...requires profile validation
+  infrastructure")` (`FhirSpecificFunctions.cs:397-431`) — the same deferred-delegate pattern as
+  `ElementResolver`. `SlicingMetadata` already captures discriminators
+  (`src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs`).
+
+## Related Future Work (out of scope for this investigation)
+
+These build **on top of** Solutions 1 & 2 and are tracked separately:
+
+- **Slicing as a parent-altitude check + FHIRPath discriminators.** Slice *assignment* and
+  cardinality stay imperative at the element owning the sliced array (forward-only over
+  `Children()`); the per-element discriminator predicate is evaluated via the existing FhirPath
+  engine. `SlicingMetadata.Discriminators` already holds the discriminator paths. This is the
+  accurate reading of the "HAPI compiles checks to FHIRPath" idea — predicate-as-FHIRPath, not
+  whole-profile-as-FHIRPath.
+- **`conformsTo()` / `memberOf()` injection.** Implement the stubbed functions by injecting
+  delegates into `FhirEvaluationContext` (mirroring `ElementResolver`). `profile`/`type`
+  discriminators need `conformsTo` evaluated against the correctly-scoped `%resource` (depends on
+  Solution 1); reference discriminators need `resolve()` (depends on Solution 2). This is why 1 & 2
+  are the foundation.
+
+## Open Question
+
+Does ignixa ever evaluate FHIRPath / validate a node handed in **without** a controlled traversal
+establishing scope (e.g. a public `element.Select("%resource.id")` on a deep node, or
+`IElement.Validate()` on an arbitrary sub-element)? If **no** (current state — all evaluation flows
+through indexing or the validation walker), Solutions 1 & 2 are sufficient. If **yes**, that single
+entry point — and only that one — would justify a lazy `ScopedElement : IElement` built from the
+`Meta<JsonNode>()` parent chain. Defer until such an API actually exists.
+
+## Implementation Seam (the three edits)
+
+There is no descent refactor — `ValidationSchema.Validate` already runs against a single root
+`element`, and scope only changes where a resource *becomes* a validation root. That is exactly two
+sites today, plus the consumer:
+
+1. **Seed at the entry point.** `ValidateResourceHandler.cs:196` currently does
+   `var state = new ValidationState();` → change to `new ValidationState().EnterRootResource(element)`.
+   This alone fixes `%resource` for every root-level invariant (`dom-*`, `bdl-*`) — the headline gap.
+2. **Re-scope on contained recursion.** `ContainedResourceCheck.cs:102` currently does
+   `state.WithLocation(containedPath)` → add `.EnterContainedResource(containedElement)`.
+3. **Consume at the check.** `FhirPathInvariantCheck.cs:168` evaluates context-free → build a
+   `FhirEvaluationContext` from `state.Scope` (snippet above) and pass it to `Evaluate`.
+
+Solution 1 is edits 1 + 3 (and the `EnterContainedResource` half of 2). Solution 2 is filling the
+`Resolver` field that those `Enter*` methods already set — `BuildResolver` returns the
+`ReferenceIndex` closure instead of null — plus the reference-integrity check. Same machinery; 2 is
+an increment on 1, not a second mechanism.
+
+## Verdict
+
+**Recommended — adopt Solution 1 with the `Resolver` field in place from the start (Solution 2
+follows as an increment).** Solution 1 alone fixes `%resource`-referencing invariants; leaving the
+`Resolver` field present-but-null means `resolve()`-dependent invariants degrade gracefully (empty)
+until Solution 2 populates it — no API churn between the two.
+
+Sequencing:
+1. Add `ResourceScope` + `EnterRootResource` / `EnterContainedResource` to `ValidationState`.
+2. Seed at `ValidateResourceHandler` entry; re-scope in `ContainedResourceCheck`.
+3. Build `FhirEvaluationContext` from scope in `FhirPathInvariantCheck`. **← Solution 1 done; `dom-*`/`bdl-*` pass.**
+4. Implement `BuildResolver` → `ReferenceIndex` (lazy, cached on `Global.Cache`); add reference-integrity check. **← Solution 2 done.**
+
+Slicing (parent-altitude check + FHIRPath discriminators) and `conformsTo`/`memberOf` injection
+follow as separate investigations, built on this foundation.

--- a/docs/features/validation/readme.md
+++ b/docs/features/validation/readme.md
@@ -29,6 +29,8 @@ FHIR validation is critical for production servers but must balance correctness,
 | [depth-refactor](investigations/depth-refactor.md) | In Progress | Consolidate ValidationTier/Mode into single ValidationDepth enum |
 | [hapi-message-format](investigations/hapi-message-format.md) | Complete | HAPI FHIR OperationOutcome structure for ecosystem compatibility |
 | [primitive-value-validation-gap](investigations/primitive-value-validation-gap.md) | Viable | Non-choice primitives use loose TypeCheck instead of strict FhirPrimitiveValidator — empty strings and invalid calendar dates accepted. Found by fhir-faker edge-case mode |
+| [tree-context-scoping](investigations/tree-context-scoping.md) | Viable | Thread %resource/%rootResource through ValidationState and inject a scoped reference index as the resolve() delegate — unblocks dom-1/bdl-* invariants and Bundle/contained resolution without adding a Parent pointer to IElement. 3-edit seam, no descent refactor |
+| [slicing-discriminators](investigations/slicing-discriminators.md) | In Progress | Slicing as a parent-altitude check: imperative slice assignment + cardinality/reporting, FHIRPath engine for the discriminator predicate only (HAPI-style). Builds on tree-context-scoping (needs conformsTo via %resource, resolve()). Prereq gap: SlicingMetadata.Discriminators lacks a discriminator type field |
 
 ## Decision
 

--- a/docs/features/validation/readme.md
+++ b/docs/features/validation/readme.md
@@ -15,6 +15,11 @@ FHIR validation is critical for production servers but must balance correctness,
 - Must integrate with terminology services for binding validation
 - Architecture inspired by Firely's compiled schema pattern
 
+## Roadmap
+
+See **[roadmap.md](roadmap.md)** — the phased implementation plan (conformance harness → differential
+snapshot generation → gap completion) that sequences the investigations below.
+
 ## Investigations
 
 | Investigation | Status | Summary |

--- a/docs/features/validation/roadmap.md
+++ b/docs/features/validation/roadmap.md
@@ -91,6 +91,7 @@ a few invariants. Deferred slices: IG-package cases, `supporting`/`profile` case
 | + unevaluable-invariant → warning (`53f4c58`) | 62.6% | 48 | 22 | `htmlChecks()` etc. no longer spurious errors |
 | + element-scoped invariant altitude (`23301c8`) | 61.5% | 18 | 54 | `pat-1`/`bdl-5`/`inv-1`/`vsd-1` fire at owning element |
 | + PR #286 tree-context merged & seeded (`efb7850`) | 64.7% | 19 | 47 | `resolve()`/`%resource` catch broken local refs |
+| + nested-resource fragment re-scoping (`1027232`) | 63.6% | 18 | 50 | `#payer` in `parameter.resource` resolves in its own scope |
 
 **The real scoreboard is the split, not the headline.** Over-strict (valid resources we wrongly
 reject — a validator's worst failure) fell **54 → 19 (−65%)**. Under-strict rose because removing

--- a/docs/features/validation/roadmap.md
+++ b/docs/features/validation/roadmap.md
@@ -1,0 +1,181 @@
+# Validation Implementation Roadmap
+
+**Status**: Active
+**Branch**: `feat/validation-implementation`
+**Created**: 2026-07-06
+
+The umbrella plan for taking Ignixa validation from "Core Complete" to a conformance-measured,
+production-solid FHIR validation library. It collects the existing investigations under
+`investigations/` into a phased sequence and records the cross-project learnings that motivated it.
+
+---
+
+## Goal
+
+A validation library whose correctness is **measured against the official HL7 test suite**, not
+asserted. Every phase is gated by a movement in the conformance pass rate, and every remaining gap is
+visible as a triage bucket rather than a guess.
+
+## Guiding principle — measure first, then build
+
+Adopted from the `rh-validator` (Rust) conformance model. We do **not** build features against
+intuition; we build the yardstick first, read where we land, and let the triage buckets order the
+work. Concretely:
+
+- The full official suite is **observational** (`[Explicit]` / not a CI gate). It prints a pass rate.
+- CI gates only a **curated, promoted subset** of deterministic tests, behind a blocking toggle
+  (observe → enforce rollout).
+- Progress is tracked with a **triage report bucketed by subsystem** (`snapshot`, `slicing`,
+  `invariant`, `terminology`, `primitive`, `json`, …) — **not** an allowlist / xfail manifest.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Base branch | Fork from `main` | Clean base. Baseline will run **without** PR #286 (tree-context/`resolve()`), so the first number understates real capability — merge #286 in, then re-baseline. |
+| Conformance oracle | **Java primary + Firely cross-check** | HL7 Java validator outcomes cover 908/913 cases (canonical reference impl); `firely-sdk-current` (169 cases) is the .NET-semantics sanity check. |
+| Comparison granularity | Boolean valid/invalid first (`errorCount == 0`), graduate to exact error/warning counts | Matches the Rust harness ramp; avoids drowning in message-text mismatches on day one. |
+| Test data source | Reuse the already-vendored `test/Ignixa.FhirPath.Tests/TestData/fhir-test-cases/` (pinned copy) | The full `FHIR/fhir-test-cases` repo — including `validator/manifest.json` (913 cases) — is already in the tree. No live download. |
+
+---
+
+## Phase 1 — Conformance harness + baseline
+
+**Objective:** wire up the official validator test cases we already have and produce a first pass rate.
+
+The `validator/` slice of the vendored `fhir-test-cases` repo (`validator/manifest.json`, 436 KB,
+913 cases) is currently consumed by **nothing**. Phase 1 fixes that by mirroring the existing
+`OfficialTestSuiteRunner.cs` pattern (which already drives the FHIRPath official suite).
+
+Scope:
+
+1. `ValidatorConformanceRunner` in `Ignixa.Validation.Tests` — loads `manifest.json`, filters
+   runnable cases, runs `ValidateResourceHandler`/`ValidationSchema`, compares verdict to the
+   reference outcome.
+2. Manifest POCO + `JsonConverter` for the dual outcome shape (inline `{errorCount,…}` **or** path
+   into `validator/outcomes/`).
+3. Reference-oracle loader: Java outcome (primary), `firely-sdk-current` (cross-check).
+4. Triage CSV/report, bucketed by subsystem, written to test output.
+5. Curated CI subset (`[Trait("Category","Conformance")]`) + full-suite `[Explicit]` run.
+
+**Exit criteria:** a committed baseline pass rate + a triage report that orders Phases 2–3.
+See `investigations/conformance-harness.md`.
+
+### Baseline — 2026-07-06 (first slice)
+
+Runner: `test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs`, validating at
+`ValidationDepth.Full` against the Java reference. Slice: **187 R4 clean-base cases** (no IG
+packages / supporting / explicit profiles), boolean valid/invalid. Base = `main` (no PR #286).
+
+**Pass rate: 63.6% (119/187).** Skew: **54 over-strict** (we reject, ref accepts) vs **14
+under-strict** (we accept, ref rejects). Over-strict dominates — good, it's mostly a handful of
+shared root causes, ranked:
+
+| Cause | ~Cases | Notes |
+|---|---|---|
+| `txt-1/txt-2` narrative invariants — `htmlChecks()` FHIRPath function unimplemented | ~14 | Engine **throws** on the missing function; `FhirPathInvariantCheck` surfaces the throw as a validation **error**. An engine limitation must not produce a spurious error — skip/warn instead. Highest-value single fix. |
+| `pat-1` invariant mis-evaluation ("SHALL at least contain a contact's details…") | ~9 | Firing/failing where the reference passes. Real invariant-eval bug. |
+| `bdl-*` Bundle-entry invariants | ~7 | Need `%resource`/`resolve()` context — **exactly PR #286 (tree-context)**. Validates the roadmap: merge #286 and re-baseline. |
+| Over-strict terminology (unresolvable snomed/loinc codes) | ~8 | We error; the reference warns on codes it can't resolve. Align severity. |
+| `ele-1` spurious empties + `vsd-1` valueset invariant | ~7 | |
+| json5 `//` comment parsing | 2 | Reference honors `allow-comments`; we throw. |
+
+Under-strict (missed errors) is mostly the known gaps: extension-definition validation, terminology,
+a few invariants. Deferred slices: IG-package cases, `supporting`/`profile` cases, non-R4 versions.
+
+## Phase 2 — Differential → snapshot generation
+
+**Objective:** build our own snapshot generator, informed by the Rust `ElementMerger`.
+
+The gap: Ignixa has **no** differential→snapshot generation. `StructureDefinitionSchemaBuilder`
+consumes already-flattened `IType.Children`; profile composition **concatenates** check lists
+(`ValidationSchema.Compose`) rather than merging differentials. Any IG that ships differential-only
+StructureDefinitions, and any runtime-authored profile, validates incorrectly and silently.
+
+Rust reference (`rh-foundation/src/snapshot/generator.rs` + `merger.rs`): recursively resolves
+`baseDefinition`, merges differential onto base via `ElementMerger::merge_elements`, uses a
+pre-existing snapshot as-is when present, detects circular dependencies via a `visited` set.
+
+Design fork (Transformer decision, to be resolved with Phase 1 data in hand):
+
+| Option | Cost | Trade-off |
+|---|---|---|
+| A. Firely `SnapshotGenerator` | Low | Battle-tested; pulls `Hl7.Fhir.*` into a load path — placement decision (Core layer rules). Good as the Phase-1 **test oracle** immediately. |
+| B. Own differential merger (Rust-style) | High | Full control, no Firely coupling, idiomatic. The "complete our own implementation" answer. |
+| C. Codegen-time only | Low | Already effectively done for core; does **not** help runtime-loaded IGs (the actual gap). |
+
+**Exit criteria:** differential-only profiles validate correctly; `snapshot` triage bucket collapses.
+See `investigations/differential-snapshot-generation.md` (to be created).
+
+## Phase 3 — Gap completion
+
+**Objective:** close the remaining correctness gaps for a solid, full library. Ordered by the Phase-1
+triage buckets; the list below is the candidate set.
+
+| Gap | Current state | Notes |
+|---|---|---|
+| Slicing / discriminators | Not implemented (`SlicingMetadata` captured, unused) | In-progress investigation. Blocked on discriminator-`type` field in codegen + `conformsTo()` stub. |
+| `conformsTo()` / `memberOf()` / `validateVS()` | `NotSupportedException` stubs | Unblocks `profile` slicing discriminators. Needs profile-validation infra + tree-context. |
+| Terminology completeness | Membership-only; `$lookup`/`$expand`/`$translate`/`$subsumes` stubbed | Local-first model (per Rust) + optional TX fallback. Steal the ValueSet-membership LRU. |
+| Primitive value validation | Loose `TypeCheck` on non-choice primitives | Empty strings + impossible dates pass. Strict `FhirPrimitiveValidator` wired only into `ChoiceElementCheck`. Cheap fix. |
+| `$validate` mode handlers | DELETE/CREATE/UPDATE integrity checks are TODOs | Referential integrity, uniqueness, immutability. |
+| Extensible/Preferred bindings | Warning-only | No real extensible enforcement beyond membership warnings. |
+
+## Cross-cutting research (not phase-gated)
+
+- **Engine architecture: check-composition vs FHIRPath-invariant-unification.** Current Ignixa uses
+  ~20 composable `IValidationCheck` types. An alternative compiles a StructureDefinition into a bag of
+  FHIRPath assertions (cardinality as `x.count() >= 1`, fixed as `x = 'v'`, discriminator predicates).
+  Our two docs disagree on whether HAPI does this (`slicing-discriminators.md` says "HAPI compiles
+  checks to FHIRPath"; `reference-implementations.md` says HAPI is Schematron/XML and recommends
+  Firely's compiled-assertion-tree). **Reconcile against real source before betting architecture.**
+  Suspicion: the "everything as FHIRPath" story is closer to research validators + Firely's assertion
+  model than to mainstream HAPI `InstanceValidator` (imperative snapshot-walking). To be created:
+  `investigations/engine-architecture.md`.
+- **Performance.** `rh-validator` went 82 ms → 170 µs/resource almost entirely via LRU caching; the
+  single biggest win (−99.3%) was a ValueSet-membership cache keyed `(valueset, system, code)`. Native
+  code fast-paths for the 3 hottest invariants (`ele-1`, `ext-1`, `per-1`) skip the FHIRPath engine.
+  Defer until we have a baseline to profile against.
+
+---
+
+## Investigation index
+
+| Investigation | Status | Phase |
+|---|---|---|
+| [validation-architecture](investigations/validation-architecture.md) | Merged | Foundation |
+| [architecture-overview](investigations/architecture-overview.md) | Complete | Foundation (ref) |
+| [integration-summary](investigations/integration-summary.md) | Complete | Foundation (ref) |
+| [parity-analysis](investigations/parity-analysis.md) | Complete | Foundation (ref) |
+| [hapi-message-format](investigations/hapi-message-format.md) | Complete | Foundation (ref) |
+| [reference-implementations](investigations/reference-implementations.md) | Complete | Cross-cutting (engine arch) |
+| [codegen-requirements](investigations/codegen-requirements.md) | Complete | Phase 2/3 input |
+| [two-tier-architecture](investigations/two-tier-architecture.md) | Viable | Foundation |
+| [depth-refactor](investigations/depth-refactor.md) | In Progress | Foundation cleanup |
+| [tree-context-scoping](investigations/tree-context-scoping.md) | Viable (PR #286) | Phase 3 enabler |
+| [slicing-discriminators](investigations/slicing-discriminators.md) | In Progress | Phase 3 |
+| [primitive-value-validation-gap](investigations/primitive-value-validation-gap.md) | Viable | Phase 3 |
+| conformance-harness | To create | Phase 1 |
+| differential-snapshot-generation | To create | Phase 2 |
+| engine-architecture | To create | Cross-cutting |
+
+## Reference: what we learned from `rh-validator` (Rust)
+
+Source: `C:\Src\rh\crates\rh-validator` (+ `rh-foundation`, `rh-fhirpath`).
+
+- **Conformance model** (Phase 1): downloads/caches `FHIR/fhir-test-cases`, runs ~570 R4 cases,
+  boolean valid/invalid comparison, triage CSV bucketed by subsystem, curated CI subset behind a
+  blocking toggle. No allowlist. *We copy this — but keep our pinned vendored copy, not their live
+  `master` download (reproducibility).*
+- **Snapshot generation** (Phase 2): `rh-foundation` merges differential onto recursively-resolved
+  base; pre-existing snapshot used as-is; circular-dep detection.
+- **FHIRPath invariants**: LRU-cached parse (errors cached too); native fast-paths for `ele-1`/
+  `ext-1`/`per-1`.
+- **Terminology**: local-first (resolve against local packages), remote only as a fallback for
+  locally-undecidable required bindings.
+- **Where Rust is *behind* Ignixa** (don't copy): R4-only (single `FhirVersion`), untyped
+  `serde_json::Value`, shallow UCUM (no grammar engine), compose-`filter` ValueSets not locally
+  decidable, no parallel batch. Ignixa's multi-version, typed-`IElement` architecture is more
+  ambitious.
+
+See [ADR-2510: Three-Tier Validation Architecture](../../adr/adr-2510-validation-architecture.md).

--- a/docs/features/validation/roadmap.md
+++ b/docs/features/validation/roadmap.md
@@ -113,16 +113,18 @@ Rust reference (`rh-foundation/src/snapshot/generator.rs` + `merger.rs`): recurs
 `baseDefinition`, merges differential onto base via `ElementMerger::merge_elements`, uses a
 pre-existing snapshot as-is when present, detects circular dependencies via a `visited` set.
 
-Design fork (Transformer decision, to be resolved with Phase 1 data in hand):
+**Decision (locked): build our own `ElementMerger`** — not Firely's `SnapshotGenerator`. No
+`Hl7.Fhir.*` coupling in Core/package layers, full control, Rust-informed. Firely's generator is kept
+in the **test layer only** as a differential oracle. The seam is isolated: `StructureDefinitionTypeAdapter`
+is snapshot-only today, so we insert a generation step upstream of it and leave the schema builder,
+checks, and resolver untouched.
 
-| Option | Cost | Trade-off |
-|---|---|---|
-| A. Firely `SnapshotGenerator` | Low | Battle-tested; pulls `Hl7.Fhir.*` into a load path — placement decision (Core layer rules). Good as the Phase-1 **test oracle** immediately. |
-| B. Own differential merger (Rust-style) | High | Full control, no Firely coupling, idiomatic. The "complete our own implementation" answer. |
-| C. Codegen-time only | Low | Already effectively done for core; does **not** help runtime-loaded IGs (the actual gap). |
+Milestones: M1 base-merge constraint tightening (no slicing) → M2 slicing/extension element insertion
+(feeds slicing) → M3 type expansion + edge cases. Measured by **enabling the deferred profile/package
+conformance slice** — Phase 2's payoff shows up there, not on clean-base.
 
-**Exit criteria:** differential-only profiles validate correctly; `snapshot` triage bucket collapses.
-See `investigations/differential-snapshot-generation.md` (to be created).
+**Exit criteria:** differential-only profiles validate correctly; the profile/package conformance
+slice runs. Detailed plan: [differential-snapshot-generation](investigations/differential-snapshot-generation.md).
 
 ## Phase 3 — Gap completion
 
@@ -133,7 +135,7 @@ triage buckets; the list below is the candidate set.
 |---|---|---|
 | Slicing / discriminators | Not implemented (`SlicingMetadata` captured, unused) | In-progress investigation. Blocked on discriminator-`type` field in codegen + `conformsTo()` stub. |
 | `conformsTo()` / `memberOf()` / `validateVS()` | `NotSupportedException` stubs | Unblocks `profile` slicing discriminators. Needs profile-validation infra + tree-context. |
-| Terminology completeness | Membership-only; `$lookup`/`$expand`/`$translate`/`$subsumes` stubbed | Local-first model (per Rust) + optional TX fallback. Steal the ValueSet-membership LRU. |
+| Terminology completeness | Membership-only; `$lookup`/`$expand`/`$translate`/`$subsumes` stubbed | **Decision locked:** (1) error-vs-warn severity — never error on an unverifiable binding; (2) expanded local valuesets; (3) remote TX server API as fallback. Local-first per Rust; membership LRU. Biggest lever on the current slice. Detailed plan: [terminology-completeness](investigations/terminology-completeness.md). |
 | Primitive value validation | Loose `TypeCheck` on non-choice primitives | Empty strings + impossible dates pass. Strict `FhirPrimitiveValidator` wired only into `ChoiceElementCheck`. Cheap fix. |
 | `$validate` mode handlers | DELETE/CREATE/UPDATE integrity checks are TODOs | Referential integrity, uniqueness, immutability. |
 | Extensible/Preferred bindings | Warning-only | No real extensible enforcement beyond membership warnings. |
@@ -172,8 +174,9 @@ triage buckets; the list below is the candidate set.
 | [tree-context-scoping](investigations/tree-context-scoping.md) | Viable (PR #286) | Phase 3 enabler |
 | [slicing-discriminators](investigations/slicing-discriminators.md) | In Progress | Phase 3 |
 | [primitive-value-validation-gap](investigations/primitive-value-validation-gap.md) | Viable | Phase 3 |
-| conformance-harness | To create | Phase 1 |
-| differential-snapshot-generation | To create | Phase 2 |
+| conformance-harness | Landed (`ValidatorConformanceRunner`) | Phase 1 |
+| [differential-snapshot-generation](investigations/differential-snapshot-generation.md) | Planned (own `ElementMerger`) | Phase 2 |
+| [terminology-completeness](investigations/terminology-completeness.md) | Planned (local + severity + remote) | Phase 3 |
 | engine-architecture | To create | Cross-cutting |
 
 ## Reference: what we learned from `rh-validator` (Rust)

--- a/docs/features/validation/roadmap.md
+++ b/docs/features/validation/roadmap.md
@@ -83,6 +83,22 @@ shared root causes, ranked:
 Under-strict (missed errors) is mostly the known gaps: extension-definition validation, terminology,
 a few invariants. Deferred slices: IG-package cases, `supporting`/`profile` cases, non-R4 versions.
 
+### Progression (R4 clean-base, 187 cases)
+
+| Step | Pass | Over-strict | Under-strict | Note |
+|---|---|---|---|---|
+| Baseline (`main`) | 63.6% | 54 | 14 | |
+| + unevaluable-invariant → warning (`53f4c58`) | 62.6% | 48 | 22 | `htmlChecks()` etc. no longer spurious errors |
+| + element-scoped invariant altitude (`23301c8`) | 61.5% | 18 | 54 | `pat-1`/`bdl-5`/`inv-1`/`vsd-1` fire at owning element |
+| + PR #286 tree-context merged & seeded (`efb7850`) | 64.7% | 19 | 47 | `resolve()`/`%resource` catch broken local refs |
+
+**The real scoreboard is the split, not the headline.** Over-strict (valid resources we wrongly
+reject — a validator's worst failure) fell **54 → 19 (−65%)**. Under-strict rose because removing
+spurious errors *unmasked* pre-existing terminology/semantic gaps that were coincidentally rejecting
+the right resources for the wrong reasons — those are honest Phase 2/3 work (terminology, snapshot,
+extension-versioning), not regressions. Architecture rationale recorded in
+[ADR 2607: Forward-Only Nodes with Descending Context Scopes](../../adr/adr-2607-forward-only-validation-context.md).
+
 ## Phase 2 — Differential → snapshot generation
 
 **Objective:** build our own snapshot generator, informed by the Rust `ElementMerger`.

--- a/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
+++ b/src/Application/Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs
@@ -193,7 +193,7 @@ public class ValidateResourceHandler : IRequestHandler<ValidateResourceCommand, 
                         Depth = validationDepth,
                         TerminologyService = _terminologyService
                     };
-                    var state = new ValidationState();
+                    var state = new ValidationState().EnterRootResource(element);
                     var validationResult = schema.Validate(element, settings, state);
 
                 if (!validationResult.IsValid)

--- a/src/Core/Ignixa.Validation/Checks/ContainedResourceCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ContainedResourceCheck.cs
@@ -98,8 +98,9 @@ public class ContainedResourceCheck(IValidationSchemaResolver schemaResolver) : 
                 continue;
             }
 
-            // Validate contained resource against its own schema
-            var containedState = state.WithLocation(containedPath);
+            // Validate contained resource against its own schema. Re-scope so %resource points at
+            // the contained resource and %rootResource at the containing parent (FHIR dom-* rule).
+            var containedState = state.WithLocation(containedPath).EnterContainedResource(containedElement);
             var containedResult = containedSchema.Validate(containedElement, settings, containedState);
 
             if (!containedResult.IsValid)

--- a/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
@@ -203,16 +203,16 @@ public class FhirPathInvariantCheck : IValidationCheck
         {
             throw;
         }
-        catch (Exception ex)
+        catch (NotSupportedException ex)
         {
-            // An invariant the engine cannot evaluate — e.g. an unimplemented FHIRPath function such
-            // as htmlChecks() / conformsTo() / memberOf() — is a validator limitation, not a resource
-            // error. Degrade to a non-failing Warning, consistent with the parse-failure path above,
-            // so we never reject a resource on our own engine gap. Logged to keep the gap visible.
+            // A KNOWN engine limitation — an unimplemented FHIRPath function (htmlChecks() /
+            // conformsTo() / memberOf()) or operator, which the engine throws NotSupportedException
+            // for. Not a resource error: degrade to a non-failing Warning, consistent with the
+            // parse-failure path above, so we never reject a resource on our own engine gap.
             // (Reference validators likewise never hard-fail a resource on an unevaluable constraint.)
             _logger?.LogWarning(
                 ex,
-                "Constraint {ConstraintKey} could not be evaluated (engine limitation); treating as non-failing",
+                "Constraint {ConstraintKey} uses an unsupported FHIRPath feature; treating as non-failing",
                 _constraint.Key);
 
             var issue = new ValidationIssue(
@@ -222,6 +222,24 @@ public class FhirPathInvariantCheck : IValidationCheck
                 $"Constraint '{_constraint.Key}' could not be evaluated: {ex.Message}");
 
             return new ValidationResult(isValid: true, issues: new[] { issue });
+        }
+        catch (Exception ex)
+        {
+            // An UNEXPECTED evaluation failure — a defect in our engine or malformed data, not a known
+            // limitation. Surface it loudly (failing Error + Error log) rather than masking it as a
+            // benign warning, so it cannot silently pass a resource or inflate conformance metrics.
+            _logger?.LogError(
+                ex,
+                "Unexpected error evaluating constraint {ConstraintKey}",
+                _constraint.Key);
+
+            var issue = new ValidationIssue(
+                IssueSeverity.Error,
+                _constraint.Key,
+                element.Location ?? string.Empty,
+                $"{_constraint.Key}: unexpected error evaluating FHIRPath expression: {ex.Message}");
+
+            return ValidationResult.Failure(issue);
         }
     }
 

--- a/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
@@ -164,8 +164,12 @@ public class FhirPathInvariantCheck : IValidationCheck
 
         try
         {
-            // Evaluate the FHIRPath expression
-            var result = _evaluator.Value.Evaluate(element, expression);
+            // Evaluate the FHIRPath expression. When tree-context scope has been seeded
+            // (resource roots and contained recursion), supply %resource / %rootResource /
+            // resolve() so root-referencing invariants (dom-*, bdl-*) evaluate correctly.
+            // When scope is unseeded (some direct callers/tests), fall back to context-free
+            // evaluation, which defaults %resource to the constrained element as before.
+            var result = _evaluator.Value.Evaluate(element, expression, BuildEvaluationContext(state));
 
             // Convert result to boolean
             // Per FHIRPath spec: empty result = false, single boolean true = true, all else = false
@@ -209,6 +213,26 @@ public class FhirPathInvariantCheck : IValidationCheck
 
             return ValidationResult.Failure(issue);
         }
+    }
+
+    /// <summary>
+    /// Builds the FHIRPath evaluation context from the validation scope. Returns null when no
+    /// resource scope has been seeded, preserving context-free evaluation for direct callers.
+    /// </summary>
+    private static EvaluationContext? BuildEvaluationContext(ValidationState state)
+    {
+        var scope = state.Scope;
+        if (scope.Resource is null)
+        {
+            return null;
+        }
+
+        return new FhirEvaluationContext
+        {
+            Resource = scope.Resource,
+            RootResource = scope.RootResource,
+            ElementResolver = scope.Resolver
+        };
     }
 
     /// <summary>

--- a/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPathInvariantCheck.cs
@@ -201,13 +201,23 @@ public class FhirPathInvariantCheck : IValidationCheck
         }
         catch (Exception ex)
         {
+            // An invariant the engine cannot evaluate — e.g. an unimplemented FHIRPath function such
+            // as htmlChecks() / conformsTo() / memberOf() — is a validator limitation, not a resource
+            // error. Degrade to a non-failing Warning, consistent with the parse-failure path above,
+            // so we never reject a resource on our own engine gap. Logged to keep the gap visible.
+            // (Reference validators likewise never hard-fail a resource on an unevaluable constraint.)
+            _logger?.LogWarning(
+                ex,
+                "Constraint {ConstraintKey} could not be evaluated (engine limitation); treating as non-failing",
+                _constraint.Key);
+
             var issue = new ValidationIssue(
-                IssueSeverity.Error,
+                IssueSeverity.Warning,
                 _constraint.Key,
                 element.Location ?? string.Empty,
-                $"{_constraint.Key}: Failed to evaluate FHIRPath expression: {ex.Message}");
+                $"Constraint '{_constraint.Key}' could not be evaluated: {ex.Message}");
 
-            return ValidationResult.Failure(issue);
+            return new ValidationResult(isValid: true, issues: new[] { issue });
         }
     }
 

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -1,0 +1,121 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Reference-integrity check (Full tier). Flags clearly-local references that fail to resolve
+/// against the scoped resolver: fragment references (<c>#id</c>) and intra-Bundle relative
+/// references (<c>Type/id</c>) inside a Bundle root.
+/// </summary>
+/// <remarks>
+/// Scoped narrowly to avoid false positives: absolute URLs (<c>http(s)://</c>), <c>urn:</c>
+/// references, and any reference is left alone when no resolver is configured. External and
+/// logical references legitimately do not resolve locally and are never flagged.
+/// </remarks>
+public sealed class ReferenceResolutionCheck : IValidationCheck
+{
+    /// <summary>
+    /// Validates that local references within the resource resolve against the scoped resolver.
+    /// </summary>
+    /// <param name="element">The resource root element to validate.</param>
+    /// <param name="settings">Validation settings.</param>
+    /// <param name="state">Current validation state carrying the scoped resolver.</param>
+    /// <returns>A validation result with an issue per unresolved local reference.</returns>
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        var resolver = state.Scope.Resolver;
+        if (resolver is null)
+        {
+            return ValidationResult.Success();
+        }
+
+        var rootIsBundle = state.Scope.RootResource?.InstanceType == "Bundle"
+            || state.Scope.Resource?.InstanceType == "Bundle";
+
+        var issues = new List<ValidationIssue>();
+        CollectUnresolved(element, resolver, rootIsBundle, issues);
+
+        return issues.Count > 0
+            ? ValidationResult.Failure(issues)
+            : ValidationResult.Success();
+    }
+
+    private static void CollectUnresolved(
+        IElement element,
+        Func<string, IElement?> resolver,
+        bool rootIsBundle,
+        List<ValidationIssue> issues)
+    {
+        foreach (var child in element.Children())
+        {
+            if (child.Name == "reference" && child.Value is string reference && IsLocalReference(reference, rootIsBundle))
+            {
+                if (resolver(reference) is null)
+                {
+                    issues.Add(ValidationIssue.InvariantFailure(
+                        "ref-resolve",
+                        $"Local reference '{reference}' does not resolve within the resource",
+                        child.Location));
+                }
+            }
+
+            CollectUnresolved(child, resolver, rootIsBundle, issues);
+        }
+    }
+
+    private static bool IsLocalReference(string reference, bool rootIsBundle)
+    {
+        if (string.IsNullOrEmpty(reference))
+        {
+            return false;
+        }
+
+        if (reference.StartsWith('#'))
+        {
+            return reference.Length > 1;
+        }
+
+        if (!rootIsBundle)
+        {
+            return false;
+        }
+
+        if (reference.Contains("://", StringComparison.Ordinal)
+            || reference.StartsWith("urn:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var slash = reference.IndexOf('/', StringComparison.Ordinal);
+        if (slash <= 0 || slash == reference.Length - 1)
+        {
+            return false;
+        }
+
+        return IsResourceTypeToken(reference.AsSpan(0, slash));
+    }
+
+    private static bool IsResourceTypeToken(ReadOnlySpan<char> token)
+    {
+        if (token.Length == 0 || !char.IsUpper(token[0]))
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            if (!char.IsLetter(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -83,6 +83,16 @@ public sealed class ReferenceResolutionCheck : IValidationCheck
         Func<string, IElement?> outerResolver)
     {
         var index = ReferenceIndex.Build(nestedResource);
+
+        // Chain to the outer resolver on a local miss. This is deliberately correct for BOTH boundary
+        // kinds we descend through:
+        //  - contained[]: a contained resource has no own `contained` (FHIR forbids nested contained),
+        //    so its index is empty and a fragment (#id) must fall through to the CONTAINER's pool —
+        //    contained resources legitimately reference each other via #id (FHIR contained-peer refs).
+        //  - Bundle.entry.resource / Parameters.parameter.resource: an independent resource resolves
+        //    fragments against its own `contained` (indexed here); relative Type/id refs fall through
+        //    to the Bundle. The fall-through is harmless for its fragments because those containers
+        //    carry no root-level `contained` to collide with.
         return reference => index.Resolve(reference) ?? outerResolver(reference);
     }
 

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -29,6 +29,14 @@ public sealed class ReferenceResolutionCheck : IValidationCheck
     /// <returns>A validation result with an issue per unresolved local reference.</returns>
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
     {
+        // Full-tier only. The schema builder registers this in profileChecks (Full), so it is already
+        // gated there; this guard makes the check self-protecting for direct callers and keeps the
+        // potentially-expensive reference walk off the Spec/Compatibility paths.
+        if (settings.Depth < ValidationDepth.Full)
+        {
+            return ValidationResult.Success();
+        }
+
         var resolver = state.Scope.Resolver;
         if (resolver is null)
         {

--- a/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ReferenceResolutionCheck.cs
@@ -54,19 +54,36 @@ public sealed class ReferenceResolutionCheck : IValidationCheck
     {
         foreach (var child in element.Children())
         {
-            if (child.Name == "reference" && child.Value is string reference && IsLocalReference(reference, rootIsBundle))
+            if (child.Name == "reference" && child.Value is string reference
+                && IsLocalReference(reference, rootIsBundle)
+                && resolver(reference) is null)
             {
-                if (resolver(reference) is null)
-                {
-                    issues.Add(ValidationIssue.InvariantFailure(
-                        "ref-resolve",
-                        $"Local reference '{reference}' does not resolve within the resource",
-                        child.Location));
-                }
+                issues.Add(ValidationIssue.InvariantFailure(
+                    "ref-resolve",
+                    $"Local reference '{reference}' does not resolve within the resource",
+                    child.Location));
             }
 
-            CollectUnresolved(child, resolver, rootIsBundle, issues);
+            // Crossing into a nested resource (contained[], Bundle.entry.resource,
+            // Parameters.parameter.resource): fragment references inside it resolve against that
+            // resource's own contained set, so re-scope the resolver to the nested resource (chained
+            // to the outer resolver so intra-Bundle relative references still resolve against the
+            // Bundle). Without this, a valid nested fragment (#payer -> that resource's contained) is
+            // falsely flagged against the outer resource's contained.
+            var childResolver = child.Name is "contained" or "resource"
+                ? BuildNestedResolver(child, resolver)
+                : resolver;
+
+            CollectUnresolved(child, childResolver, rootIsBundle, issues);
         }
+    }
+
+    private static Func<string, IElement?> BuildNestedResolver(
+        IElement nestedResource,
+        Func<string, IElement?> outerResolver)
+    {
+        var index = ReferenceIndex.Build(nestedResource);
+        return reference => index.Resolve(reference) ?? outerResolver(reference);
     }
 
     private static bool IsLocalReference(string reference, bool rootIsBundle)

--- a/src/Core/Ignixa.Validation/ReferenceIndex.cs
+++ b/src/Core/Ignixa.Validation/ReferenceIndex.cs
@@ -1,0 +1,132 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+
+namespace Ignixa.Validation;
+
+/// <summary>
+/// Scoped reference index that resolves FHIRPath <c>resolve()</c> targets within a single
+/// resource root. Indexes contained resources (by <c>#id</c>) and, when the root is a Bundle,
+/// sibling entry resources (by <c>fullUrl</c>, <c>Type/id</c>, and <c>Type/id/_history/versionId</c>).
+/// </summary>
+/// <remarks>
+/// Built once per resource root (O(entries)); the closure injected as the FHIRPath element
+/// resolver chains a contained-of-current scope to its parent scope. Mirrors the
+/// contained + bundle resolution algorithm of Firely's <c>ScopedNode.BundledResources()</c> /
+/// <c>ContainedResources()</c> without per-node parent pointers.
+/// </remarks>
+public sealed class ReferenceIndex
+{
+    private readonly Dictionary<string, IElement> _byContainedId;
+    private readonly Dictionary<string, IElement> _byBundleKey;
+
+    private ReferenceIndex(
+        Dictionary<string, IElement> byContainedId,
+        Dictionary<string, IElement> byBundleKey)
+    {
+        _byContainedId = byContainedId;
+        _byBundleKey = byBundleKey;
+    }
+
+    /// <summary>
+    /// Builds a reference index from a resource element, indexing its contained resources and,
+    /// for a Bundle root, its entry resources.
+    /// </summary>
+    /// <param name="root">The resource element to index. Must not be null.</param>
+    /// <returns>An index that resolves contained and intra-Bundle references for this root.</returns>
+    public static ReferenceIndex Build(IElement root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        var byContainedId = new Dictionary<string, IElement>(StringComparer.Ordinal);
+        var byBundleKey = new Dictionary<string, IElement>(StringComparer.Ordinal);
+
+        IndexContained(root, byContainedId);
+
+        if (root.InstanceType == "Bundle")
+        {
+            IndexBundleEntries(root, byBundleKey);
+        }
+
+        return new ReferenceIndex(byContainedId, byBundleKey);
+    }
+
+    /// <summary>
+    /// Resolves a reference to its target element within this index.
+    /// </summary>
+    /// <param name="reference">A fragment reference (<c>#id</c>) or a Bundle key (<c>fullUrl</c> / <c>Type/id</c>).</param>
+    /// <returns>The matching element, or null when the reference is not present in this index.</returns>
+    public IElement? Resolve(string reference)
+    {
+        if (string.IsNullOrEmpty(reference))
+        {
+            return null;
+        }
+
+        return reference.StartsWith('#')
+            ? _byContainedId.GetValueOrDefault(reference[1..])
+            : _byBundleKey.GetValueOrDefault(reference);
+    }
+
+    private static void IndexContained(IElement root, Dictionary<string, IElement> byContainedId)
+    {
+        foreach (var contained in root.Children("contained"))
+        {
+            var id = FirstChildValue(contained, "id");
+            if (!string.IsNullOrEmpty(id))
+            {
+                byContainedId.TryAdd(id, contained);
+            }
+        }
+    }
+
+    private static void IndexBundleEntries(IElement bundle, Dictionary<string, IElement> byBundleKey)
+    {
+        foreach (var entry in bundle.Children("entry"))
+        {
+            var resourceChildren = entry.Children("resource");
+            if (resourceChildren.Count == 0)
+            {
+                continue;
+            }
+
+            var resource = resourceChildren[0];
+
+            var fullUrl = FirstChildValue(entry, "fullUrl");
+            if (!string.IsNullOrEmpty(fullUrl))
+            {
+                byBundleKey.TryAdd(fullUrl, resource);
+            }
+
+            var id = FirstChildValue(resource, "id");
+            if (string.IsNullOrEmpty(id))
+            {
+                continue;
+            }
+
+            var type = resource.InstanceType;
+            byBundleKey.TryAdd($"{type}/{id}", resource);
+
+            var versionId = MetaVersionId(resource);
+            if (!string.IsNullOrEmpty(versionId))
+            {
+                byBundleKey.TryAdd($"{type}/{id}/_history/{versionId}", resource);
+            }
+        }
+    }
+
+    private static string? FirstChildValue(IElement element, string childName)
+    {
+        var children = element.Children(childName);
+        return children.Count == 0 ? null : children[0].Value?.ToString();
+    }
+
+    private static string? MetaVersionId(IElement resource)
+    {
+        var meta = resource.Children("meta");
+        return meta.Count == 0 ? null : FirstChildValue(meta[0], "versionId");
+    }
+}

--- a/src/Core/Ignixa.Validation/ResourceScope.cs
+++ b/src/Core/Ignixa.Validation/ResourceScope.cs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+
+namespace Ignixa.Validation;
+
+/// <summary>
+/// FHIRPath tree-context scope threaded through validation. Carries the resource-rooted
+/// variables (<c>%resource</c>, <c>%rootResource</c>) and the <c>resolve()</c> delegate so a
+/// constraint evaluated deep inside a resource sees the correct enclosing resource and can
+/// resolve sibling references — without the runtime element model exposing a parent pointer.
+/// </summary>
+/// <remarks>
+/// Immutable. Forked at resource boundaries via <see cref="ValidationState.EnterRootResource"/>
+/// and <see cref="ValidationState.EnterContainedResource"/>. Never re-pointed per element:
+/// <c>%resource</c> must remain the enclosing resource, not the constrained sub-element.
+/// </remarks>
+public record ResourceScope
+{
+    /// <summary>
+    /// Gets the nearest containing resource (the FHIRPath <c>%resource</c> variable).
+    /// </summary>
+    public IElement? Resource { get; init; }
+
+    /// <summary>
+    /// Gets the container/parent resource (the FHIRPath <c>%rootResource</c> variable).
+    /// Equals <see cref="Resource"/> for a standalone resource or an independent Bundle entry;
+    /// points at the containing resource for a contained resource.
+    /// </summary>
+    public IElement? RootResource { get; init; }
+
+    /// <summary>
+    /// Gets the reference resolver backing the FHIRPath <c>resolve()</c> function. Returns the
+    /// target <see cref="IElement"/> for a reference, or null when it does not resolve.
+    /// </summary>
+    public Func<string, IElement?>? Resolver { get; init; }
+}

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -307,6 +307,14 @@ public class StructureDefinitionSchemaBuilder
         var invariantChecks = ExtractInvariantChecks(elements, typeDefinition, schema, _parser, _logger);
         profileChecks.AddRange(invariantChecks);
 
+        // Reference-integrity (Full tier): flag local references (#id, intra-Bundle Type/id) that
+        // fail to resolve against the scoped resolver. No-ops when no resolver is seeded, so it is
+        // inert outside the scoped validation pipeline.
+        if (typeDefinition.Info.IsResource)
+        {
+            profileChecks.Add(new ReferenceResolutionCheck());
+        }
+
         // Build the canonical URL from the type name
         var canonicalUrl = $"http://hl7.org/fhir/StructureDefinition/{typeDefinition.Info.Name}";
 

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -255,9 +255,25 @@ public class StructureDefinitionSchemaBuilder
             _activeTypeNames.Value = visiting;
         }
         var addedToVisiting = visiting.Add(typeDefinition.Info.Name);
+
+        // Children that resolve to their own nested schema (backbone/complex datatypes). A
+        // constraint owned exclusively by such an element (e.g. Patient.contact's pat-1) is
+        // element-scoped: it is evaluated at that element's altitude by the nested schema, not
+        // hoisted to the resource root. Computed under the cycle guard so it matches exactly
+        // which elements ExtractNestedTypeChecks descends into.
+        var nestedElementNames = new HashSet<string>(StringComparer.Ordinal);
         try
         {
-            var nestedTypeChecks = ExtractNestedTypeChecks(elements, typeDefinition, schema, terminologyService, _logger, _parser);
+            foreach (var e in elements)
+            {
+                if (ResolveNestedType(e, typeDefinition, schema, out _, out _) == NestedTypeResolution.Resolved)
+                {
+                    nestedElementNames.Add(e.Info.Name);
+                }
+            }
+
+            var rootScopedConstraintKeys = CollectRootScopedConstraintKeys(elements, typeDefinition, nestedElementNames);
+            var nestedTypeChecks = ExtractNestedTypeChecks(elements, typeDefinition, schema, terminologyService, rootScopedConstraintKeys, _logger, _parser);
             specChecks.AddRange(nestedTypeChecks);
         }
         finally
@@ -304,7 +320,7 @@ public class StructureDefinitionSchemaBuilder
         // This includes constraints like ele-1, dom-1, resource-specific invariants
         // Moved to Profile tier to avoid false positives on minimal resources
         // Constraints are scoped to the current resource type (see ExtractInvariantChecks for filtering)
-        var invariantChecks = ExtractInvariantChecks(elements, typeDefinition, schema, _parser, _logger);
+        var invariantChecks = ExtractInvariantChecks(elements, typeDefinition, schema, _parser, nestedElementNames, _logger);
         profileChecks.AddRange(invariantChecks);
 
         // Build the canonical URL from the type name
@@ -359,6 +375,7 @@ public class StructureDefinitionSchemaBuilder
         IType typeDefinition,
         ISchema schema,
         FhirPathParser parser,
+        IReadOnlySet<string> nestedElementNames,
         ILogger? logger = null)
     {
         var checks = new List<IValidationCheck>();
@@ -367,11 +384,14 @@ public class StructureDefinitionSchemaBuilder
         // Multiple elements may reference the same constraint (e.g., ele-1 on every element)
         var seenConstraints = new HashSet<string>(StringComparer.Ordinal);
 
-        // Walk the root type AND each child element. Codegen typically duplicates root-level
-        // invariants (ele-1, dom-*) onto every child, but adapter-produced types may keep them
-        // only on the root - so we must inspect both to find them all.
+        // Walk the root type AND each NON-NESTED child element. Codegen typically duplicates
+        // root-level invariants (ele-1, dom-*) onto every child, but adapter-produced types may
+        // keep them only on the root - so we must inspect both to find them all. Nested
+        // complex/backbone children are excluded: a constraint owned only by such an element
+        // (e.g. Patient.contact's pat-1) is element-scoped and is evaluated at that element's
+        // altitude by its nested schema (see ExtractNestedTypeChecks), not at the resource root.
         var elementsToScan = new List<IType>(elements.Count + 1) { typeDefinition };
-        elementsToScan.AddRange(elements);
+        elementsToScan.AddRange(elements.Where(e => !nestedElementNames.Contains(e.Info.Name)));
 
         foreach (var element in elementsToScan)
         {
@@ -425,6 +445,7 @@ public class StructureDefinitionSchemaBuilder
         IType typeDefinition,
         ISchema schema,
         ITerminologyService? terminologyService,
+        IReadOnlySet<string> rootScopedConstraintKeys,
         ILogger<StructureDefinitionSchemaBuilder>? logger = null,
         FhirPathParser? parser = null)
     {
@@ -432,83 +453,221 @@ public class StructureDefinitionSchemaBuilder
 
         foreach (var element in elements)
         {
-            if (element.Info.IsPrimitive)
+            switch (ResolveNestedType(element, typeDefinition, schema, out var nestedTypeName, out var nestedTypeDefinition))
             {
-                continue;
-            }
-
-            if (element.Info.IsChoiceElement)
-            {
-                continue;
-            }
-
-            var typeName = GetTypeName(element);
-
-            if (string.IsNullOrEmpty(typeName) || typeName == element.Info.Name)
-            {
-                // If no type found or type is same as element name (no extended metadata), skip
-                // This happens for elements without ITypeExtended metadata
-                continue;
-            }
-
-            // Skip special types that have dedicated checks
-            // Also skip xhtml - it's a primitive that stores content directly, not in child elements
-            // Skip "Resource" type - this is used for contained resources, which are handled by ContainedResourceCheck
-            if (typeName is "Reference" or "CodeableConcept" or "Coding" or "Extension" or "xhtml" or "Resource")
-            {
-                continue;
-            }
-
-            // Determine the nested type name
-            string nestedTypeName;
-            if (typeName == "BackboneElement")
-            {
-                // BackboneElement: ResourceType.ElementName (e.g., "AuditEvent.Agent")
-                nestedTypeName = $"{typeDefinition.Info.Name}.{CapitalizeFirst(element.Info.Name)}";
-            }
-            else if (typeName == "Element")
-            {
-                // Element type might be a BackboneElement in complex datatypes (e.g., Timing.repeat)
-                // Try to find a specific type like "Timing.Repeat" first
-                var potentialBackboneType = $"{typeDefinition.Info.Name}.{CapitalizeFirst(element.Info.Name)}";
-                if (schema.GetTypeDefinition(potentialBackboneType) == null)
-                {
-                    // No specific BackboneElement type found, skip Element type
+                case NestedTypeResolution.NotNested:
                     continue;
-                }
-                nestedTypeName = potentialBackboneType;
-            }
-            else
-            {
-                // Complex datatype: Use as-is (e.g., "Address", "HumanName")
-                nestedTypeName = typeName;
-            }
-
-            // Try to get the nested type schema
-            var nestedTypeDefinition = schema.GetTypeDefinition(nestedTypeName);
-            if (nestedTypeDefinition == null)
-            {
-                logger?.LogWarning("Nested type '{NestedTypeName}' not found in schema - subtree will not be validated", nestedTypeName);
-                continue;
-            }
-
-            // Cycle guard: if this nested type is already on the active-build stack
-            // (e.g. Element->Element via contentReference, or a profile that recurses
-            // through a layered schema provider), skip to avoid infinite recursion.
-            var visiting = _activeTypeNames.Value;
-            if (visiting != null && visiting.Contains(nestedTypeName))
-            {
-                logger?.LogDebug("Cycle detected building type '{NestedTypeName}' - skipping to prevent infinite recursion", nestedTypeName);
-                continue;
+                case NestedTypeResolution.NotFound:
+                    logger?.LogWarning("Nested type '{NestedTypeName}' not found in schema - subtree will not be validated", nestedTypeName);
+                    continue;
+                case NestedTypeResolution.Cycle:
+                    // Element->Element via contentReference, or a profile that recurses through a
+                    // layered schema provider. Skip to avoid infinite recursion.
+                    logger?.LogDebug("Cycle detected building type '{NestedTypeName}' - skipping to prevent infinite recursion", nestedTypeName);
+                    continue;
             }
 
             // Build the nested schema
             var nestedBuilder = new StructureDefinitionSchemaBuilder(parser, logger);
-            var nestedSchema = nestedBuilder.BuildSchema(nestedTypeDefinition, schema, terminologyService);
+            var nestedSchema = nestedBuilder.BuildSchema(nestedTypeDefinition!, schema, terminologyService);
+
+            // Inject constraints owned by THIS element (e.g. Patient.contact's pat-1) into the
+            // nested schema so they are evaluated once per occurrence, in the element's own
+            // FHIRPath context, and skipped entirely when the element is absent. Universal
+            // constraints already hoisted to the resource root (ele-1, ext-1) are excluded to
+            // avoid duplicate evaluation. Parser is always supplied by BuildSchema; guard keeps
+            // the nullable signature honest.
+            if (parser is not null)
+            {
+                var elementScopedChecks = BuildElementScopedInvariantChecks(
+                    element, rootScopedConstraintKeys, schema, parser, logger);
+                if (elementScopedChecks.Count > 0)
+                {
+                    var injection = new ValidationSchema(
+                        nestedSchema.CanonicalUrl,
+                        nestedSchema.ResourceType,
+                        universalChecks: Array.Empty<IValidationCheck>(),
+                        specChecks: Array.Empty<IValidationCheck>(),
+                        profileChecks: elementScopedChecks);
+                    nestedSchema = ValidationSchema.Compose(new[] { nestedSchema, injection });
+                }
+            }
 
             // Create the nested type check
             var check = new NestedComplexTypeCheck(element.Info.Name, element.IsCollection, nestedSchema);
             checks.Add(check);
+        }
+
+        return checks;
+    }
+
+    /// <summary>
+    /// Outcome of resolving whether a child element has its own nested validation schema.
+    /// </summary>
+    private enum NestedTypeResolution
+    {
+        /// <summary>The element is a primitive, choice, or specially-handled type - no nested schema.</summary>
+        NotNested,
+
+        /// <summary>A nested type definition was found and is safe to build.</summary>
+        Resolved,
+
+        /// <summary>The declared nested type name could not be resolved in the schema.</summary>
+        NotFound,
+
+        /// <summary>The nested type is already on the active-build stack (recursion cycle).</summary>
+        Cycle,
+    }
+
+    /// <summary>
+    /// Determines whether a child element has its own nested validation schema (BackboneElement or
+    /// complex datatype), and if so resolves the nested type definition. Shared by
+    /// <see cref="ExtractNestedTypeChecks"/> (which builds the schema) and the pre-pass in
+    /// <see cref="BuildSchema"/> (which classifies constraints as root- vs element-scoped), so both
+    /// agree exactly on which elements form a nested altitude.
+    /// </summary>
+    private static NestedTypeResolution ResolveNestedType(
+        IType element,
+        IType typeDefinition,
+        ISchema schema,
+        out string nestedTypeName,
+        out IType? nestedTypeDefinition)
+    {
+        nestedTypeName = string.Empty;
+        nestedTypeDefinition = null;
+
+        if (element.Info.IsPrimitive || element.Info.IsChoiceElement)
+        {
+            return NestedTypeResolution.NotNested;
+        }
+
+        var typeName = GetTypeName(element);
+
+        // No type found, or type is same as element name (no extended metadata) - skip.
+        if (string.IsNullOrEmpty(typeName) || typeName == element.Info.Name)
+        {
+            return NestedTypeResolution.NotNested;
+        }
+
+        // Special types have dedicated checks; xhtml stores content directly; "Resource" is a
+        // contained resource handled by ContainedResourceCheck.
+        if (typeName is "Reference" or "CodeableConcept" or "Coding" or "Extension" or "xhtml" or "Resource")
+        {
+            return NestedTypeResolution.NotNested;
+        }
+
+        if (typeName == "BackboneElement")
+        {
+            // BackboneElement: ResourceType.ElementName (e.g., "AuditEvent.Agent").
+            nestedTypeName = $"{typeDefinition.Info.Name}.{CapitalizeFirst(element.Info.Name)}";
+        }
+        else if (typeName == "Element")
+        {
+            // Element type might be a BackboneElement in complex datatypes (e.g., Timing.repeat).
+            // Only treat it as nested when a specific type (e.g. "Timing.Repeat") exists.
+            var potentialBackboneType = $"{typeDefinition.Info.Name}.{CapitalizeFirst(element.Info.Name)}";
+            if (schema.GetTypeDefinition(potentialBackboneType) == null)
+            {
+                return NestedTypeResolution.NotNested;
+            }
+            nestedTypeName = potentialBackboneType;
+        }
+        else
+        {
+            // Complex datatype: use as-is (e.g., "Address", "HumanName").
+            nestedTypeName = typeName;
+        }
+
+        var resolved = schema.GetTypeDefinition(nestedTypeName);
+        if (resolved == null)
+        {
+            return NestedTypeResolution.NotFound;
+        }
+
+        var visiting = _activeTypeNames.Value;
+        if (visiting != null && visiting.Contains(nestedTypeName))
+        {
+            return NestedTypeResolution.Cycle;
+        }
+
+        nestedTypeDefinition = resolved;
+        return NestedTypeResolution.Resolved;
+    }
+
+    /// <summary>
+    /// Collects the constraint keys that are scoped to the resource root: keys carried by the root
+    /// type node or by any non-nested child element. Constraints that appear ONLY on nested
+    /// complex/backbone children are element-scoped and are excluded here so they can be evaluated
+    /// at the element's altitude instead of the resource root.
+    /// </summary>
+    private static HashSet<string> CollectRootScopedConstraintKeys(
+        IReadOnlyList<IType> elements,
+        IType typeDefinition,
+        IReadOnlySet<string> nestedElementNames)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        AddConstraintKeys(typeDefinition, keys);
+
+        foreach (var element in elements)
+        {
+            if (nestedElementNames.Contains(element.Info.Name))
+            {
+                continue;
+            }
+
+            AddConstraintKeys(element, keys);
+        }
+
+        return keys;
+    }
+
+    private static void AddConstraintKeys(IType element, HashSet<string> keys)
+    {
+        if (element is ITypeExtended extended && extended.Constraints is { Count: > 0 } constraints)
+        {
+            foreach (var constraint in constraints)
+            {
+                keys.Add(constraint.Key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds invariant checks for the constraints owned by a nested element that are NOT already
+    /// evaluated at the resource root (i.e. genuinely element-scoped invariants such as pat-1).
+    /// These are attached to the element's nested schema so they run once per occurrence in the
+    /// element's own FHIRPath context.
+    /// </summary>
+    private static List<IValidationCheck> BuildElementScopedInvariantChecks(
+        IType element,
+        IReadOnlySet<string> rootScopedConstraintKeys,
+        ISchema schema,
+        FhirPathParser parser,
+        ILogger? logger)
+    {
+        var checks = new List<IValidationCheck>();
+
+        if (element is not ITypeExtended extended || extended.Constraints is not { Count: > 0 } constraints)
+        {
+            return checks;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var constraint in constraints)
+        {
+            // Universal constraints (ele-1, ext-1, ...) are already hoisted to the resource root.
+            if (rootScopedConstraintKeys.Contains(constraint.Key))
+            {
+                continue;
+            }
+
+            if (!seen.Add(constraint.Key))
+            {
+                continue;
+            }
+
+            var appliesTo = ResolveAppliesTo(constraint);
+            checks.Add(new FhirPathInvariantCheck(constraint, schema, parser, appliesTo, logger));
         }
 
         return checks;

--- a/src/Core/Ignixa.Validation/ValidationState.cs
+++ b/src/Core/Ignixa.Validation/ValidationState.cs
@@ -3,6 +3,8 @@
 //     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // </copyright>
 
+using Ignixa.Abstractions;
+
 namespace Ignixa.Validation;
 
 /// <summary>
@@ -44,6 +46,13 @@ public record ValidationState
     public LocationState Location { get; init; }
 
     /// <summary>
+    /// Gets the FHIRPath tree-context scope (%resource, %rootResource, resolve()) for the
+    /// resource currently being validated. Seeded at resource boundaries via
+    /// <see cref="EnterRootResource"/> / <see cref="EnterContainedResource"/>.
+    /// </summary>
+    public ResourceScope Scope { get; init; } = new();
+
+    /// <summary>
     /// Creates a new state with updated instance information.
     /// </summary>
     /// <param name="resourceType">The resource type being validated (e.g., "Patient").</param>
@@ -75,6 +84,57 @@ public record ValidationState
             {
                 InstancePath = instancePath,
                 DefinitionPath = definitionPath
+            }
+        };
+    }
+
+    /// <summary>
+    /// Enters a resource that becomes a validation root: a standalone resource or an independent
+    /// Bundle entry. Both %resource and %rootResource point at the resource itself (a Bundle entry's
+    /// resource is not "contained" in the Bundle in the FHIRPath sense). Builds a fresh resolver
+    /// rooted at this resource.
+    /// </summary>
+    /// <param name="resource">The resource element becoming the validation root.</param>
+    /// <returns>A new validation state scoped to this resource.</returns>
+    public ValidationState EnterRootResource(IElement resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var index = ReferenceIndex.Build(resource);
+        return this with
+        {
+            Scope = new ResourceScope
+            {
+                Resource = resource,
+                RootResource = resource,
+                Resolver = index.Resolve
+            }
+        };
+    }
+
+    /// <summary>
+    /// Enters a contained resource C inside the current parent resource P: %resource becomes C and
+    /// %rootResource becomes P (the containing resource). The resolver chains C's own contained set
+    /// to the parent scope's resolver, matching FHIR resolution order (contained-of-current then
+    /// bundle/contained-of-root).
+    /// </summary>
+    /// <param name="contained">The contained resource element being entered.</param>
+    /// <returns>A new validation state scoped to the contained resource.</returns>
+    public ValidationState EnterContainedResource(IElement contained)
+    {
+        ArgumentNullException.ThrowIfNull(contained);
+
+        var parentScope = Scope;
+        var index = ReferenceIndex.Build(contained);
+        var parentResolver = parentScope.Resolver;
+
+        return this with
+        {
+            Scope = parentScope with
+            {
+                Resource = contained,
+                RootResource = parentScope.Resource,
+                Resolver = reference => index.Resolve(reference) ?? parentResolver?.Invoke(reference)
             }
         };
     }

--- a/test/Ignixa.Validation.Tests/Checks/FhirPathInvariantCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/FhirPathInvariantCheckTests.cs
@@ -454,6 +454,43 @@ public class FhirPathInvariantCheckTests
     }
 
     /// <summary>
+    /// An expression that parses but throws at evaluation time — an unimplemented FHIRPath function
+    /// such as conformsTo() — is a validator/engine limitation, not a resource error. It must yield a
+    /// non-failing Warning ("could not be evaluated"), matching the parse-failure contract, rather
+    /// than a failing Error. Regression guard for conformance over-strictness (txt-1/htmlChecks etc.).
+    /// </summary>
+    [Fact]
+    public void GivenExpressionThatThrowsAtEvaluation_WhenValidating_ThenResultIsNonFailingWithWarning()
+    {
+        // Arrange — conformsTo() parses fine but throws NotSupportedException at evaluation.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "eng-1",
+            Severity = ConstraintSeverity.Error,
+            Human = "Uses an unimplemented function",
+            Expression = "conformsTo('http://hl7.org/fhir/StructureDefinition/Patient')",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var json = JsonNode.Parse(@"{""resourceType"":""Patient""}");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert — engine limitation must NOT fail validation
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldNotBeEmpty();
+        result.Issues[0].Severity.ShouldBe(IssueSeverity.Warning);
+        result.Issues[0].Code.ShouldBe("eng-1");
+        result.Issues[0].Message.ShouldContain("could not be evaluated");
+    }
+
+    /// <summary>
     /// Tests expression that returns empty collection (treated as false).
     /// </summary>
     [Fact]

--- a/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
@@ -86,6 +86,25 @@ public class ReferenceResolutionCheckTests
     }
 
     [Fact]
+    public void GivenContainedResourceReferencingPeerContained_WhenValidating_ThenNoIssue()
+    {
+        // FHIR contained-peer reference: a contained resource references another contained resource
+        // of the same container via #id. The fragment must resolve against the CONTAINER's contained
+        // pool (the nested resource has no own contained), so it must not be flagged. Regression guard:
+        // isolating nested fragments would falsely flag this.
+        var result = Validate(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""contained"": [
+                { ""resourceType"": ""Organization"", ""id"": ""org1"" },
+                { ""resourceType"": ""Patient"", ""id"": ""linked"", ""managingOrganization"": { ""reference"": ""#org1"" } }
+            ]
+        }");
+
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
     public void GivenRootFragmentReferenceUnresolved_WhenValidating_ThenReportsRefResolve()
     {
         var result = Validate(@"{

--- a/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
@@ -1,7 +1,7 @@
-// <copyright file="ReferenceResolutionCheckTests.cs" company="Microsoft Corporation">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// </copyright>
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 using System.Text.Json.Nodes;
 using Ignixa.Abstractions;
@@ -114,5 +114,55 @@ public class ReferenceResolutionCheckTests
         }");
 
         result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenBundleEntryResourceWithRelativeReferenceToSiblingEntry_WhenValidating_ThenNoIssue()
+    {
+        // entry[0].resource holds a RELATIVE reference that does NOT resolve within its own (empty)
+        // contained set - it only resolves by falling through to the outer Bundle resolver, which
+        // indexes entry[1]'s resource by Type/id. Regression guard: dropping the nested resolver's
+        // "?? outerResolver" chain would falsely flag this as unresolved.
+        var result = Validate(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Patient"",
+                        ""id"": ""p1"",
+                        ""managingOrganization"": { ""reference"": ""Organization/o1"" }
+                    }
+                },
+                {
+                    ""resource"": { ""resourceType"": ""Organization"", ""id"": ""o1"" }
+                }
+            ]
+        }");
+
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenBundleEntryResourceFragmentResolvingWithinItsOwnContained_WhenValidating_ThenNoIssue()
+    {
+        // Bundle.entry.resource is an independent resource root within the Bundle: a fragment
+        // reference inside it must resolve against ITS OWN contained set, not the Bundle's.
+        var result = Validate(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Coverage"",
+                        ""id"": ""c1"",
+                        ""contained"": [{ ""resourceType"": ""Organization"", ""id"": ""payer"" }],
+                        ""payor"": [{ ""reference"": ""#payer"" }]
+                    }
+                }
+            ]
+        }");
+
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
     }
 }

--- a/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/ReferenceResolutionCheckTests.cs
@@ -1,0 +1,99 @@
+// <copyright file="ReferenceResolutionCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+
+namespace Ignixa.Validation.Tests.Checks;
+
+/// <summary>
+/// Tests for <see cref="ReferenceResolutionCheck"/>, focused on resource-boundary scoping of
+/// fragment references.
+/// </summary>
+public class ReferenceResolutionCheckTests
+{
+    private static ValidationResult Validate(string resourceJson)
+    {
+        var element = JsonNodeSourceNode.Create(JsonNode.Parse(resourceJson)!)
+            .ToElement(TestSchemaProvider.GetR4Schema());
+        var state = new ValidationState().EnterRootResource(element);
+        return new ReferenceResolutionCheck().Validate(
+            element,
+            new ValidationSettings { Depth = ValidationDepth.Full },
+            state);
+    }
+
+    [Fact]
+    public void GivenFragmentReferenceResolvingWithinNestedResource_WhenValidating_ThenNoIssue()
+    {
+        // Parameters -> parameter.resource (Coverage) whose OWN contained holds #payer.
+        // The fragment resolves within the nested resource's scope, not the Parameters root's.
+        var result = Validate(@"{
+            ""resourceType"": ""Parameters"",
+            ""parameter"": [{
+                ""name"": ""coverage"",
+                ""resource"": {
+                    ""resourceType"": ""Coverage"",
+                    ""id"": ""c1"",
+                    ""contained"": [{ ""resourceType"": ""Organization"", ""id"": ""payer"" }],
+                    ""payor"": [{ ""reference"": ""#payer"" }]
+                }
+            }]
+        }");
+
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenFragmentReferenceUnresolvedWithinNestedResource_WhenValidating_ThenReportsRefResolve()
+    {
+        // Same shape, but the nested resource contains no matching #payer — genuinely broken.
+        var result = Validate(@"{
+            ""resourceType"": ""Parameters"",
+            ""parameter"": [{
+                ""name"": ""coverage"",
+                ""resource"": {
+                    ""resourceType"": ""Coverage"",
+                    ""id"": ""c1"",
+                    ""payor"": [{ ""reference"": ""#payer"" }]
+                }
+            }]
+        }");
+
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenRootFragmentReferenceResolvingToContained_WhenValidating_ThenNoIssue()
+    {
+        var result = Validate(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""contained"": [{ ""resourceType"": ""Organization"", ""id"": ""org1"" }],
+            ""managingOrganization"": { ""reference"": ""#org1"" }
+        }");
+
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldNotContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenRootFragmentReferenceUnresolved_WhenValidating_ThenReportsRefResolve()
+    {
+        var result = Validate(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""managingOrganization"": { ""reference"": ""#missing"" }
+        }");
+
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseAnalysis.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseAnalysis.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Pure filtering and outcome-counting logic used by <see cref="ConformanceCaseLoader"/>, extracted
+/// so it is unit-testable against synthetic <see cref="JsonElement"/>/JSON fixtures without touching
+/// the vendored test-case directory on disk. All I/O (manifest/outcome file reads) stays in
+/// <see cref="ConformanceCaseLoader"/>; this class only ever inspects already-loaded data.
+/// </summary>
+internal static class ConformanceCaseAnalysis
+{
+    /// <summary>
+    /// Determines whether a manifest entry belongs to the R4 "clean base" slice: validatable against
+    /// the base spec alone, with no IG packages, supporting resources, or explicit profile/logical
+    /// configuration, and whose input JSON file is present.
+    /// </summary>
+    /// <param name="testCase">The manifest entry to classify.</param>
+    /// <param name="fileExists">
+    /// Predicate reporting whether <paramref name="testCase"/>'s <c>File</c> exists on disk. Injected
+    /// so this method stays pure/testable; the loader supplies the real filesystem check.
+    /// </param>
+    /// <returns>True when the entry is an R4 clean-base case.</returns>
+    public static bool IsR4CleanBase(ConformanceTestCase testCase, Func<string, bool> fileExists)
+    {
+        ArgumentNullException.ThrowIfNull(testCase);
+        ArgumentNullException.ThrowIfNull(fileExists);
+
+        if (testCase.Version != "4.0" || !testCase.UseTest)
+        {
+            return false;
+        }
+
+        if (testCase.File is null || !testCase.File.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (testCase.Packages is { Count: > 0 } || testCase.Supporting is { Count: > 0 }
+            || testCase.Profiles is { Count: > 0 } || testCase.Profile is not null || testCase.Logical is not null)
+        {
+            return false;
+        }
+
+        return fileExists(testCase.File);
+    }
+
+    /// <summary>
+    /// Counts error/fatal issues from an inline <c>java</c> outcome object: either an <c>errorCount</c>
+    /// property, or a nested <c>outcome</c> OperationOutcome.
+    /// </summary>
+    /// <param name="inline">The inline JSON object from the manifest's <c>java</c> property.</param>
+    /// <returns>The error count, or null when neither recognized shape is present.</returns>
+    public static int? TryCountErrorsInInlineOutcome(JsonElement inline)
+    {
+        if (inline.TryGetProperty("errorCount", out var ec) && ec.TryGetInt32(out var count))
+        {
+            return count;
+        }
+
+        if (inline.TryGetProperty("outcome", out var outcome) && outcome.ValueKind == JsonValueKind.Object)
+        {
+            return CountErrorIssues(outcome);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses an outcome file's raw JSON content and counts its error/fatal issues.
+    /// </summary>
+    /// <param name="json">The outcome file's raw JSON content.</param>
+    /// <returns>The error count, or null when the content is not parseable JSON.</returns>
+    public static int? TryCountErrorsInOutcomeContent(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return CountErrorIssues(doc.RootElement);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Counts issues at error/fatal severity within an OperationOutcome's <c>issue</c> array.
+    /// </summary>
+    /// <param name="operationOutcome">The OperationOutcome JSON element.</param>
+    /// <returns>The number of error/fatal issues. Zero when <c>issue</c> is absent or not an array.</returns>
+    public static int CountErrorIssues(JsonElement operationOutcome)
+    {
+        if (!operationOutcome.TryGetProperty("issue", out var issues) || issues.ValueKind != JsonValueKind.Array)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var issue in issues.EnumerateArray())
+        {
+            if (issue.TryGetProperty("severity", out var sev)
+                && sev.ValueKind == JsonValueKind.String
+                && sev.GetString() is "error" or "fatal")
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
@@ -122,7 +122,7 @@ public static class ConformanceCaseLoader
         };
 
         return errorCount is { } count
-            ? new ConformanceExpectation(count == 0, count, "java")
+            ? new ConformanceExpectation(count, "java")
             : null;
     }
 

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
@@ -1,0 +1,180 @@
+// <copyright file="ConformanceCaseLoader.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Locates the vendored official FHIR validator test suite, parses the manifest, filters to the
+/// R4 clean-base slice, and resolves reference-validator expected outcomes.
+/// See <see cref="ValidatorConformanceRunner"/> and docs/features/validation/roadmap.md.
+/// </summary>
+public static class ConformanceCaseLoader
+{
+    private const string RelativeValidatorDir =
+        "test/Ignixa.FhirPath.Tests/TestData/fhir-test-cases/validator";
+
+    private static readonly JsonSerializerOptions ManifestOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Resolves the absolute path to the vendored <c>validator/</c> directory by walking up from the
+    /// test output directory to the repo root.
+    /// </summary>
+    public static string FindValidatorDir()
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            var candidate = Path.Combine(
+                current,
+                RelativeValidatorDir.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(Path.Combine(candidate, "manifest.json")))
+            {
+                return candidate;
+            }
+
+            var parent = Path.GetDirectoryName(current);
+            if (parent == current)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate vendored FHIR validator test cases ('{RelativeValidatorDir}') above '{AppContext.BaseDirectory}'.");
+    }
+
+    /// <summary>
+    /// Loads the manifest and returns the R4 "clean base" cases — those validatable against the base
+    /// spec with no IG packages, supporting resources, or explicit profiles — that have a resolvable
+    /// Java reference outcome and a present JSON input file.
+    /// </summary>
+    public static IReadOnlyList<(ConformanceTestCase Case, ConformanceExpectation Expected)> LoadR4CleanBaseCases()
+    {
+        var validatorDir = FindValidatorDir();
+        var manifestJson = File.ReadAllText(Path.Combine(validatorDir, "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<ConformanceManifest>(manifestJson, ManifestOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize validator manifest.json.");
+
+        var results = new List<(ConformanceTestCase, ConformanceExpectation)>();
+        foreach (var testCase in manifest.TestCases)
+        {
+            if (!IsR4CleanBase(testCase, validatorDir))
+            {
+                continue;
+            }
+
+            var expected = TryResolveJavaExpectation(testCase, validatorDir);
+            if (expected is not null)
+            {
+                results.Add((testCase, expected));
+            }
+        }
+
+        return results;
+    }
+
+    private static bool IsR4CleanBase(ConformanceTestCase c, string validatorDir)
+    {
+        if (c.Version != "4.0" || !c.UseTest)
+        {
+            return false;
+        }
+
+        if (c.File is null || !c.File.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (c.Packages is { Count: > 0 } || c.Supporting is { Count: > 0 }
+            || c.Profiles is { Count: > 0 } || c.Profile is not null || c.Logical is not null)
+        {
+            return false;
+        }
+
+        return File.Exists(Path.Combine(validatorDir, c.File));
+    }
+
+    /// <summary>
+    /// Resolves the Java reference outcome (inline object or path under <c>outcomes/</c>) into an
+    /// expectation. Returns null when no usable Java outcome is available.
+    /// </summary>
+    private static ConformanceExpectation? TryResolveJavaExpectation(ConformanceTestCase c, string validatorDir)
+    {
+        if (c.Java is not { } java)
+        {
+            return null;
+        }
+
+        int? errorCount = java.ValueKind switch
+        {
+            JsonValueKind.String => CountErrorsInOutcomeFile(validatorDir, java.GetString()!),
+            JsonValueKind.Object => CountErrorsInInlineOutcome(java),
+            _ => null,
+        };
+
+        return errorCount is { } count
+            ? new ConformanceExpectation(count == 0, count, "java")
+            : null;
+    }
+
+    private static int? CountErrorsInInlineOutcome(JsonElement inline)
+    {
+        if (inline.TryGetProperty("errorCount", out var ec) && ec.TryGetInt32(out var count))
+        {
+            return count;
+        }
+
+        // Some entries embed a nested OperationOutcome under "outcome" instead of a count.
+        if (inline.TryGetProperty("outcome", out var outcome) && outcome.ValueKind == JsonValueKind.Object)
+        {
+            return CountErrorIssues(outcome);
+        }
+
+        return null;
+    }
+
+    private static int? CountErrorsInOutcomeFile(string validatorDir, string relativePath)
+    {
+        var path = Path.Combine(
+            validatorDir,
+            "outcomes",
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        return CountErrorIssues(doc.RootElement);
+    }
+
+    private static int CountErrorIssues(JsonElement operationOutcome)
+    {
+        if (!operationOutcome.TryGetProperty("issue", out var issues) || issues.ValueKind != JsonValueKind.Array)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var issue in issues.EnumerateArray())
+        {
+            if (issue.TryGetProperty("severity", out var sev)
+                && sev.ValueKind == JsonValueKind.String
+                && sev.GetString() is "error" or "fatal")
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs
@@ -1,7 +1,7 @@
-// <copyright file="ConformanceCaseLoader.cs" company="Microsoft Corporation">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// </copyright>
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 using System.Text.Json;
 
@@ -55,9 +55,11 @@ public static class ConformanceCaseLoader
     /// <summary>
     /// Loads the manifest and returns the R4 "clean base" cases — those validatable against the base
     /// spec with no IG packages, supporting resources, or explicit profiles — that have a resolvable
-    /// Java reference outcome and a present JSON input file.
+    /// Java reference outcome and a present JSON input file. Every in-scope case whose outcome could
+    /// NOT be resolved is returned as a skip (with a reason) rather than silently dropped, so the
+    /// resulting sample's denominator is never invisibly shrunk.
     /// </summary>
-    public static IReadOnlyList<(ConformanceTestCase Case, ConformanceExpectation Expected)> LoadR4CleanBaseCases()
+    public static ConformanceLoadResult LoadR4CleanBaseCases()
     {
         var validatorDir = FindValidatorDir();
         var manifestJson = File.ReadAllText(Path.Combine(validatorDir, "manifest.json"));
@@ -65,6 +67,8 @@ public static class ConformanceCaseLoader
             ?? throw new InvalidOperationException("Failed to deserialize validator manifest.json.");
 
         var results = new List<(ConformanceTestCase, ConformanceExpectation)>();
+        var skips = new List<ConformanceSkip>();
+
         foreach (var testCase in manifest.TestCases)
         {
             if (!IsR4CleanBase(testCase, validatorDir))
@@ -72,109 +76,63 @@ public static class ConformanceCaseLoader
                 continue;
             }
 
-            var expected = TryResolveJavaExpectation(testCase, validatorDir);
+            var (expected, skipReason) = ResolveJavaExpectation(testCase, validatorDir);
             if (expected is not null)
             {
                 results.Add((testCase, expected));
             }
-        }
-
-        return results;
-    }
-
-    private static bool IsR4CleanBase(ConformanceTestCase c, string validatorDir)
-    {
-        if (c.Version != "4.0" || !c.UseTest)
-        {
-            return false;
-        }
-
-        if (c.File is null || !c.File.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (c.Packages is { Count: > 0 } || c.Supporting is { Count: > 0 }
-            || c.Profiles is { Count: > 0 } || c.Profile is not null || c.Logical is not null)
-        {
-            return false;
-        }
-
-        return File.Exists(Path.Combine(validatorDir, c.File));
-    }
-
-    /// <summary>
-    /// Resolves the Java reference outcome (inline object or path under <c>outcomes/</c>) into an
-    /// expectation. Returns null when no usable Java outcome is available.
-    /// </summary>
-    private static ConformanceExpectation? TryResolveJavaExpectation(ConformanceTestCase c, string validatorDir)
-    {
-        if (c.Java is not { } java)
-        {
-            return null;
-        }
-
-        int? errorCount = java.ValueKind switch
-        {
-            JsonValueKind.String => CountErrorsInOutcomeFile(validatorDir, java.GetString()!),
-            JsonValueKind.Object => CountErrorsInInlineOutcome(java),
-            _ => null,
-        };
-
-        return errorCount is { } count
-            ? new ConformanceExpectation(count, "java")
-            : null;
-    }
-
-    private static int? CountErrorsInInlineOutcome(JsonElement inline)
-    {
-        if (inline.TryGetProperty("errorCount", out var ec) && ec.TryGetInt32(out var count))
-        {
-            return count;
-        }
-
-        // Some entries embed a nested OperationOutcome under "outcome" instead of a count.
-        if (inline.TryGetProperty("outcome", out var outcome) && outcome.ValueKind == JsonValueKind.Object)
-        {
-            return CountErrorIssues(outcome);
-        }
-
-        return null;
-    }
-
-    private static int? CountErrorsInOutcomeFile(string validatorDir, string relativePath)
-    {
-        var path = Path.Combine(
-            validatorDir,
-            "outcomes",
-            relativePath.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(path))
-        {
-            return null;
-        }
-
-        using var doc = JsonDocument.Parse(File.ReadAllText(path));
-        return CountErrorIssues(doc.RootElement);
-    }
-
-    private static int CountErrorIssues(JsonElement operationOutcome)
-    {
-        if (!operationOutcome.TryGetProperty("issue", out var issues) || issues.ValueKind != JsonValueKind.Array)
-        {
-            return 0;
-        }
-
-        var count = 0;
-        foreach (var issue in issues.EnumerateArray())
-        {
-            if (issue.TryGetProperty("severity", out var sev)
-                && sev.ValueKind == JsonValueKind.String
-                && sev.GetString() is "error" or "fatal")
+            else
             {
-                count++;
+                skips.Add(new ConformanceSkip(testCase.Name ?? testCase.File ?? "(unnamed)", skipReason!.Value));
             }
         }
 
-        return count;
+        return new ConformanceLoadResult(results, skips);
+    }
+
+    private static bool IsR4CleanBase(ConformanceTestCase testCase, string validatorDir) =>
+        ConformanceCaseAnalysis.IsR4CleanBase(
+            testCase,
+            file => File.Exists(Path.Combine(validatorDir, file)));
+
+    /// <summary>
+    /// Resolves the Java reference outcome (inline object or path under <c>outcomes/</c>) into an
+    /// expectation. Returns a skip reason instead of throwing when the outcome file is missing or
+    /// malformed — a broken vendored fixture should not abort the whole suite.
+    /// </summary>
+    private static (ConformanceExpectation? Expected, ConformanceSkipReason? Skip) ResolveJavaExpectation(
+        ConformanceTestCase testCase, string validatorDir)
+    {
+        if (testCase.Java is not { } java)
+        {
+            return (null, ConformanceSkipReason.NoOutcomeField);
+        }
+
+        switch (java.ValueKind)
+        {
+            case JsonValueKind.String:
+                var path = Path.Combine(
+                    validatorDir,
+                    "outcomes",
+                    java.GetString()!.Replace('/', Path.DirectorySeparatorChar));
+                if (!File.Exists(path))
+                {
+                    return (null, ConformanceSkipReason.OutcomeFileMissing);
+                }
+
+                var count = ConformanceCaseAnalysis.TryCountErrorsInOutcomeContent(File.ReadAllText(path));
+                return count is { } fileCount
+                    ? (new ConformanceExpectation(fileCount, "java"), null)
+                    : (null, ConformanceSkipReason.OutcomeFileMalformed);
+
+            case JsonValueKind.Object:
+                var inlineCount = ConformanceCaseAnalysis.TryCountErrorsInInlineOutcome(java);
+                return inlineCount is { } ic
+                    ? (new ConformanceExpectation(ic, "java"), null)
+                    : (null, ConformanceSkipReason.UnrecognizedOutcomeShape);
+
+            default:
+                return (null, ConformanceSkipReason.UnrecognizedOutcomeShape);
+        }
     }
 }

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoaderTests.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoaderTests.cs
@@ -1,0 +1,230 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Unit tests for <see cref="ConformanceCaseAnalysis"/>: the pure filtering and outcome-counting
+/// logic that gates which manifest entries make it into the conformance sample. These tests run
+/// against synthetic <see cref="JsonElement"/>/JSON fixtures and never touch the vendored test-case
+/// directory on disk, so the counting/filter logic is verified independently of the conformance
+/// baseline's own pass rate.
+/// </summary>
+public class ConformanceCaseLoaderTests
+{
+    private static ConformanceTestCase CleanR4Case(
+        string? version = "4.0",
+        bool useTest = true,
+        string? file = "case.json",
+        List<string>? packages = null,
+        List<string>? supporting = null,
+        List<string>? profiles = null,
+        JsonElement? profile = null,
+        JsonElement? logical = null) => new()
+    {
+        Name = "clean-base-case",
+        File = file,
+        Version = version,
+        UseTest = useTest,
+        Packages = packages,
+        Supporting = supporting,
+        Profiles = profiles,
+        Profile = profile,
+        Logical = logical,
+    };
+
+    [Theory]
+    [InlineData("""{"issue":[]}""", 0)]
+    [InlineData("""{"issue":[{"severity":"error"}]}""", 1)]
+    [InlineData("""{"issue":[{"severity":"fatal"}]}""", 1)]
+    [InlineData("""{"issue":[{"severity":"warning"}]}""", 0)]
+    [InlineData("""{"issue":[{"severity":"information"}]}""", 0)]
+    [InlineData("""{"issue":[{"severity":"error"},{"severity":"warning"},{"severity":"fatal"}]}""", 2)]
+    [InlineData("""{"unrelated":true}""", 0)]
+    [InlineData("""{"issue":"not-an-array"}""", 0)]
+    public void GivenOperationOutcomeJson_WhenCountingErrorIssues_ThenReturnsExpectedCount(string json, int expected)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ConformanceCaseAnalysis.CountErrorIssues(doc.RootElement);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenInlineOutcomeWithErrorCountProperty_WhenCounting_ThenReturnsThatCount()
+    {
+        using var doc = JsonDocument.Parse("""{"errorCount": 3}""");
+
+        var result = ConformanceCaseAnalysis.TryCountErrorsInInlineOutcome(doc.RootElement);
+
+        result.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GivenInlineOutcomeWithNestedOutcomeObject_WhenCounting_ThenCountsErrorIssuesWithin()
+    {
+        using var doc = JsonDocument.Parse("""
+        {"outcome": {"issue": [{"severity":"error"}, {"severity":"warning"}]}}
+        """);
+
+        var result = ConformanceCaseAnalysis.TryCountErrorsInInlineOutcome(doc.RootElement);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenInlineOutcomeWithNeitherRecognizedShape_WhenCounting_ThenReturnsNull()
+    {
+        using var doc = JsonDocument.Parse("""{"unrelated": true}""");
+
+        var result = ConformanceCaseAnalysis.TryCountErrorsInInlineOutcome(doc.RootElement);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenWellFormedOutcomeFileContent_WhenCounting_ThenReturnsErrorCount()
+    {
+        const string content =
+            """{"resourceType":"OperationOutcome","issue":[{"severity":"error"},{"severity":"information"}]}""";
+
+        var result = ConformanceCaseAnalysis.TryCountErrorsInOutcomeContent(content);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenMalformedOutcomeFileContent_WhenCounting_ThenReturnsNullInsteadOfThrowing()
+    {
+        const string content = "{ this is not valid json";
+
+        var result = ConformanceCaseAnalysis.TryCountErrorsInOutcomeContent(content);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenR4CaseWithExistingJsonFile_WhenFiltering_ThenIsCleanBase()
+    {
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(CleanR4Case(), _ => true);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenVersionOtherThanR4_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(version: "5.0");
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenVersionAbsent_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(version: null);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenUseTestFalse_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(useTest: false);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenFileMissing_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(file: null);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenFileNotJsonExtension_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(file: "case.xml");
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenPackagesPresent_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(packages: ["some-ig#1.0.0"]);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSupportingResourcesPresent_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(supporting: ["Patient/example.json"]);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenProfilesPresent_WhenFiltering_ThenExcluded()
+    {
+        var testCase = CleanR4Case(profiles: ["http://example.org/StructureDefinition/foo"]);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenExplicitProfilePresent_WhenFiltering_ThenExcluded()
+    {
+        using var doc = JsonDocument.Parse("""{"reference":"http://example.org/StructureDefinition/foo"}""");
+        var testCase = CleanR4Case(profile: doc.RootElement);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLogicalConfigurationPresent_WhenFiltering_ThenExcluded()
+    {
+        using var doc = JsonDocument.Parse("""{"source":"logical.json"}""");
+        var testCase = CleanR4Case(logical: doc.RootElement);
+
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(testCase, _ => true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenFileDoesNotExistOnDisk_WhenFiltering_ThenExcluded()
+    {
+        var result = ConformanceCaseAnalysis.IsR4CleanBase(CleanR4Case(), _ => false);
+
+        result.ShouldBeFalse();
+    }
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
@@ -1,0 +1,14 @@
+// <copyright file="ConformanceExpectation.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// The expected validation verdict for a case, derived from a reference validator's recorded outcome.
+/// </summary>
+/// <param name="ExpectedValid">True when the reference validator reported zero error/fatal issues.</param>
+/// <param name="ExpectedErrorCount">Error/fatal issue count from the reference outcome.</param>
+/// <param name="Source">Which oracle produced this expectation (e.g. "java").</param>
+public sealed record ConformanceExpectation(bool ExpectedValid, int ExpectedErrorCount, string Source);

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
@@ -1,7 +1,7 @@
-// <copyright file="ConformanceExpectation.cs" company="Microsoft Corporation">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// </copyright>
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 namespace Ignixa.Validation.Tests.Conformance;
 

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceExpectation.cs
@@ -8,7 +8,10 @@ namespace Ignixa.Validation.Tests.Conformance;
 /// <summary>
 /// The expected validation verdict for a case, derived from a reference validator's recorded outcome.
 /// </summary>
-/// <param name="ExpectedValid">True when the reference validator reported zero error/fatal issues.</param>
 /// <param name="ExpectedErrorCount">Error/fatal issue count from the reference outcome.</param>
 /// <param name="Source">Which oracle produced this expectation (e.g. "java").</param>
-public sealed record ConformanceExpectation(bool ExpectedValid, int ExpectedErrorCount, string Source);
+public sealed record ConformanceExpectation(int ExpectedErrorCount, string Source)
+{
+    /// <summary>True when the reference validator reported zero error/fatal issues (derived, not stored).</summary>
+    public bool ExpectedValid => ExpectedErrorCount == 0;
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceLoadResult.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceLoadResult.cs
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Result of loading the R4 clean-base slice of the vendored validator manifest: the cases that
+/// resolved to a usable Java reference outcome, plus every in-scope case that was skipped (and why).
+/// </summary>
+/// <param name="Cases">Resolved cases paired with their expected outcome.</param>
+/// <param name="Skips">In-scope cases excluded because their Java outcome could not be resolved.</param>
+public sealed record ConformanceLoadResult(
+    IReadOnlyList<(ConformanceTestCase Case, ConformanceExpectation Expected)> Cases,
+    IReadOnlyList<ConformanceSkip> Skips);

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceManifest.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceManifest.cs
@@ -1,0 +1,15 @@
+// <copyright file="ConformanceManifest.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Serialization;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>Root of the official FHIR validator <c>manifest.json</c>.</summary>
+public sealed class ConformanceManifest
+{
+    [JsonPropertyName("test-cases")]
+    public List<ConformanceTestCase> TestCases { get; set; } = [];
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceSkip.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceSkip.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT License. See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace Ignixa.Validation.Tests.Conformance;
 
-/// <summary>Root of the official FHIR validator <c>manifest.json</c>.</summary>
-public sealed class ConformanceManifest
-{
-    [JsonPropertyName("test-cases")]
-    public List<ConformanceTestCase> TestCases { get; set; } = [];
-}
+/// <summary>
+/// An R4 clean-base manifest entry that was excluded from the conformance sample, and why.
+/// </summary>
+/// <param name="Name">The manifest entry's name (or file name when unnamed).</param>
+/// <param name="Reason">Why the entry's Java reference outcome could not be resolved.</param>
+public sealed record ConformanceSkip(string Name, ConformanceSkipReason Reason);

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceSkipReason.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceSkipReason.cs
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Why an in-scope (R4 clean-base) manifest entry was excluded from the conformance sample because
+/// its reference outcome could not be resolved. Tracked explicitly so a shrinking or biased sample
+/// is visible in the report instead of silently shrinking the denominator.
+/// </summary>
+public enum ConformanceSkipReason
+{
+    /// <summary>The manifest entry has no <c>java</c> property at all.</summary>
+    NoOutcomeField,
+
+    /// <summary>The <c>java</c> property is a string path, but no file exists at that path under <c>outcomes/</c>.</summary>
+    OutcomeFileMissing,
+
+    /// <summary>The outcome file exists but is not parseable JSON.</summary>
+    OutcomeFileMalformed,
+
+    /// <summary>The <c>java</c> value (inline object or parsed outcome file) does not match any shape this loader recognizes.</summary>
+    UnrecognizedOutcomeShape,
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceTestCase.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceTestCase.cs
@@ -1,0 +1,65 @@
+// <copyright file="ConformanceTestCase.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// A single entry from the official HL7 FHIR validator <c>manifest.json</c> test suite.
+/// Only the subset of fields the baseline runner consumes is mapped; other manifest keys are ignored.
+/// </summary>
+public sealed class ConformanceTestCase
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("file")]
+    public string? File { get; set; }
+
+    /// <summary>FHIR version under test. "4.0" == R4; absent == current R5.</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("module")]
+    public string? Module { get; set; }
+
+    /// <summary>When false, the case is ignored by the suite.</summary>
+    [JsonPropertyName("use-test")]
+    public bool UseTest { get; set; } = true;
+
+    /// <summary>IG packages the case requires (id#version). Presence excludes a case from the clean-base slice.</summary>
+    [JsonPropertyName("packages")]
+    public List<string>? Packages { get; set; }
+
+    /// <summary>Extra resources to load before validating. Presence excludes a case from the clean-base slice.</summary>
+    [JsonPropertyName("supporting")]
+    public List<string>? Supporting { get; set; }
+
+    /// <summary>Alias for <see cref="Supporting"/>. Presence excludes a case from the clean-base slice.</summary>
+    [JsonPropertyName("profiles")]
+    public List<string>? Profiles { get; set; }
+
+    /// <summary>Explicit profile to validate against. Presence excludes a case from the clean-base slice.</summary>
+    [JsonPropertyName("profile")]
+    public JsonElement? Profile { get; set; }
+
+    /// <summary>Logical-model configuration for cases that cannot be auto-recognized. Presence excludes a case from the clean-base slice.</summary>
+    [JsonPropertyName("logical")]
+    public JsonElement? Logical { get; set; }
+
+    /// <summary>
+    /// Expected outcome from the HL7 Java reference validator: either an inline object
+    /// (<c>errorCount</c>, or a nested <c>outcome</c> OperationOutcome) or a string path resolved
+    /// under <c>validator/outcomes/</c>.
+    /// </summary>
+    [JsonPropertyName("java")]
+    public JsonElement? Java { get; set; }
+
+    /// <summary>Expected outcome from the Firely .NET SDK (cross-check oracle). Same dual shape as <see cref="Java"/>.</summary>
+    [JsonPropertyName("firely-sdk-current")]
+    public JsonElement? FirelySdkCurrent { get; set; }
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ConformanceTestCase.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ConformanceTestCase.cs
@@ -1,7 +1,7 @@
-// <copyright file="ConformanceTestCase.cs" company="Microsoft Corporation">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// </copyright>
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -58,8 +58,4 @@ public sealed class ConformanceTestCase
     /// </summary>
     [JsonPropertyName("java")]
     public JsonElement? Java { get; set; }
-
-    /// <summary>Expected outcome from the Firely .NET SDK (cross-check oracle). Same dual shape as <see cref="Java"/>.</summary>
-    [JsonPropertyName("firely-sdk-current")]
-    public JsonElement? FirelySdkCurrent { get; set; }
 }

--- a/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
@@ -92,7 +92,13 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
             }
 
             var settings = new ValidationSettings { Depth = ValidationDepth.Full };
-            var result = schema.Validate(sourceNode.ToElement(Schema), settings, new ValidationState());
+
+            // Seed tree-context scope exactly as the production handler does (ValidateResourceHandler),
+            // so %resource / %rootResource / resolve() engage for dom-*/bdl-* invariants and reference
+            // resolution. Without this, invariant evaluation falls back to context-free mode.
+            var element = sourceNode.ToElement(Schema);
+            var state = new ValidationState().EnterRootResource(element);
+            var result = schema.Validate(element, settings, state);
             var errors = result.Issues
                 .Where(i => i.Severity is IssueSeverity.Error or IssueSeverity.Fatal)
                 .ToList();

--- a/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
@@ -1,0 +1,179 @@
+// <copyright file="ValidatorConformanceRunner.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Schema;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace Ignixa.Validation.Tests.Conformance;
+
+/// <summary>
+/// Runs Ignixa validation against the official HL7 FHIR validator test suite and reports the pass
+/// rate versus the Java reference validator. Observational (non-gating): it establishes a baseline
+/// and emits a triage report bucketed by mismatch direction and module, so feature work can be
+/// ordered by where we actually diverge. See docs/features/validation/roadmap.md (Phase 1).
+/// </summary>
+public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
+{
+    private static readonly ISchema Schema = new R4CoreSchemaProvider();
+
+    private static readonly IValidationSchemaResolver Resolver =
+        new CachedValidationSchemaResolver(new StructureDefinitionSchemaResolver(Schema));
+
+    private readonly ITestOutputHelper _output = output;
+
+    [Fact]
+    [Trait("Category", "Conformance")]
+    public void Baseline_R4_CleanBase_AgainstJavaReference()
+    {
+        var validatorDir = ConformanceCaseLoader.FindValidatorDir();
+        var cases = ConformanceCaseLoader.LoadR4CleanBaseCases();
+        cases.ShouldNotBeEmpty();
+
+        var mismatches = new List<TriageRow>();
+        var passed = 0;
+
+        foreach (var (testCase, expected) in cases)
+        {
+            var inputPath = Path.Combine(validatorDir, testCase.File!);
+            var actualValid = TryValidate(inputPath, out var errorCount, out var firstError);
+
+            if (actualValid == expected.ExpectedValid)
+            {
+                passed++;
+            }
+            else
+            {
+                mismatches.Add(new TriageRow(
+                    testCase.Name ?? testCase.File!,
+                    testCase.Module ?? "(none)",
+                    expected.ExpectedValid,
+                    actualValid,
+                    expected.ExpectedErrorCount,
+                    errorCount,
+                    firstError));
+            }
+        }
+
+        WriteReport(cases.Count, passed, mismatches);
+
+        // Observational baseline — do not fail on pass rate. Guard only that the suite actually ran.
+        cases.Count.ShouldBeGreaterThan(0);
+    }
+
+    private static bool TryValidate(string inputPath, out int errorCount, out string? firstError)
+    {
+        try
+        {
+            var json = JsonNode.Parse(File.ReadAllText(inputPath));
+            if (json is null)
+            {
+                errorCount = 1;
+                firstError = "empty/null JSON";
+                return false;
+            }
+
+            var sourceNode = JsonNodeSourceNode.Create(json);
+            var resourceType = sourceNode.ResourceType ?? sourceNode.Name;
+            var schema = Resolver.GetSchema($"http://hl7.org/fhir/StructureDefinition/{resourceType}");
+            if (schema is null)
+            {
+                errorCount = 1;
+                firstError = $"no schema for resourceType '{resourceType}'";
+                return false;
+            }
+
+            var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+            var result = schema.Validate(sourceNode.ToElement(Schema), settings, new ValidationState());
+            var errors = result.Issues
+                .Where(i => i.Severity is IssueSeverity.Error or IssueSeverity.Fatal)
+                .ToList();
+            errorCount = errors.Count;
+            firstError = errors.Count > 0 ? errors[0].Message : null;
+            return errorCount == 0;
+        }
+        catch (Exception ex)
+        {
+            // Parse/navigation failures count as "invalid" — the reference validator rejects these too.
+            errorCount = 1;
+            firstError = $"{ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+
+    private void WriteReport(int total, int passed, List<TriageRow> mismatches)
+    {
+        var passRate = total == 0 ? 0 : 100.0 * passed / total;
+
+        // Over-strict: we report errors the reference accepts. Under-strict: we miss errors it catches.
+        var overStrict = mismatches.Count(r => !r.ActualValid && r.ExpectedValid);
+        var underStrict = mismatches.Count(r => r.ActualValid && !r.ExpectedValid);
+
+        var summary = new StringBuilder();
+        summary.AppendLine("=== Ignixa R4 clean-base conformance vs Java reference ===");
+        summary.AppendLine(
+            $"Total: {total}  Passed: {passed}  Failed: {mismatches.Count}  Pass rate: {passRate:F1}%");
+        summary.AppendLine($"Over-strict  (we reject, ref accepts): {overStrict}");
+        summary.AppendLine($"Under-strict (we accept, ref rejects): {underStrict}");
+        summary.AppendLine();
+        summary.AppendLine("Failures by module:");
+        foreach (var group in mismatches.GroupBy(r => r.Module).OrderByDescending(g => g.Count()))
+        {
+            summary.AppendLine($"  {group.Key,-16} {group.Count()}");
+        }
+
+        var csvPath = Path.Combine(AppContext.BaseDirectory, "conformance-triage-r4.csv");
+        File.WriteAllText(csvPath, BuildTriageCsv(mismatches));
+        summary.AppendLine();
+        summary.AppendLine($"Triage CSV: {csvPath}");
+
+        var text = summary.ToString();
+        _output.WriteLine(text);
+        Console.WriteLine(text);
+    }
+
+    private static string BuildTriageCsv(List<TriageRow> mismatches)
+    {
+        var csv = new StringBuilder();
+        csv.AppendLine("name,module,expectedValid,actualValid,expectedErrors,actualErrors,direction,firstError");
+        foreach (var r in mismatches.OrderBy(r => r.Module).ThenBy(r => r.Name))
+        {
+            var direction = !r.ActualValid && r.ExpectedValid ? "over-strict" : "under-strict";
+            csv.AppendLine(string.Join(
+                ',',
+                Csv(r.Name),
+                Csv(r.Module),
+                r.ExpectedValid,
+                r.ActualValid,
+                r.ExpectedErrorCount,
+                r.ActualErrorCount,
+                direction,
+                Csv(r.FirstError ?? string.Empty)));
+        }
+
+        return csv.ToString();
+    }
+
+    private static string Csv(string value)
+    {
+        var escaped = value.Replace("\r", " ").Replace("\n", " ").Replace("\"", "\"\"");
+        return $"\"{escaped}\"";
+    }
+
+    private sealed record TriageRow(
+        string Name,
+        string Module,
+        bool ExpectedValid,
+        bool ActualValid,
+        int ExpectedErrorCount,
+        int ActualErrorCount,
+        string? FirstError);
+}

--- a/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
+++ b/test/Ignixa.Validation.Tests/Conformance/ValidatorConformanceRunner.cs
@@ -1,9 +1,10 @@
-// <copyright file="ValidatorConformanceRunner.cs" company="Microsoft Corporation">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// </copyright>
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Ignixa.Abstractions;
 using Ignixa.Serialization.SourceNodes;
@@ -35,17 +36,28 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
     public void Baseline_R4_CleanBase_AgainstJavaReference()
     {
         var validatorDir = ConformanceCaseLoader.FindValidatorDir();
-        var cases = ConformanceCaseLoader.LoadR4CleanBaseCases();
-        cases.ShouldNotBeEmpty();
+        var loadResult = ConformanceCaseLoader.LoadR4CleanBaseCases();
+        loadResult.Cases.ShouldNotBeEmpty();
 
         var mismatches = new List<TriageRow>();
+        var errored = new List<ErroredRow>();
         var passed = 0;
 
-        foreach (var (testCase, expected) in cases)
+        foreach (var (testCase, expected) in loadResult.Cases)
         {
             var inputPath = Path.Combine(validatorDir, testCase.File!);
-            var actualValid = TryValidate(inputPath, out var errorCount, out var firstError);
+            var outcome = TryValidate(inputPath, out var errorCount, out var firstError);
 
+            if (outcome == ValidationOutcome.Errored)
+            {
+                errored.Add(new ErroredRow(
+                    testCase.Name ?? testCase.File!,
+                    testCase.Module ?? "(none)",
+                    firstError ?? "(no message)"));
+                continue;
+            }
+
+            var actualValid = outcome == ValidationOutcome.Valid;
             if (actualValid == expected.ExpectedValid)
             {
                 passed++;
@@ -63,13 +75,25 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
             }
         }
 
-        WriteReport(cases.Count, passed, mismatches);
+        WriteReport(loadResult, passed, mismatches, errored);
 
         // Observational baseline — do not fail on pass rate. Guard only that the suite actually ran.
-        cases.Count.ShouldBeGreaterThan(0);
+        loadResult.Cases.Count.ShouldBeGreaterThan(0);
     }
 
-    private static bool TryValidate(string inputPath, out int errorCount, out string? firstError)
+    /// <summary>
+    /// Outcome bucket for a single conformance attempt. <see cref="Errored"/> is kept separate from
+    /// <see cref="Valid"/>/<see cref="Invalid"/> so an Ignixa pipeline bug never masquerades as a
+    /// pass/fail verdict against the reference validator.
+    /// </summary>
+    private enum ValidationOutcome
+    {
+        Valid,
+        Invalid,
+        Errored,
+    }
+
+    private static ValidationOutcome TryValidate(string inputPath, out int errorCount, out string? firstError)
     {
         try
         {
@@ -78,7 +102,7 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
             {
                 errorCount = 1;
                 firstError = "empty/null JSON";
-                return false;
+                return ValidationOutcome.Invalid;
             }
 
             var sourceNode = JsonNodeSourceNode.Create(json);
@@ -88,7 +112,7 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
             {
                 errorCount = 1;
                 firstError = $"no schema for resourceType '{resourceType}'";
-                return false;
+                return ValidationOutcome.Invalid;
             }
 
             var settings = new ValidationSettings { Depth = ValidationDepth.Full };
@@ -104,20 +128,37 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
                 .ToList();
             errorCount = errors.Count;
             firstError = errors.Count > 0 ? errors[0].Message : null;
-            return errorCount == 0;
+            return errorCount == 0 ? ValidationOutcome.Valid : ValidationOutcome.Invalid;
+        }
+        catch (JsonException ex)
+        {
+            // Malformed input JSON is a genuinely invalid resource — the reference validator rejects
+            // these too, so it belongs in the pass/fail tally, not the errored bucket.
+            errorCount = 1;
+            firstError = $"{ex.GetType().Name}: {ex.Message}";
+            return ValidationOutcome.Invalid;
         }
         catch (Exception ex)
         {
-            // Parse/navigation failures count as "invalid" — the reference validator rejects these too.
-            errorCount = 1;
+            // An unexpected pipeline/engine exception (NullReferenceException, InvalidOperationException,
+            // etc.) is a defect in OUR validator, not a verdict about the resource. Scoring it as
+            // "invalid" would let an engine bug masquerade as a correct rejection on expected-invalid
+            // cases, and mischarge it as "over-strict" on expected-valid cases. Bucket it separately.
+            errorCount = 0;
             firstError = $"{ex.GetType().Name}: {ex.Message}";
-            return false;
+            return ValidationOutcome.Errored;
         }
     }
 
-    private void WriteReport(int total, int passed, List<TriageRow> mismatches)
+    private void WriteReport(
+        ConformanceLoadResult loadResult,
+        int passed,
+        List<TriageRow> mismatches,
+        List<ErroredRow> errored)
     {
-        var passRate = total == 0 ? 0 : 100.0 * passed / total;
+        var total = loadResult.Cases.Count;
+        var attempted = total - errored.Count;
+        var passRate = attempted == 0 ? 0 : 100.0 * passed / attempted;
 
         // Over-strict: we report errors the reference accepts. Under-strict: we miss errors it catches.
         var overStrict = mismatches.Count(r => !r.ActualValid && r.ExpectedValid);
@@ -126,14 +167,30 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
         var summary = new StringBuilder();
         summary.AppendLine("=== Ignixa R4 clean-base conformance vs Java reference ===");
         summary.AppendLine(
-            $"Total: {total}  Passed: {passed}  Failed: {mismatches.Count}  Pass rate: {passRate:F1}%");
+            $"Total: {total}  Passed: {passed}  Failed: {mismatches.Count}  Errored: {errored.Count}  Pass rate (of attempted): {passRate:F1}%");
         summary.AppendLine($"Over-strict  (we reject, ref accepts): {overStrict}");
         summary.AppendLine($"Under-strict (we accept, ref rejects): {underStrict}");
+        summary.AppendLine($"Skipped (in-scope, outcome unresolved): {loadResult.Skips.Count}");
         summary.AppendLine();
+
         summary.AppendLine("Failures by module:");
         foreach (var group in mismatches.GroupBy(r => r.Module).OrderByDescending(g => g.Count()))
         {
             summary.AppendLine($"  {group.Key,-16} {group.Count()}");
+        }
+
+        summary.AppendLine();
+        summary.AppendLine("Errored by exception type:");
+        foreach (var group in errored.GroupBy(r => ExceptionTypeOf(r.FirstError)).OrderByDescending(g => g.Count()))
+        {
+            summary.AppendLine($"  {group.Key,-24} {group.Count()}");
+        }
+
+        summary.AppendLine();
+        summary.AppendLine("Skipped by reason:");
+        foreach (var group in loadResult.Skips.GroupBy(s => s.Reason).OrderByDescending(g => g.Count()))
+        {
+            summary.AppendLine($"  {group.Key,-24} {group.Count()}");
         }
 
         var csvPath = Path.Combine(AppContext.BaseDirectory, "conformance-triage-r4.csv");
@@ -141,9 +198,19 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
         summary.AppendLine();
         summary.AppendLine($"Triage CSV: {csvPath}");
 
+        var erroredCsvPath = Path.Combine(AppContext.BaseDirectory, "conformance-errored-r4.csv");
+        File.WriteAllText(erroredCsvPath, BuildErroredCsv(errored));
+        summary.AppendLine($"Errored CSV: {erroredCsvPath}");
+
         var text = summary.ToString();
         _output.WriteLine(text);
         Console.WriteLine(text);
+    }
+
+    private static string ExceptionTypeOf(string firstError)
+    {
+        var separator = firstError.IndexOf(':', StringComparison.Ordinal);
+        return separator < 0 ? firstError : firstError[..separator];
     }
 
     private static string BuildTriageCsv(List<TriageRow> mismatches)
@@ -168,6 +235,23 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
         return csv.ToString();
     }
 
+    private static string BuildErroredCsv(List<ErroredRow> errored)
+    {
+        var csv = new StringBuilder();
+        csv.AppendLine("name,module,exceptionType,message");
+        foreach (var r in errored.OrderBy(r => r.Module).ThenBy(r => r.Name))
+        {
+            csv.AppendLine(string.Join(
+                ',',
+                Csv(r.Name),
+                Csv(r.Module),
+                Csv(ExceptionTypeOf(r.FirstError)),
+                Csv(r.FirstError)));
+        }
+
+        return csv.ToString();
+    }
+
     private static string Csv(string value)
     {
         var escaped = value.Replace("\r", " ").Replace("\n", " ").Replace("\"", "\"\"");
@@ -182,4 +266,6 @@ public sealed class ValidatorConformanceRunner(ITestOutputHelper output)
         int ExpectedErrorCount,
         int ActualErrorCount,
         string? FirstError);
+
+    private sealed record ErroredRow(string Name, string Module, string FirstError);
 }

--- a/test/Ignixa.Validation.Tests/Ignixa.Validation.Tests.csproj
+++ b/test/Ignixa.Validation.Tests/Ignixa.Validation.Tests.csproj
@@ -9,7 +9,8 @@
     <LangVersion>latest</LangVersion>
     <!-- Allow BDD-style test naming with underscores (Given_When_Then) -->
     <!-- Suppress CA1307 (StringComparison) and CS8604 (nullable) in test code for brevity -->
-    <NoWarn>$(NoWarn);CA1307;CA1707;CS8604</NoWarn>
+    <!-- CA2227/CA1002: conformance manifest DTOs use mutable List<T> collections for JSON deserialization -->
+    <NoWarn>$(NoWarn);CA1307;CA1707;CS8604;CA2227;CA1002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Ignixa.Validation.Tests/ReferenceIndexTests.cs
+++ b/test/Ignixa.Validation.Tests/ReferenceIndexTests.cs
@@ -1,0 +1,128 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ReferenceIndex"/> contained, bundle, and miss resolution.
+/// </summary>
+public class ReferenceIndexTests
+{
+    private static IElement ToElement(string json)
+    {
+        var node = JsonNode.Parse(json);
+        return JsonNodeSourceNode.Create(node!).ToElement(TestSchemaProvider.GetR4Schema());
+    }
+
+    [Fact]
+    public void GivenContainedResource_WhenResolvingFragment_ThenReturnsContained()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [
+                { ""resourceType"": ""Practitioner"", ""id"": ""p1"" }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var resolved = index.Resolve("#p1");
+
+        // Assert
+        resolved.ShouldNotBeNull();
+        resolved!.InstanceType.ShouldBe("Practitioner");
+    }
+
+    [Fact]
+    public void GivenBundle_WhenResolvingByTypeAndId_ThenReturnsEntryResource()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var byTypeId = index.Resolve("Patient/1");
+        var byFullUrl = index.Resolve("http://example.org/fhir/Patient/1");
+
+        // Assert
+        byTypeId.ShouldNotBeNull();
+        byTypeId!.InstanceType.ShouldBe("Patient");
+        byFullUrl.ShouldNotBeNull();
+        byFullUrl!.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenBundleEntryWithVersionId_WhenResolvingVersionedReference_ThenReturnsEntryResource()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Patient"",
+                        ""id"": ""1"",
+                        ""meta"": { ""versionId"": ""3"" }
+                    }
+                }
+            ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act
+        var resolved = index.Resolve("Patient/1/_history/3");
+
+        // Assert
+        resolved.ShouldNotBeNull();
+        resolved!.InstanceType.ShouldBe("Patient");
+    }
+
+    [Fact]
+    public void GivenUnknownReference_WhenResolving_ThenReturnsNull()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [ { ""resourceType"": ""Practitioner"", ""id"": ""p1"" } ]
+        }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act & Assert
+        index.Resolve("#missing").ShouldBeNull();
+        index.Resolve("Patient/999").ShouldBeNull();
+        index.Resolve(string.Empty).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNonBundleRoot_WhenResolvingRelativeReference_ThenReturnsNull()
+    {
+        // Arrange
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+        var index = ReferenceIndex.Build(element);
+
+        // Act & Assert
+        index.Resolve("Patient/1").ShouldBeNull();
+    }
+}

--- a/test/Ignixa.Validation.Tests/Schema/ElementScopedInvariantTests.cs
+++ b/test/Ignixa.Validation.Tests/Schema/ElementScopedInvariantTests.cs
@@ -1,0 +1,107 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Schema;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Schema;
+
+/// <summary>
+/// Verifies that element-scoped FHIRPath invariants are evaluated at the altitude of the element
+/// that owns them, not hoisted to the resource root. pat-1 is defined on Patient.contact
+/// ("SHALL at least contain a contact's details or a reference to an organization") and must run
+/// once per contact - in that contact's FHIRPath context - and not at all when there is no contact.
+/// </summary>
+public class ElementScopedInvariantTests
+{
+    private readonly ISchema _schema;
+    private readonly IValidationSchemaResolver _schemaResolver;
+
+    public ElementScopedInvariantTests()
+    {
+        _schema = new R4CoreSchemaProvider();
+        _schemaResolver = new CachedValidationSchemaResolver(new StructureDefinitionSchemaResolver(_schema));
+    }
+
+    private ValidationResult ValidatePatient(string patientJson)
+    {
+        var sourceNode = JsonNodeSourceNode.Create(JsonNode.Parse(patientJson)!);
+        var schema = _schemaResolver.GetSchema("http://hl7.org/fhir/StructureDefinition/Patient");
+        schema.ShouldNotBeNull();
+
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        return schema!.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, new ValidationState());
+    }
+
+    [Fact]
+    public void GivenPatientWithoutContact_WhenValidatingAtFullDepth_ThenPat1DoesNotFire()
+    {
+        // Arrange - no name and no contact: the old root-hoisted evaluation resolved name.exists()
+        // against Patient.name (absent) and emitted a spurious pat-1 error.
+        var patient = """
+        {
+          "resourceType": "Patient",
+          "active": true
+        }
+        """;
+
+        // Act
+        var result = ValidatePatient(patient);
+
+        // Assert
+        result.Issues.ShouldNotContain(i => i.Code == "pat-1");
+    }
+
+    [Fact]
+    public void GivenPatientWithEmptyContact_WhenValidatingAtFullDepth_ThenPat1FiresAtContactAltitude()
+    {
+        // Arrange - a contact carrying none of name/telecom/address/organization violates pat-1.
+        var patient = """
+        {
+          "resourceType": "Patient",
+          "contact": [
+            { "gender": "female" }
+          ]
+        }
+        """;
+
+        // Act
+        var result = ValidatePatient(patient);
+
+        // Assert
+        var pat1Issues = result.Issues.Where(i => i.Code == "pat-1").ToList();
+        pat1Issues.ShouldHaveSingleItem();
+        pat1Issues[0].Severity.ShouldBe(IssueSeverity.Error);
+        pat1Issues[0].Path.ShouldContain("contact");
+    }
+
+    [Fact]
+    public void GivenPatientWithValidContact_WhenValidatingAtFullDepth_ThenPat1DoesNotFire()
+    {
+        // Arrange - contact.organization satisfies pat-1 even though the Patient itself has no name.
+        var patient = """
+        {
+          "resourceType": "Patient",
+          "contact": [
+            { "organization": { "reference": "Organization/1" } }
+          ]
+        }
+        """;
+
+        // Act
+        var result = ValidatePatient(patient);
+
+        // Assert
+        result.Issues.ShouldNotContain(i => i.Code == "pat-1");
+    }
+}

--- a/test/Ignixa.Validation.Tests/Schema/ElementScopedInvariantTests.cs
+++ b/test/Ignixa.Validation.Tests/Schema/ElementScopedInvariantTests.cs
@@ -104,4 +104,140 @@ public class ElementScopedInvariantTests
         // Assert
         result.Issues.ShouldNotContain(i => i.Code == "pat-1");
     }
+
+    [Fact]
+    public void GivenPatientWithTwoContactsOnlyOneOffending_WhenValidatingAtFullDepth_ThenPat1FiresOnceAtOffendingOccurrence()
+    {
+        // Arrange - contact[0] satisfies pat-1 via organization; contact[1] carries none of
+        // name/telecom/address/organization. Multi-occurrence guard: element-scoped evaluation must
+        // run per-occurrence, not just once for the first/any match.
+        var patient = """
+        {
+          "resourceType": "Patient",
+          "contact": [
+            { "organization": { "reference": "Organization/1" } },
+            { "gender": "female" }
+          ]
+        }
+        """;
+
+        // Act
+        var result = ValidatePatientWithRootScope(patient);
+
+        // Assert
+        var pat1Issues = result.Issues.Where(i => i.Code == "pat-1").ToList();
+        pat1Issues.ShouldHaveSingleItem();
+        pat1Issues[0].Path.ShouldContain("contact[1]");
+    }
+
+    [Fact]
+    public void GivenValueSetComposeIncludeWithoutValueSetOrSystem_WhenValidatingAtFullDepth_ThenVsd1FiresAtComposeIncludeAltitude()
+    {
+        // Arrange - vsd-1 lives two backbone levels deep: ValueSet.compose.include. An include entry
+        // with neither valueSet nor system violates it.
+        var valueSet = """
+        {
+          "resourceType": "ValueSet",
+          "status": "active",
+          "compose": {
+            "include": [
+              { "concept": [{ "code": "foo" }] }
+            ]
+          }
+        }
+        """;
+
+        // Act
+        var result = ValidateValueSetWithRootScope(valueSet);
+
+        // Assert
+        var vsd1Issues = result.Issues.Where(i => i.Code == "vsd-1").ToList();
+        vsd1Issues.ShouldHaveSingleItem();
+        vsd1Issues[0].Path.ShouldContain("compose.include[0]");
+    }
+
+    [Fact]
+    public void GivenValueSetWithoutCompose_WhenValidatingAtFullDepth_ThenVsd1DoesNotFire()
+    {
+        // Arrange - no compose element at all: the nested "include" altitude is never entered, so
+        // vsd-1 must not fire (a root-hoisted evaluation would have wrongly fired here).
+        var valueSet = """
+        {
+          "resourceType": "ValueSet",
+          "status": "active"
+        }
+        """;
+
+        // Act
+        var result = ValidateValueSetWithRootScope(valueSet);
+
+        // Assert
+        result.Issues.ShouldNotContain(i => i.Code == "vsd-1");
+    }
+
+    [Fact]
+    public void GivenBundleEntryWithoutResourceRequestOrResponse_WhenValidatingAtFullDepth_ThenBdl5FiresAtEntryAltitude()
+    {
+        // Arrange - bdl-5 lives on Bundle.entry, a distinct constraint shape from pat-1 (per-entry,
+        // one backbone level), proving the element-scoped fix generalizes beyond Patient.contact.
+        var bundle = """
+        {
+          "resourceType": "Bundle",
+          "type": "collection",
+          "entry": [
+            { "fullUrl": "urn:uuid:1" }
+          ]
+        }
+        """;
+
+        // Act
+        var result = ValidateBundleWithRootScope(bundle);
+
+        // Assert
+        var bdl5Issues = result.Issues.Where(i => i.Code == "bdl-5").ToList();
+        bdl5Issues.ShouldHaveSingleItem();
+        bdl5Issues[0].Path.ShouldContain("entry[0]");
+    }
+
+    [Fact]
+    public void GivenBundleEntryWithResource_WhenValidatingAtFullDepth_ThenBdl5DoesNotFire()
+    {
+        // Arrange
+        var bundle = """
+        {
+          "resourceType": "Bundle",
+          "type": "collection",
+          "entry": [
+            { "resource": { "resourceType": "Patient", "id": "p1" } }
+          ]
+        }
+        """;
+
+        // Act
+        var result = ValidateBundleWithRootScope(bundle);
+
+        // Assert
+        result.Issues.ShouldNotContain(i => i.Code == "bdl-5");
+    }
+
+    private ValidationResult ValidatePatientWithRootScope(string patientJson) =>
+        ValidateWithRootScope("http://hl7.org/fhir/StructureDefinition/Patient", patientJson);
+
+    private ValidationResult ValidateValueSetWithRootScope(string valueSetJson) =>
+        ValidateWithRootScope("http://hl7.org/fhir/StructureDefinition/ValueSet", valueSetJson);
+
+    private ValidationResult ValidateBundleWithRootScope(string bundleJson) =>
+        ValidateWithRootScope("http://hl7.org/fhir/StructureDefinition/Bundle", bundleJson);
+
+    private ValidationResult ValidateWithRootScope(string canonicalUrl, string resourceJson)
+    {
+        var sourceNode = JsonNodeSourceNode.Create(JsonNode.Parse(resourceJson)!);
+        var schema = _schemaResolver.GetSchema(canonicalUrl);
+        schema.ShouldNotBeNull();
+
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var state = new ValidationState().EnterRootResource(element);
+        return schema!.Validate(element, settings, state);
+    }
 }

--- a/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
+++ b/test/Ignixa.Validation.Tests/TreeContextScopingTests.cs
@@ -1,0 +1,325 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.FhirPath.Parser;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests;
+
+/// <summary>
+/// Tests for FHIRPath tree-context scoping: %resource / %rootResource seeding via ValidationState,
+/// resolve() across contained and Bundle scopes, and the reference-integrity check.
+/// </summary>
+public class TreeContextScopingTests
+{
+    private readonly ISchema _schema = new R4CoreSchemaProvider();
+    private readonly FhirPathParser _parser = new();
+
+    private static IElement ToElement(string json)
+    {
+        var node = JsonNode.Parse(json);
+        return JsonNodeSourceNode.Create(node!).ToElement(TestSchemaProvider.GetR4Schema());
+    }
+
+    private static IElement ToElement(JsonNode node)
+        => JsonNodeSourceNode.Create(node).ToElement(TestSchemaProvider.GetR4Schema());
+
+    [Fact]
+    public void GivenResource_WhenEnterRootResource_ThenResourceEqualsRootResource()
+    {
+        // Arrange
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+
+        // Act
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Assert
+        state.Scope.Resource.ShouldBeSameAs(element);
+        state.Scope.RootResource.ShouldBeSameAs(element);
+        state.Scope.Resolver.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GivenContained_WhenEnterContainedResource_ThenResourceIsContainedAndRootIsParent()
+    {
+        // Arrange
+        var parent = ToElement(@"{
+            ""resourceType"": ""Observation"",
+            ""id"": ""obs1"",
+            ""contained"": [ { ""resourceType"": ""Patient"", ""id"": ""p1"" } ]
+        }");
+        var contained = parent.Children("contained")[0];
+
+        // Act
+        var state = new ValidationState()
+            .EnterRootResource(parent)
+            .EnterContainedResource(contained);
+
+        // Assert
+        state.Scope.Resource.ShouldBeSameAs(contained);
+        state.Scope.RootResource.ShouldBeSameAs(parent);
+    }
+
+    [Fact]
+    public void GivenResourceConstraintReferencingResourceVariable_WhenSeeded_ThenEvaluatesAgainstResource()
+    {
+        // Arrange
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-id",
+            Severity = ConstraintSeverity.Error,
+            Human = "Resource must have an id",
+            Expression = "%resource.id.exists()",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""abc"" }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenContainedConstraintReferencingResourceVariable_WhenScopedToContained_ThenEvaluatesAgainstContained()
+    {
+        // Arrange — a constraint asserting %resource is a Patient. When evaluated on the contained
+        // resource with proper scoping, %resource must be the contained Patient, not the parent.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-is-patient",
+            Severity = ConstraintSeverity.Error,
+            Human = "%resource must be a Patient",
+            Expression = "%resource.id = 'p1'",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var parent = ToElement(@"{
+            ""resourceType"": ""Observation"",
+            ""id"": ""obs1"",
+            ""contained"": [ { ""resourceType"": ""Patient"", ""id"": ""p1"" } ]
+        }");
+        var contained = parent.Children("contained")[0];
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState()
+            .EnterRootResource(parent)
+            .EnterContainedResource(contained);
+
+        // Act
+        var result = check.Validate(contained, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenUnseededState_WhenEvaluatingConstraintWithoutResourceVariable_ThenEvaluatesContextFree()
+    {
+        // Arrange — no scope seeded. Evaluation must proceed exactly as before (context-free):
+        // ordinary element-relative constraints still work, preserving existing-test behavior.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "res-fallback",
+            Severity = ConstraintSeverity.Error,
+            Human = "Has an id",
+            Expression = "id.exists()",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{ ""resourceType"": ""Patient"", ""id"": ""1"" }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert — unseeded evaluation must not throw and remains valid for element-relative checks
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenContainedReference_WhenConstraintUsesResolve_ThenResolvesContained()
+    {
+        // Arrange
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "resolve-contained",
+            Severity = ConstraintSeverity.Error,
+            Human = "generalPractitioner resolves to a Practitioner",
+            Expression = "generalPractitioner.reference.resolve().is(Practitioner)",
+            Xpath = null,
+            AppliesTo = new[] { "Patient" }
+        };
+
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""example"",
+            ""contained"": [ { ""resourceType"": ""Practitioner"", ""id"": ""p1"" } ],
+            ""generalPractitioner"": [ { ""reference"": ""#p1"" } ]
+        }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenBundleEntryReference_WhenConstraintUsesResolve_ThenResolvesSiblingEntry()
+    {
+        // Arrange — a Bundle constraint resolving an intra-bundle reference by Type/id.
+        var constraint = new Ignixa.Specification.ConstraintDefinition
+        {
+            Key = "resolve-bundle",
+            Severity = ConstraintSeverity.Error,
+            Human = "Observation.subject resolves within bundle",
+            Expression = "entry.resource.ofType(Observation).subject.reference.resolve().is(Patient)",
+            Xpath = null,
+            AppliesTo = new[] { "Bundle" }
+        };
+
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Patient/1"",
+                    ""resource"": { ""resourceType"": ""Patient"", ""id"": ""1"" }
+                },
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var check = new FhirPathInvariantCheck(constraint, _schema, _parser);
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenBundleWithDanglingLocalReference_WhenReferenceResolutionCheck_ThenReportsIssue()
+    {
+        // Arrange
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""fullUrl"": ""http://example.org/fhir/Observation/2"",
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""Patient/999"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Code == "ref-resolve");
+    }
+
+    [Fact]
+    public void GivenExternalReference_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — absolute external URL must not be flagged even though it doesn't resolve locally.
+        var element = ToElement(@"{
+            ""resourceType"": ""Bundle"",
+            ""type"": ""collection"",
+            ""entry"": [
+                {
+                    ""resource"": {
+                        ""resourceType"": ""Observation"",
+                        ""id"": ""2"",
+                        ""status"": ""final"",
+                        ""code"": { ""text"": ""x"" },
+                        ""subject"": { ""reference"": ""https://other.example.org/fhir/Patient/1"" }
+                    }
+                }
+            ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState().EnterRootResource(element);
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenNoResolverSeeded_WhenReferenceResolutionCheck_ThenDoesNotReportIssue()
+    {
+        // Arrange — without a seeded resolver the check is inert.
+        var element = ToElement(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""1"",
+            ""generalPractitioner"": [ { ""reference"": ""#missing"" } ]
+        }");
+        var check = new ReferenceResolutionCheck();
+        var settings = new ValidationSettings { Depth = ValidationDepth.Full };
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(element, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Validation implementation — conformance harness + correctness fixes

Base branch for the validation buildout. Wires up the official HL7 FHIR validator conformance suite, banks a set of invariant/reference correctness fixes measured against it, folds in PR #286 (tree-context scoping), and records the architecture in an ADR + a phased roadmap.

### Conformance harness (Phase 1)

The official `FHIR/fhir-test-cases` suite (913-case `validator/manifest.json` + Java reference outcomes) was already vendored in the repo but unused. `ValidatorConformanceRunner` now runs the **R4 clean-base slice (187 cases)** against the Java reference — boolean valid/invalid, observational (non-gating), emitting a triage CSV bucketed by mismatch direction and module.

### The scoreboard

| | Pass rate | Over-strict (we reject, ref accepts) | Under-strict (we accept, ref rejects) |
|---|---|---|---|
| Baseline (`main`) | 63.6% | **54** | 14 |
| This PR | 63.6% | **18** | 50 |

Headline pass-rate is flat, but **over-strict fell 54 → 18 (−67%)** — false *rejections* of valid resources, a validator's worst failure mode, nearly eliminated. The key finding: the baseline was full of **compensating false-positives** (spurious errors that coincidentally produced the right verdict for the wrong reason). Each correctness fix trims over-strict and unmasks an honest under-strict gap (mostly terminology). The over-strict/under-strict split, not the aggregate, is the real instrument.

### Correctness fixes

- **Unevaluable invariants degrade to warning** — an unimplemented FHIRPath function (`htmlChecks()`/`conformsTo()`) throwing at eval time no longer produces a spurious validation error.
- **Element-scoped invariant altitude** — constraints owned by a nested element (`pat-1` on `Patient.contact`, `bdl-5`, `inv-1`, `vsd-1`) now evaluate at their owning element, not the resource root, and are skipped when the element is absent.
- **Nested-resource fragment re-scoping** — `#fragment` references inside a nested resource (`Parameters.parameter.resource`, `Bundle.entry.resource`, `contained[]`) resolve against that resource's own `contained`, not the outer resource's.

### PR #286 folded in

Merges `feat/validation-tree-context-scoping` (%resource/%rootResource/resolve() context injection + `ReferenceResolutionCheck`). Complementary to the altitude fix (distinct mechanism: context injection vs constraint attachment). This PR supersedes #286.

### Architecture

- **ADR 2607** — Forward-only nodes with descending context scopes (rejects bidirectional node navigation; names the two failure modes reviewers must check).
- **Roadmap** (`docs/features/validation/roadmap.md`) — phased plan with the progression log and locked decisions.

### Next steps (decisions locked)

- **Phase 2:** own `ElementMerger` (differential→snapshot generation, Rust-informed) — unlocks the currently-deferred profile/IG-package conformance cases.
- **Phase 3:** terminology — expanded local valuesets + error-vs-warn severity + remote TX server API.

Detailed implementation plans in `docs/features/validation/investigations/`.

Guardrail respected throughout: `ValidationDepth.Compatibility` behavior (MS FHIR Server / legacy Firely parity) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
