### PR TITLE
Promote slicing rules to enum

### DIFF
--- a/codegen/Ignixa.Specification.Generators/CSharpCoreSchemaLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpCoreSchemaLanguage.cs
@@ -611,12 +611,13 @@ public sealed class CSharpCoreSchemaLanguage : ILanguage
                 .ToArray() ?? Array.Empty<string>();
 
             string rules = element.Slicing.Rules?.ToString() ?? "Open";
+            string rulesValue = $"Ignixa.Abstractions.SlicingRules.{rules}";
             bool ordered = element.Slicing.Ordered ?? false;
 
             if (discriminators.Length > 0)
             {
                 string discriminatorArray = $"new Ignixa.Abstractions.DiscriminatorDefinition[] {{ {string.Join(", ", discriminators)} }}";
-                slicing = $"new Ignixa.Abstractions.SlicingMetadata({discriminatorArray}, \"{rules}\", {(ordered ? "true" : "false")})";
+                slicing = $"new Ignixa.Abstractions.SlicingMetadata({discriminatorArray}, {rulesValue}, {(ordered ? "true" : "false")})";
             }
         }
 

--- a/codegen/Ignixa.Specification.Generators/CSharpStructureProviderLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpStructureProviderLanguage.cs
@@ -438,17 +438,17 @@ public sealed class CSharpStructureProviderLanguage : ILanguage
         {
             var discriminators = element.Slicing.Discriminator?
                 .Where(d => d.Type != null && !string.IsNullOrEmpty(d.Path))
-                .Select(d => $"new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.{d.Type}, \"{EscapeString(d.Path)}\")")
+                .Select(d => $"{d.Type}:{d.Path}")
                 .ToArray() ?? Array.Empty<string>();
 
             string rules = element.Slicing.Rules?.ToString() ?? "Open";
-            string rulesValue = $"SlicingRules.{rules}";
+            string rulesValue = $"Ignixa.Abstractions.SlicingRules.{rules}";
             bool ordered = element.Slicing.Ordered ?? false;
 
             if (discriminators.Length > 0)
             {
-                string discriminatorArray = $"new Ignixa.Abstractions.DiscriminatorDefinition[] {{ {string.Join(", ", discriminators)} }}";
-                slicing = $"new SlicingMetadata({discriminatorArray}, {rulesValue}, {(ordered ? "true" : "false")})";
+                string discriminatorArray = $"new[] {{ {string.Join(", ", discriminators.Select(d => $"\"{EscapeString(d)}\""))} }}";
+                slicing = $"new Ignixa.Specification.SlicingMetadata({discriminatorArray}, {rulesValue}, {(ordered ? "true" : "false")})";
             }
         }
 

--- a/codegen/Ignixa.Specification.Generators/CSharpStructureProviderLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpStructureProviderLanguage.cs
@@ -442,12 +442,13 @@ public sealed class CSharpStructureProviderLanguage : ILanguage
                 .ToArray() ?? Array.Empty<string>();
 
             string rules = element.Slicing.Rules?.ToString() ?? "Open";
+            string rulesValue = $"SlicingRules.{rules}";
             bool ordered = element.Slicing.Ordered ?? false;
 
             if (discriminators.Length > 0)
             {
                 string discriminatorArray = $"new Ignixa.Abstractions.DiscriminatorDefinition[] {{ {string.Join(", ", discriminators)} }}";
-                slicing = $"new SlicingMetadata({discriminatorArray}, \"{rules}\", {(ordered ? "true" : "false")})";
+                slicing = $"new SlicingMetadata({discriminatorArray}, {rulesValue}, {(ordered ? "true" : "false")})";
             }
         }
 

