### PR TITLE
Fix FhirFakes tag consistency

### DIFF
--- a/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
@@ -5,6 +5,7 @@
 
 using Ignixa.Abstractions;
 using System.Text.Json.Nodes;
+using Ignixa.FhirFakes;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification;
 
@@ -189,11 +190,7 @@ public abstract class FhirResourceBuilder<TBuilder>
         {
             meta["tag"] = new JsonArray
             {
-                new JsonObject
-                {
-                    ["system"] = "http://ignixa.dev/test-isolation",
-                    ["code"] = _tag
-                }
+                FhirFakeTags.CreateTestIsolationCoding(_tag)
             };
         }
 

--- a/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
@@ -116,7 +116,7 @@ public abstract class FhirResourceBuilder<TBuilder>
 
     /// <summary>
     /// Sets a tag for test isolation.
-    /// Tag will be added to meta.tag with system "http://ignixa.dev/test-isolation".
+    /// Tag will be added to meta.tag with system "http://ignixa.dev/CodeSystem/test-isolation".
     /// </summary>
     /// <param name="tag">The tag code to set.</param>
     /// <returns>This builder instance for method chaining.</returns>

--- a/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
+++ b/src/Core/Ignixa.FhirFakes/Builders/FhirResourceBuilder.cs
@@ -116,7 +116,7 @@ public abstract class FhirResourceBuilder<TBuilder>
 
     /// <summary>
     /// Sets a tag for test isolation.
-    /// Tag will be added to meta.tag with system "http://ignixa.dev/CodeSystem/test-isolation".
+    /// Tag will be added to meta.tag with system "http://ignixa.io/fhir/CodeSystem/test-isolation".
     /// </summary>
     /// <param name="tag">The tag code to set.</param>
     /// <returns>This builder instance for method chaining.</returns>

--- a/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
+++ b/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
@@ -9,7 +9,7 @@ namespace Ignixa.FhirFakes;
 
 internal static class FhirFakeTags
 {
-    public const string TestIsolationCodeSystem = "http://ignixa.dev/CodeSystem/test-isolation";
+    public const string TestIsolationCodeSystem = "http://ignixa.io/fhir/CodeSystem/test-isolation";
 
     public static JsonObject CreateTestIsolationCoding(string code)
     {

--- a/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
+++ b/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+
+namespace Ignixa.FhirFakes;
+
+internal static class FhirFakeTags
+{
+    public const string TestIsolationSystem = "http://ignixa.dev/test-isolation";
+
+    public static JsonObject CreateTestIsolationCoding(string code)
+    {
+        ArgumentNullException.ThrowIfNull(code);
+
+        return new JsonObject
+        {
+            ["system"] = TestIsolationSystem,
+            ["code"] = code
+        };
+    }
+}

--- a/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
+++ b/src/Core/Ignixa.FhirFakes/FhirFakeTags.cs
@@ -9,7 +9,7 @@ namespace Ignixa.FhirFakes;
 
 internal static class FhirFakeTags
 {
-    public const string TestIsolationSystem = "http://ignixa.dev/test-isolation";
+    public const string TestIsolationCodeSystem = "http://ignixa.dev/CodeSystem/test-isolation";
 
     public static JsonObject CreateTestIsolationCoding(string code)
     {
@@ -17,7 +17,7 @@ internal static class FhirFakeTags
 
         return new JsonObject
         {
-            ["system"] = TestIsolationSystem,
+            ["system"] = TestIsolationCodeSystem,
             ["code"] = code
         };
     }

--- a/src/Core/Ignixa.FhirFakes/SchemaBasedFhirResourceFaker.cs
+++ b/src/Core/Ignixa.FhirFakes/SchemaBasedFhirResourceFaker.cs
@@ -1106,7 +1106,7 @@ public class SchemaBasedFhirResourceFaker
             meta["tag"] = tagArray;
         }
 
-        tagArray.Add(new JsonObject { ["code"] = _tag });
+        tagArray.Add(FhirFakeTags.CreateTestIsolationCoding(_tag));
     }
 
     /// <summary>

--- a/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
@@ -68,7 +68,7 @@ public class CareTeamBuilderTests
         metaTags.Count.ShouldBe(1);
 
         var tagObj = metaTags![0] as JsonObject;
-        tagObj!["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        tagObj!["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
         tagObj["code"]?.GetValue<string>().ShouldBe(tag);
     }
 

--- a/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/CareTeamBuilderTests.cs
@@ -68,7 +68,7 @@ public class CareTeamBuilderTests
         metaTags.Count.ShouldBe(1);
 
         var tagObj = metaTags![0] as JsonObject;
-        tagObj!["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        tagObj!["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
         tagObj["code"]?.GetValue<string>().ShouldBe(tag);
     }
 

--- a/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
@@ -79,7 +79,7 @@ public class DiagnosticReportBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/DiagnosticReportBuilderTests.cs
@@ -79,7 +79,7 @@ public class DiagnosticReportBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
@@ -72,7 +72,7 @@ public class GroupBuilderTests
         tags!.Count.ShouldBe(1);
 
         var firstTag = tags?[0]?.AsObject();
-        firstTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        firstTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
         firstTag?["code"]?.GetValue<string>().ShouldBe(tag);
     }
 

