### PR TITLE
feat(validation): structural micro-rules sprint (+11 cases, over-strict held at 10)

### DIFF
--- a/src/Core/Ignixa.Validation/Checks/AttachmentSizeCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/AttachmentSizeCheck.cs
@@ -1,0 +1,74 @@
+// <copyright file="AttachmentSizeCheck.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Validates that Attachment.size, when stated, matches the actual decoded byte length of
+/// Attachment.data. Tier 1 (Fast) validator - a closed-world structural check with no terminology
+/// or profile dependency.
+/// </summary>
+public class AttachmentSizeCheck : IValidationCheck, ISingletonCheck
+{
+    /// <summary>
+    /// Validates that a stated Attachment.size matches the decoded Attachment.data length.
+    /// </summary>
+    /// <param name="element">The Attachment element to validate.</param>
+    /// <param name="settings">Validation settings.</param>
+    /// <param name="state">Current validation state.</param>
+    /// <returns>A validation result indicating success or failure.</returns>
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        var sizeChildren = element.Children("size");
+        if (sizeChildren.Count == 0 || !TryGetIntegerValue(sizeChildren[0].Value, out var statedSize))
+        {
+            return ValidationResult.Success();
+        }
+
+        var dataChildren = element.Children("data");
+        if (dataChildren.Count == 0)
+        {
+            return ValidationResult.Success();
+        }
+
+        var dataText = dataChildren[0].Value?.ToString();
+        if (string.IsNullOrEmpty(dataText) || !FhirPrimitiveValidator.TryDecodeBase64(dataText, out var bytes))
+        {
+            // Malformed/absent base64 content is reported by TypeCheck; avoid a misleading
+            // size mismatch on top of an already-invalid value.
+            return ValidationResult.Success();
+        }
+
+        var actualSize = bytes!.Length;
+        if (statedSize != actualSize)
+        {
+            return ValidationResult.Failure(ValidationIssue.InvariantFailure(
+                "structure",
+                $"Stated Attachment Size {statedSize} does not match actual attachment size {actualSize}",
+                element.Location));
+        }
+
+        return ValidationResult.Success();
+    }
+
+    private static bool TryGetIntegerValue(object? value, out long result)
+    {
+        switch (value)
+        {
+            case int i:
+                result = i;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/BundleFullUrlCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/BundleFullUrlCheck.cs
@@ -1,0 +1,62 @@
+// <copyright file="BundleFullUrlCheck.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Validates that, when present, Bundle.entry.fullUrl is an absolute URI rather than a relative
+/// reference (e.g. "Patient/1"). Tier 1 (Fast) validator, scoped to the Bundle resource type.
+/// </summary>
+/// <remarks>
+/// Only checks fullUrl values that are actually present: whether a fullUrl is required at all is a
+/// separate, context-dependent FHIR rule (it varies by Bundle.type and whether entries need to
+/// resolve local references) that this check does not attempt. Skipped in Compatibility mode,
+/// matching the same absolute-URI leniency <see cref="CodingStructureCheck"/> already applies to
+/// Coding.system for Microsoft FHIR Server alignment.
+/// </remarks>
+public sealed class BundleFullUrlCheck : IValidationCheck, ISingletonCheck
+{
+    /// <inheritdoc />
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        if (settings.Depth == ValidationDepth.Compatibility)
+        {
+            return ValidationResult.Success();
+        }
+
+        var entries = element.Children("entry");
+        if (entries.Count == 0)
+        {
+            return ValidationResult.Success();
+        }
+
+        var issues = new List<ValidationIssue>();
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var fullUrlChildren = entries[i].Children("fullUrl");
+            if (fullUrlChildren.Count == 0)
+            {
+                continue;
+            }
+
+            var fullUrlNode = fullUrlChildren[0];
+            var fullUrl = fullUrlNode.Value?.ToString();
+            if (string.IsNullOrEmpty(fullUrl) || Uri.TryCreate(fullUrl, UriKind.Absolute, out _))
+            {
+                continue;
+            }
+
+            issues.Add(ValidationIssue.InvariantFailure(
+                "invalid",
+                $"The fullUrl must be an absolute URL (not '{fullUrl}')",
+                fullUrlNode.Location ?? $"{element.Location}.entry[{i}].fullUrl"));
+        }
+
+        return issues.Count > 0 ? ValidationResult.Failure(issues) : ValidationResult.Success();
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/BundleLinkRelationCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/BundleLinkRelationCheck.cs
@@ -1,0 +1,55 @@
+// <copyright file="BundleLinkRelationCheck.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Validates that each Bundle.link.relation value occurs at most once. Tier 1 (Fast) validator,
+/// scoped to the Bundle resource type - a closed-world structural rule with no terminology
+/// dependency (link relation values are not bound to a code system we validate).
+/// </summary>
+public sealed class BundleLinkRelationCheck : IValidationCheck, ISingletonCheck
+{
+    /// <inheritdoc />
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        var links = element.Children("link");
+        if (links.Count == 0)
+        {
+            return ValidationResult.Success();
+        }
+
+        var issues = new List<ValidationIssue>();
+        var seenRelations = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var i = 0; i < links.Count; i++)
+        {
+            var relationChildren = links[i].Children("relation");
+            if (relationChildren.Count == 0)
+            {
+                continue;
+            }
+
+            var relation = relationChildren[0].Value?.ToString();
+            if (string.IsNullOrEmpty(relation))
+            {
+                continue;
+            }
+
+            if (!seenRelations.Add(relation))
+            {
+                issues.Add(ValidationIssue.InvariantFailure(
+                    "invalid",
+                    $"The link relationship type '{relation}' can only occur once",
+                    links[i].Location ?? $"{element.Location}.link[{i}]"));
+            }
+        }
+
+        return issues.Count > 0 ? ValidationResult.Failure(issues) : ValidationResult.Success();
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/EmptyArrayCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/EmptyArrayCheck.cs
@@ -1,0 +1,91 @@
+// <copyright file="EmptyArrayCheck.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Validation.Abstractions;
+
+namespace Ignixa.Validation.Checks;
+
+/// <summary>
+/// Rejects a JSON array that is present but empty anywhere in the resource's raw JSON tree
+/// ("Array cannot be empty - the property should not be present if it has no values"). Tier 2
+/// (Spec) validator, mirroring <see cref="StructuralShapeCheck"/>'s ele-1 empty-array rule.
+/// </summary>
+/// <remarks>
+/// <see cref="StructuralShapeCheck"/> already enforces this for every declared element that gets
+/// its own nested schema, but complex datatypes such as CodeableConcept and Coding are not expanded
+/// into a nested schema (see <c>StructureDefinitionSchemaBuilder.ResolveNestedType</c>), so an empty
+/// array nested inside one of them (e.g. <c>category[0].coding: []</c>) is never inspected by that
+/// per-element check. This check closes that gap with a single schema-independent walk of the raw
+/// JSON tree from the resource root, so the rule applies uniformly regardless of how deep the
+/// StructureDefinition-driven schema expansion goes.
+/// <para>
+/// "contained" is excluded: contained resources are validated independently via
+/// <see cref="ContainedResourceCheck"/>, which applies this same structural rule (and every other
+/// resource-level check) to each contained resource's own JSON subtree. Walking into "contained"
+/// here would either duplicate that validation or require re-deriving its resource-root path
+/// conventions; skipping it keeps this check strictly about the current resource's own shape.
+/// </para>
+/// </remarks>
+public sealed class EmptyArrayCheck : IValidationCheck, ISingletonCheck
+{
+    /// <inheritdoc />
+    public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)
+    {
+        if (element.Meta<JsonNode>() is not JsonObject root)
+        {
+            return ValidationResult.Success();
+        }
+
+        var issues = new List<ValidationIssue>();
+        WalkObject(root, element.InstanceType, issues);
+
+        return issues.Count > 0 ? ValidationResult.Failure(issues) : ValidationResult.Success();
+    }
+
+    private static void WalkObject(JsonObject obj, string path, List<ValidationIssue> issues)
+    {
+        foreach (var (key, value) in obj)
+        {
+            if (value is null || string.Equals(key, "resourceType", StringComparison.Ordinal)
+                || string.Equals(key, "contained", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var childPath = $"{path}.{key}";
+            switch (value)
+            {
+                case JsonArray array:
+                    WalkArray(array, childPath, issues);
+                    break;
+                case JsonObject nested:
+                    WalkObject(nested, childPath, issues);
+                    break;
+            }
+        }
+    }
+
+    private static void WalkArray(JsonArray array, string path, List<ValidationIssue> issues)
+    {
+        if (array.Count == 0)
+        {
+            issues.Add(ValidationIssue.InvariantFailure(
+                "invalid",
+                "Array cannot be empty - the property should not be present if it has no values",
+                path));
+            return;
+        }
+
+        for (var i = 0; i < array.Count; i++)
+        {
+            if (array[i] is JsonObject item)
+            {
+                WalkObject(item, $"{path}[{i}]", issues);
+            }
+        }
+    }
+}

--- a/src/Core/Ignixa.Validation/Checks/FhirPrimitiveValidator.cs
+++ b/src/Core/Ignixa.Validation/Checks/FhirPrimitiveValidator.cs
@@ -61,6 +61,27 @@ public static class FhirPrimitiveValidator
     public static bool IsPrimitiveType(string fhirType) => PrimitiveTypes.Contains(fhirType);
 
     /// <summary>
+    /// Decodes a FHIR <c>base64Binary</c> string, tolerating the interspersed whitespace the FHIR
+    /// base64Binary regex permits. Used both to validate the encoding and (by callers that need the
+    /// decoded length, e.g. Attachment.size cross-checks) to obtain the actual byte content.
+    /// </summary>
+    /// <param name="text">The candidate base64Binary string value.</param>
+    /// <param name="bytes">The decoded bytes, or null when <paramref name="text"/> is not valid base64.</param>
+    /// <returns>True if <paramref name="text"/> is valid base64; otherwise false.</returns>
+    public static bool TryDecodeBase64(string text, out byte[]? bytes)
+    {
+        Span<byte> buffer = text.Length <= 256 ? stackalloc byte[text.Length] : new byte[text.Length];
+        if (!Convert.TryFromBase64String(text, buffer, out var bytesWritten))
+        {
+            bytes = null;
+            return false;
+        }
+
+        bytes = buffer[..bytesWritten].ToArray();
+        return true;
+    }
+
+    /// <summary>
     /// Validates the primitive value carried by <paramref name="element"/> against
     /// <paramref name="fhirType"/>. Non-primitive types and absent/null values return
     /// success (shape/cardinality are enforced by other checks).
@@ -188,6 +209,12 @@ public static class FhirPrimitiveValidator
 
         if (fhirType is "date" or "dateTime" or "instant" && !IsCalendarDateValid(text, out reason))
         {
+            return false;
+        }
+
+        if (fhirType == "base64Binary" && !TryDecodeBase64(text, out _))
+        {
+            reason = $"value '{text}' is not valid base64: contains characters outside the base64 alphabet or has an invalid length/padding";
             return false;
         }
 

--- a/src/Core/Ignixa.Validation/Checks/NarrativeCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/NarrativeCheck.cs
@@ -3,6 +3,7 @@
 //     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // </copyright>
 
+using System.Text.RegularExpressions;
 using Ignixa.Abstractions;
 using Ignixa.Validation.Abstractions;
 
@@ -12,10 +13,35 @@ namespace Ignixa.Validation.Checks;
 /// Validates FHIR Narrative (text) structure.
 /// Ensures text.status is present and valid.
 /// Ensures text.div is present when status is not 'empty'.
+/// Ensures div content does not embed scripting/framing elements or non-predefined XML entities.
 /// Tier 1 (Fast) validator.
 /// </summary>
 public class NarrativeCheck : IValidationCheck, ISingletonCheck
 {
+    // Matches both opening and closing tag names ("<script", "</script") so a denied element is
+    // caught regardless of which delimiter it's spotted through.
+    private static readonly Regex TagNameRegex = new(@"<\s*/?\s*([A-Za-z][A-Za-z0-9]*)", RegexOptions.Compiled);
+
+    // XML permits only these five general entities without a DTD; anything else named (e.g. the
+    // HTML-only "&reg;") is not valid XHTML.
+    private static readonly Regex NamedEntityRegex = new(@"&([A-Za-z][A-Za-z0-9]*);", RegexOptions.Compiled);
+
+    private static readonly HashSet<string> AllowedXmlEntities =
+        new(StringComparer.Ordinal) { "amp", "lt", "gt", "apos", "quot" };
+
+    // Scripting/framing/embedding elements are excluded from the narrative's basic HTML formatting
+    // subset (FHIR narrative rule: HTML 4.0 chapters 7-11 except section 4 of chapter 9, and 15).
+    // A deny-list (rather than a full allow-list) keeps the risk of over-rejecting legitimate
+    // formatting markup low while still catching the dangerous cases this rule exists to prevent.
+    private static readonly HashSet<string> DisallowedXhtmlElements =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "script", "style", "object", "embed", "iframe", "frame", "frameset", "noframes",
+            "noscript", "applet", "form", "input", "button", "select", "textarea", "link",
+            "meta", "base", "title", "head", "body", "html", "svg", "video", "audio", "canvas",
+            "math", "param", "source",
+        };
+
     /// <summary>
     /// Validates Narrative structure.
     /// </summary>
@@ -50,7 +76,8 @@ public class NarrativeCheck : IValidationCheck, ISingletonCheck
             }
 
             // Compatibility mode: status is not required, but div is.
-            if (!textNode.Children("div").Any())
+            var compatibilityDivChildren = textNode.Children("div");
+            if (compatibilityDivChildren.Count == 0)
             {
                 issues.Add(ValidationIssue.InvariantFailure(
                     "txt-1",
@@ -59,7 +86,8 @@ public class NarrativeCheck : IValidationCheck, ISingletonCheck
                 return ValidationResult.Failure(issues);
             }
 
-            return ValidationResult.Success();
+            ValidateDivContent(compatibilityDivChildren[0], issues);
+            return issues.Count > 0 ? ValidationResult.Failure(issues) : ValidationResult.Success();
         }
 
         var statusNode = statusChildren[0];
@@ -74,12 +102,17 @@ public class NarrativeCheck : IValidationCheck, ISingletonCheck
         }
 
         // Check for div field (required if status is not 'empty')
-        if (status != "empty" && !textNode.Children("div").Any())
+        var divChildren = textNode.Children("div");
+        if (status != "empty" && divChildren.Count == 0)
         {
             issues.Add(ValidationIssue.InvariantFailure(
                 "txt-1",
                 "Narrative must have a div field when status is not 'empty'",
                 $"{textNode.Location}.div"));
+        }
+        else if (divChildren.Count > 0)
+        {
+            ValidateDivContent(divChildren[0], issues);
         }
 
         if (issues.Count > 0)
@@ -88,5 +121,44 @@ public class NarrativeCheck : IValidationCheck, ISingletonCheck
         }
 
         return ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Scans narrative div content for disallowed (scripting/framing) HTML elements and for named
+    /// XML entities other than the five predefined general entities.
+    /// </summary>
+    private static void ValidateDivContent(IElement divNode, List<ValidationIssue> issues)
+    {
+        var div = divNode.Value?.ToString();
+        if (string.IsNullOrEmpty(div))
+        {
+            return;
+        }
+
+        var reportedTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in TagNameRegex.Matches(div))
+        {
+            var tagName = match.Groups[1].Value;
+            if (DisallowedXhtmlElements.Contains(tagName) && reportedTags.Add(tagName))
+            {
+                issues.Add(ValidationIssue.InvariantFailure(
+                    "invalid",
+                    $"Invalid element name in the XHTML ('{tagName}')",
+                    divNode.Location));
+            }
+        }
+
+        var reportedEntities = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match match in NamedEntityRegex.Matches(div))
+        {
+            var entityName = match.Groups[1].Value;
+            if (!AllowedXmlEntities.Contains(entityName) && reportedEntities.Add(entityName))
+            {
+                issues.Add(ValidationIssue.InvariantFailure(
+                    "invalid",
+                    $"Invalid entity in the XHTML ('&{entityName};')",
+                    divNode.Location));
+            }
+        }
     }
 }