--- a/src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs
+++ b/src/Core/Ignixa.Abstractions/Structure/SlicingMetadata.cs
@@ -22,7 +22,7 @@ public sealed class SlicingMetadata
     /// <param name="slices">Named slices carried by a profile; empty for a bare slicing header.</param>
     public SlicingMetadata(
         IReadOnlyList<DiscriminatorDefinition> discriminators,
-        string rules,
+        SlicingRules rules,
         bool ordered,
         IReadOnlyList<SliceDefinition>? slices = null)
     {
@@ -36,7 +36,7 @@ public sealed class SlicingMetadata
     public IReadOnlyList<DiscriminatorDefinition> Discriminators { get; }
 
     /// <summary>Gets the slicing rules: <c>Open</c>, <c>Closed</c>, or <c>OpenAtEnd</c>.</summary>
-    public string Rules { get; }
+    public SlicingRules Rules { get; }
 
     /// <summary>Gets a value indicating whether slices must appear in order.</summary>
     public bool Ordered { get; }

--- a/src/Core/Ignixa.Abstractions/Structure/SlicingRules.cs
+++ b/src/Core/Ignixa.Abstractions/Structure/SlicingRules.cs
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.Abstractions;
+
+/// <summary>
+/// Rules that define whether unsliced content is allowed in a sliced FHIR element.
+/// </summary>
+public enum SlicingRules
+{
+    /// <summary>Additional content is allowed anywhere in the sliced element.</summary>
+    Open,
+
+    /// <summary>Additional content that does not match a slice is not allowed.</summary>
+    Closed,
+
+    /// <summary>Additional content is allowed only after all matched slices.</summary>
+    OpenAtEnd,
+}

--- a/src/Core/Ignixa.PackageManagement/Infrastructure/StructureDefinitionTypeAdapter.cs
+++ b/src/Core/Ignixa.PackageManagement/Infrastructure/StructureDefinitionTypeAdapter.cs
@@ -257,11 +257,11 @@ public sealed class StructureDefinitionTypeAdapter
         _ => DiscriminatorType.Value,
     };
 
-    private static SlicingRules ParseSlicingRules(string? rules) => rules switch
+    private static SlicingRules ParseSlicingRules(string? rules) => rules?.ToUpperInvariant() switch
     {
-        null or "" or "open" or "Open" => SlicingRules.Open,
-        "closed" or "Closed" => SlicingRules.Closed,
-        "openAtEnd" or "OpenAtEnd" or "open-at-end" => SlicingRules.OpenAtEnd,
+        null or "" or "OPEN" => SlicingRules.Open,
+        "CLOSED" => SlicingRules.Closed,
+        "OPENATEND" or "OPEN-AT-END" => SlicingRules.OpenAtEnd,
         _ => throw new InvalidOperationException($"Unsupported slicing rules value '{rules}'."),
     };
 

--- a/src/Core/Ignixa.PackageManagement/Infrastructure/StructureDefinitionTypeAdapter.cs
+++ b/src/Core/Ignixa.PackageManagement/Infrastructure/StructureDefinitionTypeAdapter.cs
@@ -219,7 +219,7 @@ public sealed class StructureDefinitionTypeAdapter
         }
 
         var discriminators = ExtractDiscriminators(slicing);
-        var rules = ReadString(slicing, "rules") ?? "open";
+        var rules = ParseSlicingRules(ReadString(slicing, "rules"));
         var ordered = ReadBool(slicing, "ordered") ?? false;
         var slices = ExtractSlices(elements, headerIndex, headerPath, discriminators);
 
@@ -255,6 +255,14 @@ public sealed class StructureDefinitionTypeAdapter
         "type" => DiscriminatorType.Type,
         "profile" => DiscriminatorType.Profile,
         _ => DiscriminatorType.Value,
+    };
+
+    private static SlicingRules ParseSlicingRules(string? rules) => rules switch
+    {
+        null or "" or "open" or "Open" => SlicingRules.Open,
+        "closed" or "Closed" => SlicingRules.Closed,
+        "openAtEnd" or "OpenAtEnd" or "open-at-end" => SlicingRules.OpenAtEnd,
+        _ => throw new InvalidOperationException($"Unsupported slicing rules value '{rules}'."),
     };
 
     /// <summary>

