### PR TITLE
fix(validation): run CodeSystem/ValueSet conformance checks at Compatibility depth

### DIFF
--- a/src/Core/Ignixa.Validation/Abstractions/ICompatibilityConformanceCheck.cs
+++ b/src/Core/Ignixa.Validation/Abstractions/ICompatibilityConformanceCheck.cs
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ignixa.Validation.Abstractions;
+
+/// <summary>
+/// Marks a profile-tier <see cref="IValidationCheck"/> that must also run at
+/// <see cref="ValidationDepth.Compatibility"/> depth, in addition to <see cref="ValidationDepth.Full"/>.
+/// <para>
+/// Reserved for closed-world, terminology-independent conformance checks (e.g. CodeSystem/ValueSet
+/// shape rules) that Microsoft FHIR Server's Firely-based fallback validator also enforces at
+/// Compatibility depth. Every other profile check (FHIRPath invariants, slicing, reference resolution,
+/// choice-variant recursion) intentionally stays Full-only — see <c>ValidationDepthTests</c> for the
+/// regression coverage protecting that boundary (Bug #210-6: a blanket depth comparison previously let
+/// Compatibility run the entire profile tier).
+/// </para>
+/// </summary>
+[SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Marker interface: carries the run-at-Compatibility-too contract for ValidationSchema.Validate.")]
+public interface ICompatibilityConformanceCheck
+{
+}

--- a/src/Core/Ignixa.Validation/Abstractions/ValidationSchema.cs
+++ b/src/Core/Ignixa.Validation/Abstractions/ValidationSchema.cs
@@ -139,7 +139,8 @@ public sealed class ValidationSchema
     /// Depth.Minimal: Run universal checks only.
     /// Depth.Spec: Run universal + spec checks.
     /// Depth.Full: Run universal + spec + profile checks.
-    /// Depth.Compatibility: Run universal + spec checks (same as Spec, no profile checks).
+    /// Depth.Compatibility: Run universal + spec checks, plus the subset of profile checks marked
+    /// <see cref="ICompatibilityConformanceCheck"/> (all other profile checks stay Full-only).
     /// </summary>
     /// <param name="element">The element to validate.</param>
     /// <param name="settings">Validation settings (including depth).</param>
@@ -165,12 +166,23 @@ public sealed class ValidationSchema
             }
         }
 
-        // Profile checks: run ONLY for Full depth (not Compatibility)
+        // Profile checks: run for Full depth. Compatibility depth runs only the checks marked
+        // ICompatibilityConformanceCheck (see that interface for why the boundary is drawn there).
         if (settings.Depth == ValidationDepth.Full)
         {
             foreach (var check in _profileChecks)
             {
                 results.Add(check.Validate(element, settings, state));
+            }
+        }
+        else if (settings.Depth == ValidationDepth.Compatibility)
+        {
+            foreach (var check in _profileChecks)
+            {
+                if (check is ICompatibilityConformanceCheck)
+                {
+                    results.Add(check.Validate(element, settings, state));
+                }
             }
         }
 

--- a/src/Core/Ignixa.Validation/Checks/CodeSystemPropertyTypeCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/CodeSystemPropertyTypeCheck.cs
@@ -17,7 +17,7 @@ namespace Ignixa.Validation.Checks;
 /// only the resource's own property declarations and concept values are consulted; undeclared
 /// properties are ignored here (they draw a separate "unknown property" warning upstream).
 /// </summary>
-public sealed class CodeSystemPropertyTypeCheck : IValidationCheck, ISingletonCheck
+public sealed class CodeSystemPropertyTypeCheck : IValidationCheck, ISingletonCheck, ICompatibilityConformanceCheck
 {
     /// <inheritdoc />
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)

--- a/src/Core/Ignixa.Validation/Checks/CodeSystemSupplementContentCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/CodeSystemSupplementContentCheck.cs
@@ -16,7 +16,7 @@ namespace Ignixa.Validation.Checks;
 /// 'supplement'." Closed-world — depends only on the resource's own <c>supplements</c> and
 /// <c>content</c> elements.
 /// </summary>
-public sealed class CodeSystemSupplementContentCheck : IValidationCheck, ISingletonCheck
+public sealed class CodeSystemSupplementContentCheck : IValidationCheck, ISingletonCheck, ICompatibilityConformanceCheck
 {
     /// <inheritdoc />
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)

--- a/src/Core/Ignixa.Validation/Checks/ValueSetFilterCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ValueSetFilterCheck.cs
@@ -18,7 +18,7 @@ namespace Ignixa.Validation.Checks;
 /// 'notSelectable' must be either 'true' or 'false', not '1'." Only the FHIR-defined boolean
 /// concept-properties are consulted, so no code-system knowledge is required.
 /// </summary>