--- a/src/Core/Ignixa.Validation/Checks/TypeCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/TypeCheck.cs
@@ -203,7 +203,8 @@ public class TypeCheck : IValidationCheck
             "dateTime" => (settings.Depth == ValidationDepth.Full ? DateTimePatternStrict : DateTimePatternPermissive).IsMatch(text),
             "instant" => InstantPattern.IsMatch(text), // Requires timezone (Z or +/-HH:MM)
             "time" => TimePattern.IsMatch(text),
-            "uri" or "url" or "oid" or "uuid" or "code" or "markdown" or "base64Binary" => true, // Permissive for general URIs
+            "uri" or "url" or "oid" or "uuid" or "code" or "markdown" => true, // Permissive for general URIs
+            "base64Binary" => FhirPrimitiveValidator.TryDecodeBase64(text, out _),
             "canonical" => Uri.TryCreate(text, UriKind.RelativeOrAbsolute, out _),
             _ => true // Unknown types pass
         };

--- a/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
+++ b/src/Core/Ignixa.Validation/Schema/StructureDefinitionSchemaBuilder.cs
@@ -86,6 +86,19 @@ public class StructureDefinitionSchemaBuilder
             universalChecks.Add(new NarrativeCheck());
         }
 
+        // Bundle-specific structural checks: closed-world rules with no terminology dependency.
+        if (typeDefinition.Info.Name == "Bundle")
+        {
+            universalChecks.Add(new BundleFullUrlCheck());
+            universalChecks.Add(new BundleLinkRelationCheck());
+        }
+
+        // Attachment.size, when stated, must match the decoded Attachment.data length.
+        if (typeDefinition.Info.Name == "Attachment")
+        {
+            universalChecks.Add(new AttachmentSizeCheck());
+        }
+
         // Extract cardinality checks (moved to Fast tier for Microsoft FHIR Server alignment)
         // Cardinality checks enforce both minimum (required fields have min=1) and maximum cardinality
         // This eliminates the need for a separate RequiredFieldCheck