--- a/src/Core/Ignixa.Specification/Generated/R4BCoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R4BCoreSchemaProvider.g.cs
@@ -18873,7 +18873,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -21264,7 +21264,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -22269,7 +22269,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "author",
@@ -23713,7 +23713,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "contentType",
@@ -25466,7 +25466,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -52008,7 +52008,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "coding",
@@ -52111,7 +52111,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "concept",
@@ -53888,7 +53888,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -61589,7 +61589,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -61692,7 +61692,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -66347,7 +66347,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -66474,7 +66474,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -70347,7 +70347,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -70594,7 +70594,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -70745,7 +70745,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -70872,7 +70872,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -70975,7 +70975,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -77956,7 +77956,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -79949,7 +79949,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -79973,7 +79973,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -80028,7 +80028,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -80419,7 +80419,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -80546,7 +80546,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -80721,7 +80721,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -80776,7 +80776,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -81671,7 +81671,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -81798,7 +81798,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "strength",
@@ -81925,7 +81925,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "key",
@@ -82148,7 +82148,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "label",
@@ -82251,7 +82251,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "identity",
@@ -82402,7 +82402,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "discriminator",
@@ -82553,7 +82553,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -82656,7 +82656,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -100970,7 +100970,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -101145,7 +101145,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "url",
@@ -106911,7 +106911,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -107213,7 +107213,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -121827,7 +121827,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -137782,7 +137782,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "versionId",
@@ -140444,7 +140444,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -141257,7 +141257,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "status",
@@ -150821,7 +150821,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -153922,7 +153922,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "start",
@@ -157191,7 +157191,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -160045,7 +160045,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -160388,7 +160388,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -161328,7 +161328,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -163863,7 +163863,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "low",
@@ -163966,7 +163966,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "numerator",
@@ -164069,7 +164069,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "lowNumerator",
@@ -164196,7 +164196,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "reference",
@@ -165081,7 +165081,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -172112,7 +172112,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "origin",
@@ -174667,7 +174667,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -197930,7 +197930,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -198081,7 +198081,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "bounds",
@@ -198496,7 +198496,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -198908,7 +198908,7 @@ public sealed partial class R4BCoreSchemaProvider : Ignixa.Abstractions.IFhirSch
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",

--- a/src/Core/Ignixa.Specification/Generated/R4CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R4CoreSchemaProvider.g.cs
@@ -18401,7 +18401,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -19677,7 +19677,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -20682,7 +20682,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "author",
@@ -22126,7 +22126,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "contentType",
@@ -23879,7 +23879,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -43621,7 +43621,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "coding",
@@ -45398,7 +45398,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -53099,7 +53099,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -53202,7 +53202,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -57857,7 +57857,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -57984,7 +57984,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -61857,7 +61857,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -62104,7 +62104,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -62255,7 +62255,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -62382,7 +62382,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -69411,7 +69411,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -71404,7 +71404,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -71428,7 +71428,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -71483,7 +71483,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -71874,7 +71874,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -72001,7 +72001,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -74193,7 +74193,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -74248,7 +74248,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -75143,7 +75143,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -75270,7 +75270,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "strength",
@@ -75397,7 +75397,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "key",
@@ -75620,7 +75620,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "label",
@@ -75723,7 +75723,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "identity",
@@ -75874,7 +75874,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "discriminator",
@@ -76025,7 +76025,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -76128,7 +76128,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -91272,7 +91272,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -91447,7 +91447,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "url",
@@ -97213,7 +97213,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -97515,7 +97515,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -110568,7 +110568,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -132389,7 +132389,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "versionId",
@@ -135051,7 +135051,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -135864,7 +135864,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "status",
@@ -143023,7 +143023,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -146124,7 +146124,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "start",
@@ -149393,7 +149393,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -152247,7 +152247,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -152590,7 +152590,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -153530,7 +153530,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -156065,7 +156065,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "low",
@@ -156168,7 +156168,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "numerator",
@@ -156271,7 +156271,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "reference",
@@ -156422,7 +156422,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -165271,7 +165271,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "origin",
@@ -167826,7 +167826,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -175723,7 +175723,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -175898,7 +175898,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "lowLimit",
@@ -194606,7 +194606,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -194757,7 +194757,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "bounds",
@@ -195172,7 +195172,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -195584,7 +195584,7 @@ public sealed partial class R4CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",