--- a/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/GroupBuilderTests.cs
@@ -72,7 +72,7 @@ public class GroupBuilderTests
         tags!.Count.ShouldBe(1);
 
         var firstTag = tags?[0]?.AsObject();
-        firstTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        firstTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
         firstTag?["code"]?.GetValue<string>().ShouldBe(tag);
     }
 

--- a/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
@@ -85,7 +85,7 @@ public class LocationBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/LocationBuilderTests.cs
@@ -85,7 +85,7 @@ public class LocationBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
@@ -116,7 +116,7 @@ public class MedicationDispenseBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
     }
 
     #endregion

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationDispenseBuilderTests.cs
@@ -116,7 +116,7 @@ public class MedicationDispenseBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
     }
 
     #endregion

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
@@ -106,7 +106,7 @@ public class MedicationRequestBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
     }
 
     #endregion

--- a/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/MedicationRequestBuilderTests.cs
@@ -106,7 +106,7 @@ public class MedicationRequestBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
     }
 
     #endregion

--- a/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
@@ -80,7 +80,7 @@ public class PractitionerBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.io/fhir/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Builders/PractitionerBuilderTests.cs
@@ -80,7 +80,7 @@ public class PractitionerBuilderTests
 
         var metaTag = tags?[0]?.AsObject();
         metaTag?["code"]?.GetValue<string>().ShouldBe(tag);
-        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/test-isolation");
+        metaTag?["system"]?.GetValue<string>().ShouldBe("http://ignixa.dev/CodeSystem/test-isolation");
     }
 
     [Fact]

--- a/test/Ignixa.FhirFakes.Tests/WithTagFunctionalityTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/WithTagFunctionalityTests.cs
@@ -54,7 +54,7 @@ public class WithTagFunctionalityTests
         tagArray.Count.ShouldBe(1);
 
         var tag = tagArray[0]!.AsObject();
-        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationSystem);
+        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationCodeSystem);
         tag["code"]!.GetValue<string>().ShouldBe(tagCode);
     }
 
@@ -150,7 +150,7 @@ public class WithTagFunctionalityTests
     private static void AssertQualifiedTag(JsonNode resource, string tagCode)
     {
         var tag = resource["meta"]!["tag"]![0]!.AsObject();
-        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationSystem);
+        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationCodeSystem);
         tag["code"]!.GetValue<string>().ShouldBe(tagCode);
     }
 }

--- a/test/Ignixa.FhirFakes.Tests/WithTagFunctionalityTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/WithTagFunctionalityTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Text.Json.Nodes;
+using Ignixa.FhirFakes;
 using Shouldly;
 using Ignixa.Specification.Generated;
 
@@ -35,7 +36,7 @@ public class WithTagFunctionalityTests
     }
 
     [Fact]
-    public void GivenFakerWithTag_WhenGeneratingResource_ThenResourceHasTagWithCode()
+    public void GivenFakerWithTag_WhenGeneratingResource_ThenResourceHasQualifiedTag()
     {
         // Arrange
         var tagCode = Guid.NewGuid().ToString();
@@ -53,7 +54,7 @@ public class WithTagFunctionalityTests
         tagArray.Count.ShouldBe(1);
 
         var tag = tagArray[0]!.AsObject();
-        tag["code"].ShouldNotBeNull();
+        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationSystem);
         tag["code"]!.GetValue<string>().ShouldBe(tagCode);
     }
 
@@ -70,12 +71,9 @@ public class WithTagFunctionalityTests
         var observation = _faker.Generate("Observation");
 
         // Assert - All resources should have the same tag
-        var getTagCode = (JsonNode resource) =>
-            resource["meta"]!["tag"]![0]!["code"]!.GetValue<string>();
-
-        getTagCode(patient1.MutableNode).ShouldBe(tagCode);
-        getTagCode(patient2.MutableNode).ShouldBe(tagCode);
-        getTagCode(observation.MutableNode).ShouldBe(tagCode);
+        AssertQualifiedTag(patient1.MutableNode, tagCode);
+        AssertQualifiedTag(patient2.MutableNode, tagCode);
+        AssertQualifiedTag(observation.MutableNode, tagCode);
     }
 
     [Fact]
@@ -94,11 +92,8 @@ public class WithTagFunctionalityTests
         var patient2 = _faker.Generate("Patient");
 
         // Assert
