### PR TITLE
fix(typed-models): add missing package READMEs, regenerate stability matrix

### DIFF
--- a/docs/site/docs/core-sdk/overview.md
+++ b/docs/site/docs/core-sdk/overview.md
@@ -41,6 +41,7 @@ The Ignixa Core SDK is a collection of high-performance, reusable .NET libraries
 | **Abstractions** | *(foundation - no internal deps)* |
 | **Analyzers** | *(Roslyn analyzer - no runtime deps)* |
 | **Serialization** | Abstractions, Analyzers |
+| **Models.R4** / **Models.R5** | Serialization, Abstractions |
 | **FhirPath** | Abstractions |
 | **Specification** | Serialization, Abstractions |
 | **Search** | FhirPath, Specification, Serialization |
@@ -65,7 +66,9 @@ The Ignixa Core SDK is a collection of high-performance, reusable .NET libraries
 
 | Package | Description |
 |---------|-------------|
-| **Ignixa.Serialization** | High-performance JSON serialization with typed models |
+| **Ignixa.Serialization** | High-performance JSON serialization, plus the shared base layer for typed models |
+| **Ignixa.Models.R4** | Opt-in strongly-typed POCO facades for FHIR R4, zero-copy over the Serialization runtime |
+| **Ignixa.Models.R5** | Opt-in strongly-typed POCO facades for FHIR R5, zero-copy over the Serialization runtime |
 | **Ignixa.Search** | Search parameter definitions and indexing |
 | **Ignixa.Validation** | Schema-based validation engine |
 
@@ -101,6 +104,10 @@ dotnet add package Ignixa.Abstractions
 dotnet add package Ignixa.Serialization
 dotnet add package Ignixa.Specification
 
+# Typed models (opt-in, pick the version(s) you need; Beta, requires --prerelease)
+dotnet add package Ignixa.Models.R4 --prerelease
+dotnet add package Ignixa.Models.R5 --prerelease
+
 # FHIRPath evaluation
 dotnet add package Ignixa.FhirPath
 