--- a/src/Core/Ignixa.Specification/Generated/R5CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R5CoreSchemaProvider.g.cs
@@ -24291,7 +24291,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -27317,7 +27317,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -28425,7 +28425,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "author",
@@ -31855,7 +31855,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "contentType",
@@ -33656,7 +33656,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "availableTime",
@@ -33759,7 +33759,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "daysOfWeek",
@@ -33910,7 +33910,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -34013,7 +34013,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -34092,7 +34092,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -61251,7 +61251,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "coding",
@@ -61354,7 +61354,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "concept",
@@ -63419,7 +63419,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -73720,7 +73720,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -73823,7 +73823,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -78430,7 +78430,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -78557,7 +78557,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -83051,7 +83051,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -83322,7 +83322,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83473,7 +83473,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83600,7 +83600,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83703,7 +83703,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83854,7 +83854,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -94715,7 +94715,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -96269,7 +96269,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -96293,7 +96293,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -96348,7 +96348,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -96763,7 +96763,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -96890,7 +96890,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -97065,7 +97065,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -97120,7 +97120,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -98063,7 +98063,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -98190,7 +98190,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "strength",
@@ -98341,7 +98341,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "purpose",
@@ -98540,7 +98540,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "key",
@@ -98763,7 +98763,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "label",
@@ -98866,7 +98866,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "identity",
@@ -99017,7 +99017,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "discriminator",
@@ -99168,7 +99168,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -99271,7 +99271,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -121135,7 +121135,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -121310,7 +121310,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "purpose",
@@ -121509,7 +121509,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "url",
@@ -129340,7 +129340,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -129642,7 +129642,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -147985,7 +147985,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -165041,7 +165041,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "versionId",
@@ -166300,7 +166300,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -166451,7 +166451,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -167720,7 +167720,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "status",
@@ -180220,7 +180220,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -183729,7 +183729,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "start",
@@ -190590,7 +190590,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -191818,7 +191818,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -192806,7 +192806,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -195437,7 +195437,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "low",
@@ -195540,7 +195540,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "numerator",
@@ -195643,7 +195643,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "lowNumerator",
@@ -195770,7 +195770,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "reference",
@@ -196679,7 +196679,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -204637,7 +204637,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "origin",
@@ -207765,7 +207765,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -240589,7 +240589,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -240740,7 +240740,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "bounds",
@@ -242527,7 +242527,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -242987,7 +242987,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -247416,7 +247416,7 @@ public sealed partial class R5CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "channelType",

--- a/src/Core/Ignixa.Specification/Generated/R6CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/R6CoreSchemaProvider.g.cs
@@ -24923,7 +24923,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -27561,7 +27561,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -28566,7 +28566,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "author",
@@ -31996,7 +31996,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "contentType",
@@ -33797,7 +33797,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "period",
@@ -33924,7 +33924,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "daysOfWeek",
@@ -34075,7 +34075,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -34178,7 +34178,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -34257,7 +34257,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -61464,7 +61464,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "coding",
@@ -61567,7 +61567,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "concept",
@@ -63632,7 +63632,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -73727,7 +73727,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -73830,7 +73830,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -78437,7 +78437,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -78564,7 +78564,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -83058,7 +83058,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -83329,7 +83329,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83480,7 +83480,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83607,7 +83607,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83710,7 +83710,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -83861,7 +83861,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -95559,7 +95559,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -97137,7 +97137,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -97161,7 +97161,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -97216,7 +97216,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -97631,7 +97631,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -97758,7 +97758,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -97933,7 +97933,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -97988,7 +97988,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -98931,7 +98931,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -99058,7 +99058,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "strength",
@@ -99209,7 +99209,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "purpose",
@@ -99408,7 +99408,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "key",
@@ -99631,7 +99631,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "label",
@@ -99734,7 +99734,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "identity",
@@ -99885,7 +99885,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "discriminator",
@@ -100036,7 +100036,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -100139,7 +100139,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -121207,7 +121207,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "description",
@@ -121382,7 +121382,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "purpose",
@@ -121581,7 +121581,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "url",
@@ -130211,7 +130211,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -130513,7 +130513,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -149151,7 +149151,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -166135,7 +166135,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "versionId",
@@ -170716,7 +170716,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -170867,7 +170867,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -172136,7 +172136,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "status",
@@ -184883,7 +184883,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -188464,7 +188464,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "start",
@@ -195397,7 +195397,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -196649,7 +196649,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -197661,7 +197661,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -200292,7 +200292,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "low",
@@ -200395,7 +200395,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "numerator",
@@ -200498,7 +200498,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "lowNumerator",
@@ -200625,7 +200625,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "reference",
@@ -201534,7 +201534,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -202467,7 +202467,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -209866,7 +209866,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "origin",
@@ -212994,7 +212994,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -247187,7 +247187,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -247338,7 +247338,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "bounds",
@@ -249125,7 +249125,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -249585,7 +249585,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -254014,7 +254014,7 @@ public sealed partial class R6CoreSchemaProvider : Ignixa.Abstractions.IFhirSche
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "channelType",

--- a/src/Core/Ignixa.Specification/Generated/STU3CoreSchemaProvider.g.cs
+++ b/src/Core/Ignixa.Specification/Generated/STU3CoreSchemaProvider.g.cs
@@ -14112,7 +14112,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -15237,7 +15237,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -16218,7 +16218,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "author",
@@ -17590,7 +17590,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "contentType",
@@ -19343,7 +19343,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -35401,7 +35401,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "coding",
@@ -37154,7 +37154,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -44989,7 +44989,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -45092,7 +45092,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "system",
@@ -47665,7 +47665,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -47792,7 +47792,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -49675,7 +49675,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -49850,7 +49850,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -50025,7 +50025,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -55167,7 +55167,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -57414,7 +57414,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "modifierExtension",
@@ -57438,7 +57438,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -57493,7 +57493,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "sequence",
@@ -57884,7 +57884,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -58059,7 +58059,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
         };
     }