-public sealed class ValueSetFilterCheck : IValidationCheck, ISingletonCheck
+public sealed class ValueSetFilterCheck : IValidationCheck, ISingletonCheck, ICompatibilityConformanceCheck
 {
     // FHIR-standard concept-properties (http://hl7.org/fhir/concept-properties) whose type is
     // boolean. Their filter values are constrained regardless of the target code system.

--- a/src/Core/Ignixa.Validation/Checks/ValueSetIncludeSystemCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/ValueSetIncludeSystemCheck.cs
@@ -16,7 +16,7 @@ namespace Ignixa.Validation.Checks;
 /// must be absolute." Closed-world and terminology-independent — a single raw-JSON walk of the
 /// ValueSet root, so it is registered only for the ValueSet resource type.
 /// </summary>
-public sealed class ValueSetIncludeSystemCheck : IValidationCheck, ISingletonCheck
+public sealed class ValueSetIncludeSystemCheck : IValidationCheck, ISingletonCheck, ICompatibilityConformanceCheck
 {
     /// <inheritdoc />
     public ValidationResult Validate(IElement element, ValidationSettings settings, ValidationState state)

--- a/test/Ignixa.Validation.Tests/CompatibilityConformanceCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/CompatibilityConformanceCheckTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="CompatibilityConformanceCheckTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Schema;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests;
+
+/// <summary>
+/// Regression tests for GH #320: <see cref="ValidationDepth.Compatibility"/> must run the
+/// CodeSystem/ValueSet conformance checks (which Microsoft FHIR Server's fallback Firely validator
+/// also enforces) even though it does not run the rest of the profile tier (invariants, slicing,
+/// reference resolution — see <see cref="ValidationDepthTests"/> for that regression coverage).
+/// </summary>
+public class CompatibilityConformanceCheckTests
+{
+    private readonly ISchema _schema = new R4CoreSchemaProvider();
+    private readonly StructureDefinitionSchemaBuilder _builder = new();
+
+    [Trait("Category", "Regression")]
+    [Fact]
+    public void GivenCompatibilityDepth_WhenValueSetIncludeSystemIsRelative_ThenReportsIssue()
+    {
+        var typeDefinition = _schema.GetTypeDefinition("ValueSet");
+        var schema = _builder.BuildSchema(typeDefinition!, _schema);
+
+        var json = JsonNode.Parse("""
+            {
+                "resourceType": "ValueSet",
+                "id": "vs1",
+                "status": "active",
+                "compose": {
+                    "include": [
+                        { "system": "not-an-absolute-uri" }
+                    ]
+                }
+            }
+            """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+
+        var compatSettings = new ValidationSettings { Depth = ValidationDepth.Compatibility };
+        var compatResult = schema.Validate(element, compatSettings);
+
+        compatResult.Issues.ShouldContain(i => i.Code == "vs-1");
+    }
+
+    [Trait("Category", "Regression")]
+    [Fact]
+    public void GivenCompatibilityDepth_WhenCodeSystemSupplementHasWrongContent_ThenReportsIssue()
+    {
+        var typeDefinition = _schema.GetTypeDefinition("CodeSystem");
+        var schema = _builder.BuildSchema(typeDefinition!, _schema);
+
+        var json = JsonNode.Parse("""
+            {
+                "resourceType": "CodeSystem",
+                "id": "cs1",
+                "status": "active",
+                "content": "complete",
+                "supplements": "http://example.org/CodeSystem/base"
+            }
+            """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+
+        var compatSettings = new ValidationSettings { Depth = ValidationDepth.Compatibility };
+        var compatResult = schema.Validate(element, compatSettings);
+
+        compatResult.Issues.ShouldContain(i => i.Code == "csc-1");
+    }
+}


### PR DESCRIPTION
## Summary
- `ValidationSchema.Validate` gated all profile-tier checks behind an exact `settings.Depth == ValidationDepth.Full` comparison, so `Compatibility` depth silently skipped `ValueSetIncludeSystemCheck`, `ValueSetFilterCheck`, `CodeSystemSupplementContentCheck`, and `CodeSystemPropertyTypeCheck`.
- This forced Microsoft FHIR Server's `IgnixaResourceValidator` (which runs at `Compatibility` for Firely-SDK parity) to keep routing CodeSystem/ValueSet through a Firely fallback validator indefinitely.
- A blanket `>= Full` comparison was tried and reverted previously (regression-tested as "Bug #210-6"): it let `Compatibility` run the *entire* profile tier — FHIRPath invariants, slicing, reference resolution — which are intentionally `Full`-only.
- Fix: add a marker interface, `ICompatibilityConformanceCheck`, so only the closed-world CodeSystem/ValueSet conformance checks opt into running at both `Full` and `Compatibility`. Every other profile check stays gated to `Full` exactly as before, so the Bug #210-6 regression tests are untouched and still pass.

## Test plan
- [x] New regression tests (`CompatibilityConformanceCheckTests.cs`) confirm `vs-1` and `csc-1` issues now surface at `Compatibility` depth
- [x] Existing `ValidationDepthTests.cs` (Bug #210-6 regression coverage) still passes — Compatibility still does not run invariants/slicing/reference-resolution
- [x] `dotnet test test/Ignixa.Validation.Tests/Ignixa.Validation.Tests.csproj` — 670/670 passing (net9.0 and net10.0)
- [x] `dotnet build All.sln` — 0 errors, 0 new warnings

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)