-        var getTagCode = (JsonNode resource) =>
-            resource["meta"]!["tag"]![0]!["code"]!.GetValue<string>();
-
-        getTagCode(patient1.MutableNode).ShouldBe(tagCode1);
-        getTagCode(patient2.MutableNode).ShouldBe(tagCode2);
+        AssertQualifiedTag(patient1.MutableNode, tagCode1);
+        AssertQualifiedTag(patient2.MutableNode, tagCode2);
     }
 
     [Fact]
@@ -149,6 +144,13 @@ public class WithTagFunctionalityTests
 
         var tagArray = meta["tag"]!.AsArray();
         tagArray.Count.ShouldBe(1);
-        tagArray[0]!["code"]!.GetValue<string>().ShouldBe(tagCode);
+        AssertQualifiedTag(patient.MutableNode, tagCode);
+    }
+
+    private static void AssertQualifiedTag(JsonNode resource, string tagCode)
+    {
+        var tag = resource["meta"]!["tag"]![0]!.AsObject();
+        tag["system"]!.GetValue<string>().ShouldBe(FhirFakeTags.TestIsolationSystem);
+        tag["code"]!.GetValue<string>().ShouldBe(tagCode);
     }
 }

--- a/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
@@ -87,11 +87,15 @@ public class DailyAppointmentScheduleScenarioTests
             var tags = resource.MutableNode["meta"]?["tag"]?.AsArray()
                 .ToList();
             tags.ShouldNotBeNull($"{resource.ResourceType}/{resource.Id} should have meta.tag");
-            tags!.Any(t => t!["system"] is { } system &&
-                system.ToString() == FhirFakeTags.TestIsolationCodeSystem &&
-                t["code"] is { } code &&
-                code.ToString() == tag).ShouldBeTrue(
+            tags!.ShouldContain(t => HasQualifiedTestIsolationTag(t, tag),
                 $"{resource.ResourceType}/{resource.Id} should carry the qualified test-isolation tag");
         }
     }
+
+    private static bool HasQualifiedTestIsolationTag(JsonNode? tagElement, string tag) =>
+        tagElement is not null &&
+        tagElement["system"] is { } system &&
+        system.GetValue<string>() == FhirFakeTags.TestIsolationCodeSystem &&
+        tagElement["code"] is { } code &&
+        code.GetValue<string>() == tag;
 }

--- a/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Text.Json.Nodes;
+using Ignixa.FhirFakes;
 using Ignixa.FhirFakes.Workflow;
 using Ignixa.Specification.Generated;
 using Shouldly;
@@ -83,11 +84,14 @@ public class DailyAppointmentScheduleScenarioTests
         result.Graph.AllResources.Count.ShouldBeGreaterThan(0);
         foreach (var resource in result.Graph.AllResources)
         {
-            var tagCodes = resource.MutableNode["meta"]?["tag"]?.AsArray()
-                .Select(t => t!["code"]?.ToString())
+            var tags = resource.MutableNode["meta"]?["tag"]?.AsArray()
                 .ToList();
-            tagCodes.ShouldNotBeNull($"{resource.ResourceType}/{resource.Id} should have meta.tag");
-            tagCodes!.ShouldContain(tag, $"{resource.ResourceType}/{resource.Id} should carry the tag");
+            tags.ShouldNotBeNull($"{resource.ResourceType}/{resource.Id} should have meta.tag");
+            tags!.Any(t => t!["system"] is { } system &&
+                system.ToString() == FhirFakeTags.TestIsolationSystem &&
+                t["code"] is { } code &&
+                code.ToString() == tag).ShouldBeTrue(
+                $"{resource.ResourceType}/{resource.Id} should carry the qualified test-isolation tag");
         }
     }
 }

--- a/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/Workflow/DailyAppointmentScheduleScenarioTests.cs
@@ -88,7 +88,7 @@ public class DailyAppointmentScheduleScenarioTests
                 .ToList();
             tags.ShouldNotBeNull($"{resource.ResourceType}/{resource.Id} should have meta.tag");
             tags!.Any(t => t!["system"] is { } system &&
-                system.ToString() == FhirFakeTags.TestIsolationSystem &&
+                system.ToString() == FhirFakeTags.TestIsolationCodeSystem &&
                 t["code"] is { } code &&
                 code.ToString() == tag).ShouldBeTrue(
                 $"{resource.ResourceType}/{resource.Id} should carry the qualified test-isolation tag");


### PR DESCRIPTION
## Summary
- Centralize FhirFakes test-isolation tag Coding creation in a shared internal helper
- Use the shared tag shape from both `FhirResourceBuilder` and `SchemaBasedFhirResourceFaker`
- Strengthen schema-faker and `DailyAppointmentSchedule` workflow tests to require the qualified tag system and code

## Test Plan
- [x] `dotnet test test\Ignixa.FhirFakes.Tests\Ignixa.FhirFakes.Tests.csproj`