@@ -58114,7 +58114,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -58937,7 +58937,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "path",
@@ -59064,7 +59064,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "strength",
@@ -59191,7 +59191,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "key",
@@ -59414,7 +59414,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "label",
@@ -59517,7 +59517,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "identity",
@@ -59668,7 +59668,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "discriminator",
@@ -59819,7 +59819,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -59922,7 +59922,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",
@@ -72731,7 +72731,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "url",
@@ -78226,7 +78226,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -78528,7 +78528,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "use",
@@ -97988,7 +97988,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "versionId",
@@ -98163,7 +98163,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -99072,7 +99072,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "status",
@@ -104499,7 +104499,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "name",
@@ -107631,7 +107631,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "start",
@@ -116474,7 +116474,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "value",
@@ -118858,7 +118858,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "low",
@@ -118961,7 +118961,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "numerator",
@@ -119064,7 +119064,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "reference",
@@ -120069,7 +120069,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -124257,7 +124257,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "origin",
@@ -128263,7 +128263,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -144470,7 +144470,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "event",
@@ -144597,7 +144597,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "bounds",
@@ -145012,7 +145012,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "type",
@@ -145321,7 +145321,7 @@ public sealed partial class STU3CoreSchemaProvider : Ignixa.Abstractions.IFhirSc
                 defaultTypeName: Constants.Str_Extension,
                 referenceTargets: null,
                 contentReference: null,