@@ -135,6 +142,20 @@ var resourceType = sourceNode.ResourceType; // "Patient"
 var id = sourceNode["id"].Text;             // "123"
 var familyName = sourceNode["name"][0]["family"].Text; // "Smith"
 ```
+
+### Use Typed Models (opt-in)
+
+```csharp
+using Ignixa.Models.R4;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
+
+// Same zero-copy JSON underneath -- typed accessors instead of string navigation.
+Patient patient = ResourceJsonNode.Parse(json).As<Patient>();
+var familyName = patient.Name[0].Family; // "Smith", compile-time checked
+```
+
+See [Typed Models](/docs/core-sdk/typed-models) for cross-version usage and the `As<T>()` safety guard.
 
 ### Evaluate FHIRPath
 
@@ -255,11 +276,17 @@ var result2 = element.Select("name.given.first()");
 | FhirPath | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Validation | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Search | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Models.R4 | | ✅ | | | |
+| Models.R5 | | | | ✅ | |
+
+Typed models are version-specific by design (one package per FHIR version), unlike the version-agnostic
+core packages above -- see [Typed Models](/docs/core-sdk/typed-models#fhir-version-support) for details.
 
 ## Related Documentation
 
 - [Abstractions](/docs/core-sdk/abstractions)
 - [Serialization](/docs/core-sdk/serialization)
+- [Typed Models](/docs/core-sdk/typed-models)
 - [FHIRPath](/docs/core-sdk/fhirpath)
 - [Validation](/docs/core-sdk/validation)
 - [Search](/docs/core-sdk/search)

--- a/docs/site/docs/core-sdk/stability.md
+++ b/docs/site/docs/core-sdk/stability.md
@@ -39,6 +39,8 @@ A package is never more stable than any package it depends on.
 | `Ignixa.Validation` | Stable | FHIR resource validation with profile support |
 | `Ignixa.DeId` | Beta (pre-release) | FHIR data de-identification library supporting R4, R4B, R5, R6, and STU3 via Ignixa SDK |
 | `Ignixa.FhirMappingLanguage` | Beta (pre-release) | FHIR Mapping Language (FML) parser and execution engine |
+| `Ignixa.Models.R4` | Beta (pre-release) | FHIR R4 strongly-typed POCO facades over the Ignixa element/JSON runtime (opt-in). Subclasses the shared Ignixa.Models base layer in Ignixa.Serialization. |
+| `Ignixa.Models.R5` | Beta (pre-release) | FHIR R5 strongly-typed POCO facades over the Ignixa element/JSON runtime (opt-in). Subclasses the shared Ignixa.Models base layer in Ignixa.Serialization. |
 | `Ignixa.NarrativeGenerator` | Beta (pre-release) | FHIR narrative generation using Scriban templates with FHIRPath support |
 | `Ignixa.TestScript` | Beta (pre-release) | FHIR TestScript execution engine - parse and evaluate TestScript resources against any FHIR server |
 | `Ignixa.TestScript.FhirFakes` | Beta (pre-release) | FhirFakes integration for TestScript fixture generation - auto-generate test data from resource type |

--- a/docs/site/docs/core-sdk/typed-models.md
+++ b/docs/site/docs/core-sdk/typed-models.md
@@ -1,0 +1,187 @@
+---
+sidebar_position: 4
+title: Typed Models
+description: Firely-grade strongly-typed POCO facades over the Ignixa JSON/IElement runtime -- zero-copy, opt-in, cross-version safe.
+---
+
+# Typed Models
+
+`Ignixa.Models.R4` and `Ignixa.Models.R5` are opt-in packages that add strongly-typed POCO facades
+(`patient.Name[0].Family`, compile-time safety, IntelliSense over every element, enums for every value
+set) on top of the JSON/`IElement` runtime every other Core SDK package already uses. They are **views**,
+not a second source of truth: every generated type reads and writes directly against the same
+`JsonObject` `Ignixa.Serialization` parses, so extensions, primitive shadow elements (`_birthDate`), and
+unknown elements all survive untouched, and there is no POCO&harr;JSON serialization step to keep in sync.
+
+This is the ergonomic layer Firely SDK is best known for, without taking the Firely dependency
+(see [Firely SDK Compatibility](/docs/core-sdk/firely-sdk-compatibility) for that comparison) and without
+losing the schema-driven, multi-version request path the server itself runs on. The server runs with
+neither package referenced; add them only where you want typed ergonomics for a specific version.
+
+## Why Use This Package?
+
+- **Zero-copy**: no allocation-heavy deserialize/reserialize cycle. A typed facade is a thin wrapper
+  around the exact same `JsonObject` you already have.
+- **Shared base across versions**: elements that are structurally identical across R4 and R5 (e.g.
+  `Coding`, `Money`) are generated **once**, in `Ignixa.Serialization` under the `Ignixa.Models`
+  namespace. `Ignixa.Models.R4`/`.R5` only add the R4/R5-specific delta on top. Where a value set gains
+  or loses codes between versions under the same URL (a common, easy-to-miss source of silent data
+  loss), the generator detects it and correctly splits that element per-version instead of sharing it.
+- **Cross-version, safely**: a single parsed node can be viewed as `Ignixa.Models.R4.Patient` and
+  `Ignixa.Models.R5.Patient` simultaneously -- both are windows onto the same data. `As<T>()` guards
+  against the opposite mistake: reinterpreting a version-tagged node through a facade that doesn't
+  support that version throws, rather than silently misreading the wrong shape.
+- **Generated, not hand-maintained**: facades are produced by the same specification-driven generator
+  pipeline (`codegen/Ignixa.Specification.Generators`) that already produces the server's schema
+  providers, so typed-model coverage tracks the FHIR spec directly instead of drifting from hand-written
+  code.
+
+## Installation
+
+```bash
+# Pick the version(s) you need -- both can be referenced from the same project.
+dotnet add package Ignixa.Models.R4 --prerelease
+dotnet add package Ignixa.Models.R5 --prerelease
+```
+
+Both packages are **Beta** stability (see [Package Stability](/docs/core-sdk/stability)) and require the
+`--prerelease` flag.
+
+## Quick Start
+
+```csharp
+using Ignixa.Abstractions;
+using Ignixa.Models.R4;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
+
+const string json = """
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "gender": "female",
+  "birthDate": "1974-12-25",
+  "name": [ { "family": "Chalmers", "given": [ "Jean" ] } ]
+}
+""";
+
+// Parse once, view as the R4-typed facade -- zero-copy over the same backing JsonObject.
+Patient patient = ResourceJsonNode.Parse(json).As<Patient>();
+
+Console.WriteLine(patient.Name[0].Family);   // "Chalmers"
+Console.WriteLine(patient.Gender);            // AdministrativeGender.Female
+
+// Mutate through the typed facade; writes land directly on the backing JSON.
+patient.Active = true;
+
+string serialized = patient.SerializeToString();
+```
+
+### Viewing the same node across versions
+
+Because facades are views, not owners, one parsed node can be viewed through more than one version's
+lens at once:
+
+```csharp
+var resource = ResourceJsonNode.Parse(json);
+
+Ignixa.Models.R4.Patient asR4 = resource.As<Ignixa.Models.R4.Patient>();
+Ignixa.Models.R5.Patient asR5 = resource.As<Ignixa.Models.R5.Patient>();
+
+asR4.Active = true;
+Console.WriteLine(asR5.Active); // true -- same backing JsonObject, write visible through either view
+```
+
+Code written against the **shared base type** (`Ignixa.Models.Patient`) works against either version's
+facade -- true cross-version code, not just cross-version data:
+
+```csharp
+using Ignixa.Models;
+
+static string? Describe(Patient p) => p.Name.FirstOrDefault()?.Family;
+
+Describe(asR4); // works
+Describe(asR5); // also works -- same shared base type
+```
+
+### Explicit version dispatch
+
+```csharp
+// Throws InvalidOperationException on a registry miss rather than silently returning a wrong-typed facade.
+ResourceJsonNode viaVersion = resource.AsVersion(FhirVersion.R4);
+
+// Best-effort variant: returns false and leaves the node unmodified on a miss.
+if (resource.TryAsVersion(FhirVersion.R4, out var versioned))
+{
+    // ...
+}
+```
+
+### Cross-version safety guard
+
+`As<T>()` validates a version-tagged node against the target facade's supported version set (via a
+generated `CompatibleFhirVersionsAttribute` on every facade) and throws if they don't match -- e.g.
+reinterpreting R4 data through an R5-only accessor:
+
+```csharp
+var r4Patient = ResourceJsonNode.Parse(json).As<Ignixa.Models.R4.Patient>(); // FhirVersion stamped R4
+
+r4Patient.As<Ignixa.Models.R5.Patient>();
+// throws InvalidCastException: "Cannot convert a R4 resource to Patient, which only supports [R5]."
+```
+
+The guard is permissive for untagged nodes (`FhirVersion == null`) so it never breaks code that doesn't
+track version explicitly, and `As<T>(validate: false)` remains available as an expert escape hatch.
+
+## Architecture
+
+- **Shared base layer**: identical types live once in `Ignixa.Serialization`, namespace `Ignixa.Models`
+  (e.g. `Ignixa.Models.Patient`, `Ignixa.Models.Coding`).
+- **Per-version packages**: `Ignixa.Models.R4`/`.R5` subclass the shared base with only the elements
+  that genuinely diverge for that version (`Ignixa.Models.R4.Patient : Ignixa.Models.Patient`).
+- **Classification, not guesswork**: a build-time classifier walks every targeted version's
+  `StructureDefinition`s and compares element-level signatures -- type, cardinality, and (for
+  code-bound elements) the *actual expanded code set*, not just the value-set URL -- to decide what's
+  safe to share versus what must be per-version.
+- **Generated, checked in**: output is committed source, not build-time codegen in your project. A
+  regen-drift guard (`build/check-typed-model-regen.ps1`/`.sh`) proves the checked-in output still
+  matches what the generator produces.
+
+## Coverage Notes
+
+Not every element gets a typed accessor. Two intentional fallbacks, both documented on the generated
+member itself:
+
+- **`Reference`-typed elements** (e.g. `Observation.subject`) are exposed as a raw `JsonNode?`/`JsonArray?`
+  rather than a typed `Reference` property, since `Reference` targets are polymorphic across resource
+  types.
+- **Value sets that can't be expanded** (unbounded code systems, expansion failures) fall back to a plain
+  `string` property instead of an enum.
+
+Both fallbacks still round-trip byte-for-byte -- they just don't get compile-time member names.
+
+## Integration with Other Packages
+
+- **Ignixa.Serialization**: hosts the shared base layer and the `ResourceJsonNode`/`BaseJsonNode` runtime
+  every facade builds on.
+- **Ignixa.Abstractions**: supplies `FhirVersion` and other cross-cutting contracts.
+- **Ignixa.Specification**: the same `StructureDefinition` data that drives the server's schema providers
+  drives the typed-model generator, so coverage stays aligned with the rest of the SDK.
+
+## FHIR Version Support
+
+| Package | STU3 | R4 | R4B | R5 | R6 |
+|---------|:----:|:--:|:---:|:--:|:--:|
+| Ignixa.Models.R4 | | ✅ | | | |
+| Ignixa.Models.R5 | | | | ✅ | |
+
+Unlike the version-agnostic core packages (Abstractions, Specification, Serialization, FhirPath,
+Validation, Search), typed-model packages are version-specific by design -- that's what makes the typed
+surface possible. See [ADR-2609](https://github.com/brendankowitz/ignixa-fhir/blob/main/docs/features/typed-models/adr-2609-stu3-classification-group.md)
+for the proposed approach to adding STU3.
+
+## Related Documentation
+
+- [Serialization](/docs/core-sdk/serialization) -- the runtime typed models are built on
+- [Package Stability](/docs/core-sdk/stability)
+- [Firely SDK Compatibility](/docs/core-sdk/firely-sdk-compatibility)

--- a/docs/site/docs/core-sdk/typed-models.md
+++ b/docs/site/docs/core-sdk/typed-models.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3.5
 title: Typed Models
 description: Firely-grade strongly-typed POCO facades over the Ignixa JSON/IElement runtime -- zero-copy, opt-in, cross-version safe.
 ---
@@ -127,7 +127,8 @@ reinterpreting R4 data through an R5-only accessor:
 var r4Patient = ResourceJsonNode.Parse(json).As<Ignixa.Models.R4.Patient>(); // FhirVersion stamped R4
 
 r4Patient.As<Ignixa.Models.R5.Patient>();
-// throws InvalidCastException: "Cannot convert a R4 resource to Patient, which only supports [R5]."
+// throws InvalidCastException: "Cannot convert a R4 resource to Patient, which only supports [R5].
+// Use TryAsVersion/AsVersion for safe dispatch, or As<T>(validate: false) to bypass this check."
 ```
 
 The guard is permissive for untagged nodes (`FhirVersion == null`) so it never breaks code that doesn't

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -86,6 +86,7 @@ const sidebars = {
         'core-sdk/stability',
         'core-sdk/abstractions',
         'core-sdk/serialization',
+        'core-sdk/typed-models',
         'core-sdk/fhirpath',
         'core-sdk/validation',
         'core-sdk/search',

--- a/src/Core/Models/Ignixa.Models.R4/README.md
+++ b/src/Core/Models/Ignixa.Models.R4/README.md
@@ -61,6 +61,8 @@ string serialized = patient.SerializeToString();
 ```csharp
 using Ignixa.Abstractions;
 
+ResourceJsonNode resource = ResourceJsonNode.Parse(json);
+
 // Explicit, version-aware dispatch -- throws InvalidOperationException on a registry miss rather than
 // silently returning a wrong-typed facade.
 ResourceJsonNode viaR4 = resource.AsVersion(FhirVersion.R4);

--- a/src/Core/Models/Ignixa.Models.R4/README.md
+++ b/src/Core/Models/Ignixa.Models.R4/README.md
@@ -1,0 +1,86 @@
+# Ignixa.Models.R4
+
+FHIR R4 strongly-typed POCO facades over the Ignixa element/JSON runtime. Opt-in: subclasses the shared
+`Ignixa.Models` base layer in `Ignixa.Serialization`, so it adds Firely-grade ergonomics
+(`patient.Name[0].Family`, compile-time safety, IntelliSense over every element, enums for every value
+set) without becoming a second source of truth — every generated type is a zero-copy view over the same
+`JsonObject`/`IElement` runtime the rest of the SDK already uses.
+
+## Why Use This Package?
+
+- **Zero-copy**: typed facades read and write directly against the backing JSON; there is no
+  POCO&harr;JSON serialization step, so extensions, primitive shadow elements (`_birthDate`), and
+  unknown elements all survive untouched.
+- **Shared base, R4-specific deltas**: types identical across versions (e.g. `Coding`) live once in
+  `Ignixa.Serialization`; R4-specific shape lives here. You get the base type's ergonomics for free and
+  only pull in this package for the R4-specific delta.
+- **Cross-version safe by construction**: `As<T>()` validates that a version-tagged node is only
+  reinterpreted through a facade that actually supports that version, so R4 data can't silently be
+  misread through another version's shaped accessor.
+- **Opt-in, never on the core request path**: the server runs without this package. Add it only where
+  you want typed R4 ergonomics.
+
+## Installation
+
+```bash
+dotnet add package Ignixa.Models.R4 --prerelease
+```
+
+## Quick Start
+
+```csharp
+using Ignixa.Abstractions;
+using Ignixa.Models.R4;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
+
+const string json = """
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "gender": "female",
+  "birthDate": "1974-12-25",
+  "name": [ { "family": "Chalmers", "given": [ "Jean" ] } ]
+}
+""";
+
+// Parse once, view as the R4-typed facade -- zero-copy over the same backing JsonObject.
+Patient patient = ResourceJsonNode.Parse(json).As<Patient>();
+
+Console.WriteLine(patient.Name[0].Family);       // "Chalmers"
+Console.WriteLine(patient.Gender);                // AdministrativeGender.Female
+
+// Mutate through the typed facade; writes land directly on the backing JSON.
+patient.Active = true;
+
+string serialized = patient.SerializeToString();
+```
+
+### Cross-version dispatch
+
+```csharp
+using Ignixa.Abstractions;
+
+// Explicit, version-aware dispatch -- throws InvalidOperationException on a registry miss rather than
+// silently returning a wrong-typed facade.
+ResourceJsonNode viaR4 = resource.AsVersion(FhirVersion.R4);
+
+// Or the best-effort variant:
+if (resource.TryAsVersion(FhirVersion.R4, out var versioned))
+{
+    // ...
+}
+```
+
+## Integration with Other Packages
+
+- **Ignixa.Serialization**: provides the shared `Ignixa.Models` base layer this package subclasses, plus
+  the `ResourceJsonNode`/`BaseJsonNode` runtime every facade is built on.
+- **Ignixa.Models.R5**: the R5 counterpart. Both can be referenced from the same project — a single
+  parsed node can be viewed as `Ignixa.Models.R4.Patient` and `Ignixa.Models.R5.Patient`
+  simultaneously, since neither owns the underlying data.
+- **Ignixa.Abstractions**: supplies `FhirVersion` and other cross-cutting contracts.
+
+## License
+
+MIT License - see LICENSE file in repository root

--- a/src/Core/Models/Ignixa.Models.R5/README.md
+++ b/src/Core/Models/Ignixa.Models.R5/README.md
@@ -1,0 +1,86 @@
+# Ignixa.Models.R5
+
+FHIR R5 strongly-typed POCO facades over the Ignixa element/JSON runtime. Opt-in: subclasses the shared
+`Ignixa.Models` base layer in `Ignixa.Serialization`, so it adds Firely-grade ergonomics
+(`patient.Name[0].Family`, compile-time safety, IntelliSense over every element, enums for every value
+set) without becoming a second source of truth — every generated type is a zero-copy view over the same
+`JsonObject`/`IElement` runtime the rest of the SDK already uses.
+
+## Why Use This Package?
+
+- **Zero-copy**: typed facades read and write directly against the backing JSON; there is no
+  POCO&harr;JSON serialization step, so extensions, primitive shadow elements (`_birthDate`), and
+  unknown elements all survive untouched.
+- **Shared base, R5-specific deltas**: types identical across versions (e.g. `Coding`) live once in
+  `Ignixa.Serialization`; R5-specific shape lives here. You get the base type's ergonomics for free and
+  only pull in this package for the R5-specific delta.
+- **Cross-version safe by construction**: `As<T>()` validates that a version-tagged node is only
+  reinterpreted through a facade that actually supports that version, so R5 data can't silently be
+  misread through another version's shaped accessor.
+- **Opt-in, never on the core request path**: the server runs without this package. Add it only where
+  you want typed R5 ergonomics.
+
+## Installation
+
+```bash
+dotnet add package Ignixa.Models.R5 --prerelease
+```
+
+## Quick Start
+
+```csharp
+using Ignixa.Abstractions;
+using Ignixa.Models.R5;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
+
+const string json = """
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "gender": "female",
+  "birthDate": "1974-12-25",
+  "name": [ { "family": "Chalmers", "given": [ "Jean" ] } ]
+}
+""";
+
+// Parse once, view as the R5-typed facade -- zero-copy over the same backing JsonObject.
+Patient patient = ResourceJsonNode.Parse(json).As<Patient>();
+
+Console.WriteLine(patient.Name[0].Family);       // "Chalmers"
+Console.WriteLine(patient.Gender);                // AdministrativeGender.Female
+
+// Mutate through the typed facade; writes land directly on the backing JSON.
+patient.Active = true;
+
+string serialized = patient.SerializeToString();
+```
+
+### Cross-version dispatch
+
+```csharp
+using Ignixa.Abstractions;
+
+// Explicit, version-aware dispatch -- throws InvalidOperationException on a registry miss rather than
+// silently returning a wrong-typed facade.
+ResourceJsonNode viaR5 = resource.AsVersion(FhirVersion.R5);
+
+// Or the best-effort variant:
+if (resource.TryAsVersion(FhirVersion.R5, out var versioned))
+{
+    // ...
+}
+```
+
+## Integration with Other Packages
+
+- **Ignixa.Serialization**: provides the shared `Ignixa.Models` base layer this package subclasses, plus
+  the `ResourceJsonNode`/`BaseJsonNode` runtime every facade is built on.
+- **Ignixa.Models.R4**: the R4 counterpart. Both can be referenced from the same project — a single
+  parsed node can be viewed as `Ignixa.Models.R4.Patient` and `Ignixa.Models.R5.Patient`
+  simultaneously, since neither owns the underlying data.
+- **Ignixa.Abstractions**: supplies `FhirVersion` and other cross-cutting contracts.
+
+## License
+
+MIT License - see LICENSE file in repository root

--- a/src/Core/Models/Ignixa.Models.R5/README.md
+++ b/src/Core/Models/Ignixa.Models.R5/README.md
@@ -61,6 +61,8 @@ string serialized = patient.SerializeToString();
 ```csharp
 using Ignixa.Abstractions;
 
+ResourceJsonNode resource = ResourceJsonNode.Parse(json);
+
 // Explicit, version-aware dispatch -- throws InvalidOperationException on a registry miss rather than
 // silently returning a wrong-typed facade.
 ResourceJsonNode viaR5 = resource.AsVersion(FhirVersion.R5);


### PR DESCRIPTION
## Summary
- `dotnet pack` was broken for both new model packages (`Ignixa.Models.R4`/`.R5`) merged in #275: `NU5039: The readme file 'README.md' does not exist in the package`. `Directory.Build.props` sets `PackageReadmeFile=README.md` for every package unconditionally, but only includes a README when one exists in the project directory — every other package under `src/Core/` has one, these two didn't.
- Added READMEs matching the existing per-package convention, with real, verified `As<T>()`/`AsVersion` examples.
- Regenerated `docs/site/docs/core-sdk/stability.md` (auto-generated via `eng/Generate-StabilityMatrix.ps1`) to pick up the two new Beta-tier packages, which it was missing since it hadn't been re-run since they were added.

## Test plan
- [x] `dotnet pack` succeeds for both `Ignixa.Models.R4` and `Ignixa.Models.R5`, README embeds correctly in the .nupkg, dependency/TFM metadata verified.
- [x] `dotnet build All.sln` clean (0/0), verified prior to this branch.
- [x] `Ignixa.Models.Tests` (36/36) and `Ignixa.RepoGuards.Tests` (13/13, including `PackageStabilityGuardTests`) pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>