@@ -157,6 +170,15 @@ public class StructureDefinitionSchemaBuilder
                     typeName);
             });
         specChecks.AddRange(shapeChecks);
+
+        // Empty-array rejection (ele-1) at resource altitude: closes the gap StructuralShapeCheck
+        // leaves for complex datatypes (CodeableConcept, Coding, ...) that never get their own nested
+        // schema, so an empty array nested inside one (e.g. category[0].coding: []) would otherwise
+        // go unchecked. Runs once per resource via a single raw-JSON walk; see EmptyArrayCheck remarks.
+        if (typeDefinition.Info.IsResource)
+        {
+            specChecks.Add(new EmptyArrayCheck());
+        }
 
         // Extract reference format checks - check the type name, not element name
         // Skip choice elements: their DefaultTypeName may be Reference but the actual type

--- a/test/Ignixa.Validation.Tests/Checks/AttachmentSizeCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/AttachmentSizeCheckTests.cs
@@ -1,0 +1,91 @@
+// <copyright file="AttachmentSizeCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Checks;
+
+/// <summary>
+/// Tests for AttachmentSizeCheck.
+/// </summary>
+public class AttachmentSizeCheckTests
+{
+    private static ValidationResult ValidateAttachment(string attachmentJson)
+    {
+        var json = JsonNode.Parse($"{{\"resourceType\":\"Media\",\"content\":{attachmentJson}}}");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var attachmentElement = element.Children("content")[0];
+        var check = new AttachmentSizeCheck();
+
+        return check.Validate(attachmentElement, new ValidationSettings(), new ValidationState());
+    }
+
+    [Fact]
+    public void GivenSizeMatchingDecodedDataLength_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - "help i'm a bug" is 14 bytes
+        var result = ValidateAttachment(
+            "{\"contentType\":\"application/octet-stream\",\"data\":\"aGVscCBpJ20gYSBidWc=\",\"size\":14}");
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenSizeNotMatchingDecodedDataLength_WhenValidating_ThenReturnsError()
+    {
+        // Arrange - "help i'm a bug" is 14 bytes, stated size is 100
+        var result = ValidateAttachment(
+            "{\"contentType\":\"application/octet-stream\",\"data\":\"aGVscCBpJ20gYSBidWc=\",\"size\":100}");
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Message.Contains("does not match actual attachment size", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenNoSize_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var result = ValidateAttachment(
+            "{\"contentType\":\"application/octet-stream\",\"data\":\"aGVscCBpJ20gYSBidWc=\"}");
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenSizeButNoData_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - nothing to cross-check against; cardinality/other checks handle a missing url/data
+        var result = ValidateAttachment("{\"contentType\":\"application/octet-stream\",\"size\":14}");
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenSizeWithMalformedData_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - malformed base64 is reported by TypeCheck; this check must not pile on a
+        // misleading size-mismatch message for content that's already invalid.
+        var result = ValidateAttachment(
+            "{\"contentType\":\"application/octet-stream\",\"data\":\"%%%2@()()\",\"size\":14}");
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+}

--- a/test/Ignixa.Validation.Tests/Checks/BundleFullUrlCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/BundleFullUrlCheckTests.cs
@@ -1,0 +1,110 @@
+// <copyright file="BundleFullUrlCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Checks;
+
+/// <summary>
+/// Tests for BundleFullUrlCheck.
+/// </summary>
+public class BundleFullUrlCheckTests
+{
+    private static ValidationResult Validate(string json, ValidationDepth depth = ValidationDepth.Full)
+    {
+        var node = JsonNode.Parse(json);
+        var sourceNode = JsonNodeSourceNode.Create(node);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var check = new BundleFullUrlCheck();
+
+        return check.Validate(element, new ValidationSettings { Depth = depth }, new ValidationState());
+    }
+
+    [Fact]
+    public void GivenRelativeFullUrl_WhenValidating_ThenReturnsError()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [
+                { "fullUrl": "Patient/1", "resource": { "resourceType": "Patient", "id": "1" } }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Message.Contains("must be an absolute URL", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenAbsoluteFullUrl_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [
+                { "fullUrl": "urn:uuid:212c57ad-45cd-4882-87e7-8415ded3db05", "resource": { "resourceType": "Patient", "id": "1" } }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenNoFullUrl_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - fullUrl-required is a separate, context-dependent rule this check does not enforce
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "transaction",
+            "entry": [
+                { "resource": { "resourceType": "Patient", "id": "1" }, "request": { "method": "PUT", "url": "Patient/1" } }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenRelativeFullUrl_WhenValidatingInCompatibilityMode_ThenReturnsSuccess()
+    {
+        // Arrange - matches CodingStructureCheck's precedent of tolerating relative URIs in
+        // Compatibility mode (Microsoft FHIR Server alignment).
+        var result = Validate(
+            """
+            {
+                "resourceType": "Bundle",
+                "type": "collection",
+                "entry": [
+                    { "fullUrl": "Patient/1", "resource": { "resourceType": "Patient", "id": "1" } }
+                ]
+            }
+            """,
+            ValidationDepth.Compatibility);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+}

--- a/test/Ignixa.Validation.Tests/Checks/BundleLinkRelationCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/BundleLinkRelationCheckTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="BundleLinkRelationCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Checks;
+
+/// <summary>
+/// Tests for BundleLinkRelationCheck.
+/// </summary>
+public class BundleLinkRelationCheckTests
+{
+    private static ValidationResult Validate(string json)
+    {
+        var node = JsonNode.Parse(json);
+        var sourceNode = JsonNodeSourceNode.Create(node);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var check = new BundleLinkRelationCheck();
+
+        return check.Validate(element, new ValidationSettings(), new ValidationState());
+    }
+
+    [Fact]
+    public void GivenDuplicateSelfRelation_WhenValidating_ThenReturnsError()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "link": [
+                { "url": "base/Patient?name=test", "relation": "self" },
+                { "url": "base/Patient?name=test", "relation": "self" }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Message.Contains("'self' can only occur once", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenDuplicateNonSelfRelation_WhenValidating_ThenReturnsError()
+    {
+        // Arrange - the underlying rule is general: no relation type may repeat, not just "self".
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "link": [
+                { "url": "base/Patient?name=test", "relation": "first" },
+                { "url": "base/Patient?name=test", "relation": "first" }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Message.Contains("'first' can only occur once", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenDistinctRelations_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "link": [
+                { "url": "base/Patient?name=test", "relation": "self" },
+                { "url": "base/Patient?name=test&page=2", "relation": "next" }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenNoLinks_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Bundle",
+            "type": "collection"
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+}

--- a/test/Ignixa.Validation.Tests/Checks/EmptyArrayCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/EmptyArrayCheckTests.cs
@@ -1,0 +1,99 @@
+// <copyright file="EmptyArrayCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Validation;
+using Ignixa.Validation.Checks;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Checks;
+
+/// <summary>
+/// Tests for EmptyArrayCheck.
+/// </summary>
+public class EmptyArrayCheckTests
+{
+    private static ValidationResult Validate(string json)
+    {
+        var node = JsonNode.Parse(json);
+        var sourceNode = JsonNodeSourceNode.Create(node);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var check = new EmptyArrayCheck();
+
+        return check.Validate(element, new ValidationSettings(), new ValidationState());
+    }
+
+    [Fact]
+    public void GivenEmptyArrayNestedInsideCodeableConcept_WhenValidating_ThenReturnsError()
+    {
+        // Arrange - CodeableConcept is never expanded into its own nested schema, so this gap is
+        // only caught by a raw-JSON walk from the resource root.
+        var result = Validate("""
+        {
+            "resourceType": "DocumentReference",
+            "status": "current",
+            "category": [{ "coding": [] }],
+            "content": [
+                { "attachment": { "contentType": "text/plain", "data": "Zm9v" } }
+            ]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Path == "DocumentReference.category[0].coding");
+    }
+
+    [Fact]
+    public void GivenNoEmptyArrays_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Patient",
+            "name": [{ "family": "Smith", "given": ["Jane"] }]
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenEmptyContainedArray_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - "contained" is excluded: established behavior tolerates an empty array here.
+        var result = Validate("""
+        {
+            "resourceType": "Patient",
+            "contained": []
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenEmptyTopLevelArray_WhenValidating_ThenReturnsError()
+    {
+        // Arrange
+        var result = Validate("""
+        {
+            "resourceType": "Patient",
+            "name": []
+        }
+        """);
+
+        // Act / Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Path == "Patient.name");
+    }
+}

--- a/test/Ignixa.Validation.Tests/Checks/FhirPrimitiveValidatorConformanceTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/FhirPrimitiveValidatorConformanceTests.cs
@@ -356,4 +356,28 @@ public class FhirPrimitiveValidatorConformanceTests
         result.IsValid.ShouldBeFalse("Expected invalid dateTime (2000-13) even with shadow but validation passed");
         result.Issues.ShouldContain(i => i.Code == "type-1");
     }
+
+    // -------------------------------------------------------------------------
+    // valueBase64Binary
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("\"aGVscCBpJ20gYSBidWc=\"")] // "help i'm a bug"
+    [InlineData("\"Zm9v\"")] // "foo"
+    public void GivenValidBase64Binary_WhenValidating_ThenReturnsSuccess(string jsonValue)
+    {
+        var result = ValidatePrimitive("valueBase64Binary", jsonValue, new[] { "base64Binary" });
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("\"...\"")]
+    [InlineData("\"%%%2@()()\"")]
+    [InlineData("\"abc\"")] // length not a multiple of 4
+    public void GivenInvalidBase64Binary_WhenValidating_ThenReturnsError(string jsonValue)
+    {
+        var result = ValidatePrimitive("valueBase64Binary", jsonValue, new[] { "base64Binary" });
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Code == "type-1");
+    }
 }

--- a/test/Ignixa.Validation.Tests/Checks/NarrativeCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/NarrativeCheckTests.cs
@@ -252,4 +252,110 @@ public class NarrativeCheckTests
         Assert.Single(result.Issues);
         Assert.Contains(result.Issues, i => i.Code == "txt-1" && i.Path.Contains(".div", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void GivenNarrativeDivWithScriptElement_WhenValidating_ThenReturnsError()
+    {
+        // Arrange
+        var json = JsonNode.Parse("""
+        {
+          "resourceType": "Patient",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">some text   <script>somescript</script>   </div>"
+          }
+        }
+        """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var check = new NarrativeCheck();
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.Message.Contains("Invalid element name in the XHTML ('script')", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenNarrativeDivWithInvalidNamedEntity_WhenValidating_ThenReturnsError()
+    {
+        // Arrange
+        var json = JsonNode.Parse("""
+        {
+          "resourceType": "Encounter",
+          "status": "finished",
+          "class": { "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB" },
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Current Procedural Terminology (CPT&reg;)</div>"
+          }
+        }
+        """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var check = new NarrativeCheck();
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.Message.Contains("Invalid entity in the XHTML ('&reg;')", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GivenNarrativeDivWithOnlyPredefinedXmlEntities_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var json = JsonNode.Parse("""
+        {
+          "resourceType": "Patient",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A &amp; B &lt;tag&gt; &quot;quoted&quot; &apos;text&apos;</div>"
+          }
+        }
+        """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var check = new NarrativeCheck();
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void GivenNarrativeDivWithBasicFormattingElements_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var json = JsonNode.Parse("""
+        {
+          "resourceType": "Patient",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Name</b>: <a href=\"Patient-example.html\">Jane</a></p></div>"
+          }
+        }
+        """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var check = new NarrativeCheck();
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Issues);
+    }
 }

--- a/test/Ignixa.Validation.Tests/Checks/TypeCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/TypeCheckTests.cs
@@ -937,4 +937,46 @@ public class TypeCheckTests
         result.IsValid.ShouldBeTrue();
         result.Issues.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void GivenValidBase64BinaryData_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange
+        var json = JsonNode.Parse(
+            "{\"resourceType\":\"Media\",\"content\":{\"contentType\":\"application/octet-stream\",\"data\":\"aGVscCBpJ20gYSBidWc=\"}}");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var contentElement = element.Children("content")[0];
+        var check = new TypeCheck("data", "base64Binary");
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(contentElement, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+        result.Issues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenInvalidBase64BinaryData_WhenValidating_ThenReturnsError()
+    {
+        // Arrange - regression for https://github.com/hapifhir/org.hl7.fhir.core/issues/1248
+        var json = JsonNode.Parse(
+            "{\"resourceType\":\"Media\",\"content\":{\"contentType\":\"application/octet-stream\",\"data\":\"%%%2@()()\"}}");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+        var contentElement = element.Children("content")[0];
+        var check = new TypeCheck("data", "base64Binary");
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(contentElement, settings, state);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Issues.ShouldContain(i => i.Code == "type-1");
+    }
 }


### PR DESCRIPTION
## Structural micro-rules sprint

Fable's #1 lever: deterministic, closed-world structural checks — the safe, fast under-strict points with **zero over-strict risk** (no oracle disagreement possible).

### Result
| | Over-strict | Under-strict | Pass rate |
|---|---|---|---|
| Before (T1 tip) | 10 | 56 | 64.7% |
| This PR | **10 (gate held)** | **45** | **70.6%** |

11 cases closed net, **over-strict unchanged at 10** — a hard zero-new-over-strict gate was enforced after every check.

### Checks added (`Ignixa.Validation/Checks/`)
- **base64Binary validity** (`FhirPrimitiveValidator` + `TypeCheck`) — closes `attachment-with-invalid-binary`.
- **`AttachmentSizeCheck`** — stated `Attachment.size` vs decoded `data` length; skips if data already malformed (no double error).
- **`EmptyArrayCheck`** — empty JSON arrays are invalid; single root walk, excludes `contained`. Closes `empty-array` + 2 bonus.
- **`BundleFullUrlCheck`** — `entry.fullUrl` present-implies-absolute; Compatibility-exempt. Closes `bundle-duplicate-id` + 2 bonus.
- **`BundleLinkRelationCheck`** — a `link` relation can't repeat (generalized beyond `self`, confirmed against the reference outcome). Closes `bundle-id-2`.
- **`NarrativeCheck` extended** — scripting/framing deny-list + named-XML-entity validation. Closes `pat-security-bad-xhtml`, `xml-bad-entities-json`.

### Deliberately skipped (with evidence)
`bad-markdown-no-html`, `pat-security-bad-string`, `dr-example-org` — each has a **byte-identical paired case expecting valid**, because the rule is mode-gated (`security-checks` / `noHtmlInMarkdown` / `examples`) and our harness has no such toggle. Implementing unconditionally would flip the paired case to over-strict — exactly the trap to avoid. Deferred until the harness models validation modes.

Also noted out-of-scope: `attachment-tx` stays under-strict due to a broader gap — `ChoiceElementCheck` never recurses into nested schemas for complex choice-element variants (`value.ofType(Attachment)`). Separate follow-up.

Full suite: **595 passed, 0 failed**. CLI + Application handler tests spot-checked green. Compatibility depth semantics unchanged; no `Hl7.Fhir.*` in Core.

Stacked on #310 (terminology T1); will retarget to main when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