-                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, "Open", false)
+                slicing: new Ignixa.Abstractions.SlicingMetadata(new Ignixa.Abstractions.DiscriminatorDefinition[] { new Ignixa.Abstractions.DiscriminatorDefinition(Ignixa.Abstractions.DiscriminatorType.Value, "url") }, Ignixa.Abstractions.SlicingRules.Open, false)
             ),
             new CoreType(
                 name: "code",

--- a/src/Core/Ignixa.Specification/IExtendedElementMetadata.cs
+++ b/src/Core/Ignixa.Specification/IExtendedElementMetadata.cs
@@ -102,10 +102,25 @@ public interface IExtendedElementMetadata
 public record BindingMetadata(string ValueSetUrl, string Strength);
 
 /// <summary>
+/// Rules that define whether unsliced content is allowed in a sliced FHIR element.
+/// </summary>
+public enum SlicingRules
+{
+    /// <summary>Additional content is allowed anywhere in the sliced element.</summary>
+    Open,
+
+    /// <summary>Additional content that does not match a slice is not allowed.</summary>
+    Closed,
+
+    /// <summary>Additional content is allowed only after all matched slices.</summary>
+    OpenAtEnd,
+}
+
+/// <summary>
 /// Slicing metadata for elements that can be sliced in profiles.
 /// </summary>
 /// <param name="Discriminators">Array of discriminator paths (e.g., ["type:url"] for extension slicing).</param>
 /// <param name="Rules">Slicing rules: Open, Closed, or OpenAtEnd.</param>
 /// <param name="Ordered">Whether slices must appear in a specific order.</param>
 [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Array is appropriate for readonly metadata")]
-public record SlicingMetadata(string[] Discriminators, string Rules, bool Ordered);
+public record SlicingMetadata(string[] Discriminators, SlicingRules Rules, bool Ordered);

--- a/src/Core/Ignixa.Specification/IExtendedElementMetadata.cs
+++ b/src/Core/Ignixa.Specification/IExtendedElementMetadata.cs
@@ -102,25 +102,10 @@ public interface IExtendedElementMetadata
 public record BindingMetadata(string ValueSetUrl, string Strength);
 
 /// <summary>
-/// Rules that define whether unsliced content is allowed in a sliced FHIR element.
-/// </summary>
-public enum SlicingRules
-{
-    /// <summary>Additional content is allowed anywhere in the sliced element.</summary>
-    Open,
-
-    /// <summary>Additional content that does not match a slice is not allowed.</summary>
-    Closed,
-
-    /// <summary>Additional content is allowed only after all matched slices.</summary>
-    OpenAtEnd,
-}
-
-/// <summary>
 /// Slicing metadata for elements that can be sliced in profiles.
 /// </summary>
 /// <param name="Discriminators">Array of discriminator paths (e.g., ["type:url"] for extension slicing).</param>
 /// <param name="Rules">Slicing rules: Open, Closed, or OpenAtEnd.</param>
 /// <param name="Ordered">Whether slices must appear in a specific order.</param>
 [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Array is appropriate for readonly metadata")]
-public record SlicingMetadata(string[] Discriminators, SlicingRules Rules, bool Ordered);
+public record SlicingMetadata(string[] Discriminators, Ignixa.Abstractions.SlicingRules Rules, bool Ordered);

--- a/src/Core/Ignixa.Validation/Checks/SlicingCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/SlicingCheck.cs
@@ -26,9 +26,6 @@ namespace Ignixa.Validation.Checks;
 /// </remarks>
 public sealed class SlicingCheck : IValidationCheck
 {
-    private const string ClosedRule = "CLOSED";
-    private const string OpenAtEndRule = "OPENATEND";
-
     private readonly string _slicedName;
     private readonly SlicingMetadata _metadata;
     private readonly bool _isClosed;
@@ -45,9 +42,8 @@ public sealed class SlicingCheck : IValidationCheck
         _slicedName = slicedName ?? throw new ArgumentNullException(nameof(slicedName));
         _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
 
-        var rules = metadata.Rules?.ToUpperInvariant().Replace("-", string.Empty, StringComparison.Ordinal) ?? "OPEN";
-        _isClosed = rules == ClosedRule;
-        _isOpenAtEnd = rules == OpenAtEndRule;
+        _isClosed = metadata.Rules == SlicingRules.Closed;
+        _isOpenAtEnd = metadata.Rules == SlicingRules.OpenAtEnd;
         _deferred = ComputeDeferred(metadata);
     }
 

--- a/test/Ignixa.PackageManagement.Tests/StructureDefinitionTypeAdapterTests.cs
+++ b/test/Ignixa.PackageManagement.Tests/StructureDefinitionTypeAdapterTests.cs
@@ -211,4 +211,69 @@ public class StructureDefinitionTypeAdapterTests
         subject.ReferenceTargets.ShouldContain("Patient");
         subject.ReferenceTargets.ShouldContain("Group");
     }
+
+    // ===== Slicing rules parsing =====
+
+    [Theory]
+    [InlineData("open", SlicingRules.Open)]
+    [InlineData("Open", SlicingRules.Open)]
+    [InlineData("OPEN", SlicingRules.Open)]
+    [InlineData("closed", SlicingRules.Closed)]
+    [InlineData("Closed", SlicingRules.Closed)]
+    [InlineData("CLOSED", SlicingRules.Closed)]
+    [InlineData("openAtEnd", SlicingRules.OpenAtEnd)]
+    [InlineData("OpenAtEnd", SlicingRules.OpenAtEnd)]
+    [InlineData("OPENATEND", SlicingRules.OpenAtEnd)]
+    [InlineData("open-at-end", SlicingRules.OpenAtEnd)]
+    public void GivenExtensionSlicingWithRulesValue_WhenAdapted_ThenParsesExpectedSlicingRules(string rulesValue, SlicingRules expected)
+    {
+        var type = new StructureDefinitionTypeAdapter().Adapt(PatientWithExtensionSlicingJson(rulesValue), "4.0.1")!;
+        var extension = (ITypeExtended)type.Children.Single(c => c.Info.Name == "extension");
+
+        extension.Slicing.ShouldNotBeNull();
+        extension.Slicing!.Rules.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenExtensionSlicingWithoutRulesProperty_WhenAdapted_ThenDefaultsToOpen()
+    {
+        var type = new StructureDefinitionTypeAdapter().Adapt(PatientWithExtensionSlicingJson(rulesValue: null), "4.0.1")!;
+        var extension = (ITypeExtended)type.Children.Single(c => c.Info.Name == "extension");
+
+        extension.Slicing.ShouldNotBeNull();
+        extension.Slicing!.Rules.ShouldBe(SlicingRules.Open);
+    }
+
+    [Fact]
+    public void GivenExtensionSlicingWithUnrecognizedRulesValue_WhenAdapted_ThenThrowsInvalidOperationException()
+    {
+        var adapter = new StructureDefinitionTypeAdapter();
+
+        Should.Throw<InvalidOperationException>(() => adapter.Adapt(PatientWithExtensionSlicingJson("bogus"), "4.0.1"));
+    }
+
+    private static string PatientWithExtensionSlicingJson(string? rulesValue)
+    {
+        var rulesProperty = rulesValue is null ? string.Empty : $"\"rules\":\"{rulesValue}\",";
+        return $$"""
+            {
+              "resourceType": "StructureDefinition",
+              "id": "Patient",
+              "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "version": "4.0.1",
+              "name": "Patient",
+              "kind": "resource",
+              "abstract": false,
+              "type": "Patient",
+              "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+              "snapshot": {
+                "element": [
+                  { "id": "Patient", "path": "Patient", "min": 0, "max": "*" },
+                  { "id": "Patient.extension", "path": "Patient.extension", "min": 0, "max": "*",
+                    "slicing": { "discriminator": [{ "type": "value", "path": "url" }], {{rulesProperty}}"ordered": false } }
+                ]
+              }
+            }
+            """;
+    }
 }

--- a/test/Ignixa.Validation.Tests/Checks/SlicingCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/SlicingCheckTests.cs
@@ -31,7 +31,7 @@ public sealed class SlicingCheckTests
         return JsonNodeSourceNode.Create(json).ToElement(TestSchemaProvider.GetR4Schema());
     }
 
-    private static SlicingMetadata ValueUrlSlicing(string rules, params SliceDefinition[] slices)
+    private static SlicingMetadata ValueUrlSlicing(SlicingRules rules, params SliceDefinition[] slices)
         => new(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Value, "url") },
             rules,
@@ -45,7 +45,7 @@ public sealed class SlicingCheckTests
     public void GivenExtensionMatchingSliceWithinMax_WhenValidating_ThenSucceeds()
     {
         var element = PatientWith("""[{"url":"http://x/race","valueString":"Asian"}]""");
-        var metadata = ValueUrlSlicing("closed", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.Closed, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -58,7 +58,7 @@ public sealed class SlicingCheckTests
     public void GivenTwoExtensionsForSingleCardinalitySlice_WhenValidating_ThenReportsSliceCardinalityError()
     {
         var element = PatientWith("""[{"url":"http://x/race","valueString":"A"},{"url":"http://x/race","valueString":"B"}]""");
-        var metadata = ValueUrlSlicing("open", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.Open, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -74,7 +74,7 @@ public sealed class SlicingCheckTests
     public void GivenUnknownUrlUnderClosedSlicing_WhenValidating_ThenReportsUnmatchedError()
     {
         var element = PatientWith("""[{"url":"http://x/unknown","valueString":"?"}]""");
-        var metadata = ValueUrlSlicing("closed", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.Closed, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -88,7 +88,7 @@ public sealed class SlicingCheckTests
     public void GivenUnknownUrlUnderOpenSlicing_WhenValidating_ThenAcceptsAsDefaultBucket()
     {
         var element = PatientWith("""[{"url":"http://x/unknown","valueString":"?"}]""");
-        var metadata = ValueUrlSlicing("open", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.Open, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -102,7 +102,7 @@ public sealed class SlicingCheckTests
     {
         var element = PatientWith("""[{"url":"http://x/race","valueString":"A"}]""");
         var metadata = ValueUrlSlicing(
-            "open",
+            SlicingRules.Open,
             ValueUrlSlice("race", 0, 1, "http://x/race"),
             ValueUrlSlice("birthsex", 1, 1, "http://x/birthsex"));
         var check = new SlicingCheck("extension", metadata);
@@ -122,7 +122,7 @@ public sealed class SlicingCheckTests
         var element = PatientWith("""[{"url":"http://x/a","valueString":"present"}]""");
         var metadata = new SlicingMetadata(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Exists, "valueString") },
-            "closed",
+            SlicingRules.Closed,
             ordered: false,
             new[] { new SliceDefinition("hasValueString", 1, 1, new[] { new SliceDiscriminatorValue(DiscriminatorType.Exists, "valueString", null) }) });
         var check = new SlicingCheck("extension", metadata);
@@ -137,7 +137,7 @@ public sealed class SlicingCheckTests
     public void GivenSpecDepth_WhenValidating_ThenSkippedRegardlessOfViolations()
     {
         var element = PatientWith("""[{"url":"http://x/race","valueString":"A"},{"url":"http://x/race","valueString":"B"}]""");
-        var metadata = ValueUrlSlicing("closed", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.Closed, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, new ValidationSettings { Depth = ValidationDepth.Spec }, new ValidationState());
@@ -152,7 +152,7 @@ public sealed class SlicingCheckTests
         var element = PatientWith("""[{"url":"http://x/race","valueString":"A"},{"url":"http://x/race","valueString":"B"}]""");
         var metadata = new SlicingMetadata(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Profile, "$this") },
-            "closed",
+            SlicingRules.Closed,
             ordered: false,
             new[] { new SliceDefinition("race", 0, 1, new[] { new SliceDiscriminatorValue(DiscriminatorType.Profile, "$this", "http://x/race") }) });
         var check = new SlicingCheck("extension", metadata);
@@ -175,7 +175,7 @@ public sealed class SlicingCheckTests
         """);
         var metadata = new SlicingMetadata(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Type, "value") },
-            "closed",
+            SlicingRules.Closed,
             ordered: false,
             new[]
             {
@@ -199,7 +199,7 @@ public sealed class SlicingCheckTests
           {"url":"http://x/extra","valueString":"trailing"}
         ]
         """);
-        var metadata = ValueUrlSlicing("openAtEnd", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.OpenAtEnd, ValueUrlSlice("race", 0, 1, "http://x/race"));
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -217,7 +217,30 @@ public sealed class SlicingCheckTests
           {"url":"http://x/race","valueString":"A"}
         ]
         """);
-        var metadata = ValueUrlSlicing("openAtEnd", ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var metadata = ValueUrlSlicing(SlicingRules.OpenAtEnd, ValueUrlSlice("race", 0, 1, "http://x/race"));
+        var check = new SlicingCheck("extension", metadata);
+
+        var result = check.Validate(element, FullDepth, new ValidationState());
+
+        result.IsValid.ShouldBeFalse();
+        var issue = result.Issues.ShouldHaveSingleItem();
+        issue.Code.ShouldBe("slicing-unmatched");
+    }
+
+    [Fact]
+    public void GivenOpenAtEndEnumRule_WhenUnmatchedContentPrecedesMatchedSlice_ThenReportsUnmatchedError()
+    {
+        var element = PatientWith("""
+        [
+          {"url":"http://x/extra","valueString":"leading"},
+          {"url":"http://x/race","valueString":"A"}
+        ]
+        """);
+        var metadata = new SlicingMetadata(
+            new[] { new DiscriminatorDefinition(DiscriminatorType.Value, "url") },
+            SlicingRules.OpenAtEnd,
+            ordered: false,
+            new[] { ValueUrlSlice("race", 0, 1, "http://x/race") });
         var check = new SlicingCheck("extension", metadata);
 
         var result = check.Validate(element, FullDepth, new ValidationState());
@@ -238,7 +261,7 @@ public sealed class SlicingCheckTests
         """);
         var metadata = new SlicingMetadata(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Value, "url") },
-            "open",
+            SlicingRules.Open,
             ordered: true,
             new[]
             {
@@ -263,7 +286,7 @@ public sealed class SlicingCheckTests
         // Information issue, never raise a slicing Error (which would falsely reject a valid resource).
         var metadata = new SlicingMetadata(
             new[] { new DiscriminatorDefinition(DiscriminatorType.Value, "%terminologies") },
-            "closed",
+            SlicingRules.Closed,
             ordered: false,
             new[] { new SliceDefinition("race", 0, 1, new[] { new SliceDiscriminatorValue(DiscriminatorType.Value, "%terminologies", "http://x/race") }) });
         var check = new SlicingCheck("extension", metadata);
@@ -286,7 +309,7 @@ public sealed class SlicingCheckTests
         ]
         """);
         var metadata = ValueUrlSlicing(
-            "closed",
+            SlicingRules.Closed,
             ValueUrlSlice("race", 0, 1, "http://x/race"),
             ValueUrlSlice("birthsex", 0, 1, "http://x/birthsex"));
         var check = new SlicingCheck("extension", metadata);


### PR DESCRIPTION
## Summary
- Add typed `SlicingRules` metadata for abstraction and specification slicing contracts.
- Update codegen and regenerated core schema providers to emit enum members instead of string rule literals.
- Update validation and package profile adapter paths to consume parsed enum values, with slicing tests covering enum construction.

## Test Plan
- `dotnet build All.sln --no-restore --nologo`
- `dotnet test test\Ignixa.Validation.Tests\Ignixa.Validation.Tests.csproj --filter "Slicing|OverStrict|Conformance" --no-restore --nologo`
- `dotnet test test\Ignixa.PackageManagement.Tests\Ignixa.PackageManagement.Tests.csproj --no-restore --nologo`