### PR TITLE
fix(validation): recover null-valued and DomainResource-only unknown members

### DIFF
--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
@@ -258,13 +258,15 @@ public sealed class ProcedureState : ScenarioState
         }
 
         // Set outcome if provided
-        // R4/R4B/STU3/R5: 0..1 CodeableConcept (single object). R6: 0..* CodeableConcept (JSON array).
+        // R4/R4B/STU3/R5: 0..1 CodeableConcept (single object). R6: 0..* CodeableReference, whose
+        // coded value moves under "concept" (CodeableReference has no "text" of its own).
         if (!string.IsNullOrEmpty(Outcome))
         {
-            var outcomeCodeableConcept = new JsonObject { ["text"] = Outcome };
-            node["outcome"] = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R6
-                ? new JsonArray { outcomeCodeableConcept }
-                : outcomeCodeableConcept;
+            var isR6Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R6;
+            var outcomeConcept = new JsonObject { ["text"] = Outcome };
+            node["outcome"] = isR6Plus
+                ? new JsonArray { new JsonObject { ["concept"] = outcomeConcept } }
+                : outcomeConcept;
         }
 
         // Set complication if provided
@@ -280,14 +282,15 @@ public sealed class ProcedureState : ScenarioState
         }
 
         // Set follow-up if provided
+        // R4/R4B/STU3/R5: CodeableConcept[]. R6: CodeableReference[], whose coded value moves
+        // under "concept" (CodeableReference has no "text" of its own).
         if (!string.IsNullOrEmpty(FollowUp))
         {
+            var isR6Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R6;
+            var followUpConcept = new JsonObject { ["text"] = FollowUp };
             node["followUp"] = new JsonArray
             {
-                new JsonObject
-                {
-                    ["text"] = FollowUp
-                }
+                isR6Plus ? new JsonObject { ["concept"] = followUpConcept } : followUpConcept
             };
         }
 

--- a/src/Core/Ignixa.Validation/Checks/UnknownPropertyCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/UnknownPropertyCheck.cs
@@ -3,6 +3,7 @@
 //     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // </copyright>
 
+using System.Text.Json.Nodes;
 using Ignixa.Abstractions;
 using Ignixa.Validation.Abstractions;
 
@@ -17,8 +18,14 @@ namespace Ignixa.Validation.Checks;
 /// FHIR resources must only contain properties defined in their StructureDefinition.
 /// Exceptions:
 /// - Shadow properties (_propertyName) for primitive extensions
-/// - Standard extension arrays (extension, modifierExtension)
-/// - Universal resource properties (id, resourceType, meta, implicitRules, language, text, contained)
+/// - "resourceType": the JSON serialization discriminator, not a FHIR element
+/// <para>
+/// Every other Resource-level property - id, meta, implicitRules, language, text, contained,
+/// extension, modifierExtension - is validated against <c>allowedPropertyNames</c> like any other
+/// element, because <c>StructureDefinitionSchemaBuilder</c> already includes them there for every
+/// type whose own StructureDefinition actually declares them (e.g. Patient, a DomainResource, has
+/// text/contained/extension/modifierExtension; Bundle, a bare Resource, does not).
+/// </para>
 /// </remarks>
 public class UnknownPropertyCheck : IValidationCheck, ISingletonCheck
 {
@@ -27,7 +34,7 @@ public class UnknownPropertyCheck : IValidationCheck, ISingletonCheck
     private readonly string? _resourceTypeName;
     private static readonly HashSet<string> UniversalProperties = new(StringComparer.Ordinal)
     {
-        "id", "resourceType", "meta", "implicitRules", "language", "text", "contained"
+        "resourceType"
     };
 
     /// <summary>
@@ -91,10 +98,6 @@ public class UnknownPropertyCheck : IValidationCheck, ISingletonCheck
                 if (_allowedPropertyNames.Contains(mainProperty) || IsChoiceTypeProperty(mainProperty))
                     continue;
             }
-
-            // Skip standard extension arrays
-            if (property == "extension" || property == "modifierExtension")
-                continue;
 
             // Check if property is in allowed list
             if (!_allowedPropertyNames.Contains(property))
@@ -161,6 +164,22 @@ public class UnknownPropertyCheck : IValidationCheck, ISingletonCheck
             if (!string.IsNullOrEmpty(child.Name))
             {
                 properties.Add(child.Name);
+            }
+        }
+
+        // Children() omits members whose JSON value is null (JsonNodeSourceNode filters them before
+        // constructing child nodes), so a null-valued unknown member would otherwise be invisible.
+        // Recover only those - a shadow-only property (e.g. "_unknownField" with no "unknownField")
+        // is already represented above under its trimmed base name, and re-adding its literal
+        // underscore-prefixed raw key here would report it twice under two different spellings.
+        if (element.Meta<JsonNode>() is JsonObject raw)
+        {
+            foreach (var (key, value) in raw)
+            {
+                if (value is null)
+                {
+                    properties.Add(key);
+                }
             }
         }
 

--- a/src/Core/Ignixa.Validation/Checks/UnknownPropertyCheck.cs
+++ b/src/Core/Ignixa.Validation/Checks/UnknownPropertyCheck.cs
@@ -169,14 +169,14 @@ public class UnknownPropertyCheck : IValidationCheck, ISingletonCheck
 
         // Children() omits members whose JSON value is null (JsonNodeSourceNode filters them before
         // constructing child nodes), so a null-valued unknown member would otherwise be invisible.
-        // Recover only those - a shadow-only property (e.g. "_unknownField" with no "unknownField")
-        // is already represented above under its trimmed base name, and re-adding its literal
-        // underscore-prefixed raw key here would report it twice under two different spellings.
+        // Recover only those - but skip a null-valued shadow (e.g. "_unknownField") whose base name
+        // ("unknownField") is already in the set from Children(), since that's one bad property
+        // reported under two spellings, not two bad properties.
         if (element.Meta<JsonNode>() is JsonObject raw)
         {
             foreach (var (key, value) in raw)
             {
-                if (value is null)
+                if (value is null && !properties.Contains(key.TrimStart('_')))
                 {
                     properties.Add(key);
                 }

--- a/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
@@ -343,6 +343,55 @@ public class UnknownPropertyCheckTests
     }
 
     [Fact]
+    public void GivenNullValuedAllowedProperty_WhenValidating_ThenReturnsSuccess()
+    {
+        // Arrange - the null-recovery path must not flag a property that's actually allowed.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""active"": null
+        }");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
+        var check = new UnknownPropertyCheck(allowedProperties);
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void GivenUnknownPropertyWithNullValuedShadow_WhenValidating_ThenReturnsSingleError()
+    {
+        // Arrange - an unknown property carrying a null-valued shadow (e.g. a primitive-extension
+        // placeholder) is one bad element under two spellings ("bogus" and "_bogus"), not two.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""bogus"": ""value"",
+            ""_bogus"": null
+        }");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
+        var check = new UnknownPropertyCheck(allowedProperties);
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Single(result.Issues);
+        Assert.Contains("bogus", result.Issues[0].Message);
+    }
+
+    [Fact]
     public void GivenPatientWithInvalidShadowProperty_WhenValidating_ThenReturnsError()
     {
         // Arrange

--- a/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
@@ -329,7 +329,7 @@ public class UnknownPropertyCheckTests
             ""bogus"": null
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();

--- a/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
+++ b/test/Ignixa.Validation.Tests/Checks/UnknownPropertyCheckTests.cs
@@ -31,7 +31,7 @@ public class UnknownPropertyCheckTests
             ""name"": [{""family"": ""Doe""}]
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -84,7 +84,7 @@ public class UnknownPropertyCheckTests
             }]
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name" };
+        var allowedProperties = new[] { "active", "name", "extension" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -93,7 +93,7 @@ public class UnknownPropertyCheckTests
         var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
 
         // Assert
-        Assert.True(result.IsValid); // extension is always allowed
+        Assert.True(result.IsValid); // extension is allowed because it's in the StructureDefinition's own element list
         Assert.Empty(result.Issues);
     }
 
@@ -109,7 +109,7 @@ public class UnknownPropertyCheckTests
             }]
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name" };
+        var allowedProperties = new[] { "active", "name", "modifierExtension" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -118,7 +118,7 @@ public class UnknownPropertyCheckTests
         var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
 
         // Assert
-        Assert.True(result.IsValid); // modifierExtension is always allowed
+        Assert.True(result.IsValid); // modifierExtension is allowed because it's in the StructureDefinition's own element list
         Assert.Empty(result.Issues);
     }
 
@@ -141,7 +141,8 @@ public class UnknownPropertyCheckTests
             ""contained"": []
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name" };
+        // A DomainResource's own StructureDefinition includes id/meta/implicitRules/language/text/contained.
+        var allowedProperties = new[] { "id", "meta", "implicitRules", "language", "text", "contained", "active", "name" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -150,7 +151,7 @@ public class UnknownPropertyCheckTests
         var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
 
         // Assert
-        Assert.True(result.IsValid); // all universal properties allowed
+        Assert.True(result.IsValid); // all universal properties allowed because they're in the DomainResource's own element list
         Assert.Empty(result.Issues);
     }
 
@@ -169,7 +170,7 @@ public class UnknownPropertyCheckTests
             ""modifierExtension"": []
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "birthDate", "gender" };
+        var allowedProperties = new[] { "id", "meta", "active", "name", "birthDate", "gender", "extension", "modifierExtension" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -196,7 +197,7 @@ public class UnknownPropertyCheckTests
             ""unknownField"": ""value""
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -223,7 +224,7 @@ public class UnknownPropertyCheckTests
             }]
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -248,7 +249,7 @@ public class UnknownPropertyCheckTests
             }
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -275,7 +276,7 @@ public class UnknownPropertyCheckTests
             ""unknownField3"": ""value3""
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
-        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var allowedProperties = new[] { "id", "active", "name", "gender", "birthDate" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -315,6 +316,30 @@ public class UnknownPropertyCheckTests
         // Assert
         Assert.True(result.IsValid); // _birthDate is allowed because birthDate is allowed
         Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void GivenPatientWithNullValuedUnknownProperty_WhenValidating_ThenReturnsError()
+    {
+        // Arrange - GH #323: a null-valued unknown member is dropped by JsonNodeSourceNode before
+        // it ever becomes an IElement child, so it must be recovered from the raw JSON directly.
+        var json = JsonNode.Parse(@"{
+            ""resourceType"": ""Patient"",
+            ""id"": ""p1"",
+            ""bogus"": null
+        }");
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var allowedProperties = new[] { "active", "name", "gender", "birthDate" };
+        var check = new UnknownPropertyCheck(allowedProperties);
+        var settings = new ValidationSettings();
+        var state = new ValidationState();
+
+        // Act
+        var result = check.Validate(sourceNode.ToElement(TestSchemaProvider.GetR4Schema()), settings, state);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.Code == "unknown-property" && i.Message.Contains("bogus"));
     }
 
     [Fact]
@@ -369,9 +394,11 @@ public class UnknownPropertyCheckTests
     }
 
     [Fact]
-    public void GivenEmptyAllowedList_WhenValidating_ThenAllNonUniversalPropertiesFail()
+    public void GivenEmptyAllowedList_WhenValidating_ThenAllPropertiesExceptResourceTypeFail()
     {
-        // Arrange
+        // Arrange - "resourceType" is the only property this check tolerates unconditionally (it's
+        // the JSON serialization discriminator, not a FHIR element); everything else, including base
+        // Resource properties like "id", must come from the caller-supplied allowed list.
         var json = JsonNode.Parse(@"{
             ""resourceType"": ""Patient"",
             ""id"": ""123"",
@@ -388,7 +415,8 @@ public class UnknownPropertyCheckTests
 
         // Assert
         Assert.False(result.IsValid);
-        Assert.Single(result.Issues);
+        Assert.Equal(2, result.Issues.Count);
+        Assert.Contains(result.Issues, i => i.Code == "unknown-property" && i.Message.Contains("id"));
         Assert.Contains(result.Issues, i => i.Code == "unknown-property" && i.Message.Contains("active"));
     }
 
@@ -433,7 +461,7 @@ public class UnknownPropertyCheckTests
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
         // Include "value[x]" as a choice type element
-        var allowedProperties = new[] { "status", "code", "subject", "value[x]", "effective[x]" };
+        var allowedProperties = new[] { "id", "status", "code", "subject", "value[x]", "effective[x]" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();
@@ -457,7 +485,7 @@ public class UnknownPropertyCheckTests
         }");
         var sourceNode = JsonNodeSourceNode.Create(json);
         // Include "effective[x]" as a choice type element
-        var allowedProperties = new[] { "status", "code", "subject", "value[x]", "effective[x]" };
+        var allowedProperties = new[] { "id", "status", "code", "subject", "value[x]", "effective[x]" };
         var check = new UnknownPropertyCheck(allowedProperties);
         var settings = new ValidationSettings();
         var state = new ValidationState();

--- a/test/Ignixa.Validation.Tests/Schema/ResourceOnlyUniversalPropertyTests.cs
+++ b/test/Ignixa.Validation.Tests/Schema/ResourceOnlyUniversalPropertyTests.cs
@@ -51,6 +51,32 @@ public class ResourceOnlyUniversalPropertyTests
     }
 
     [Trait("Category", "Regression")]
+    [Theory]
+    [InlineData("contained", "[{\"resourceType\": \"Patient\", \"id\": \"contained1\"}]")]
+    [InlineData("extension", "[{\"url\": \"http://example.org/ext\", \"valueString\": \"x\"}]")]
+    [InlineData("modifierExtension", "[{\"url\": \"http://example.org/ext\", \"valueString\": \"x\"}]")]
+    public void GivenBundleWithDomainResourceOnlyProperty_WhenValidating_ThenReportsUnknownProperty(string propertyName, string propertyValueJson)
+    {
+        var typeDefinition = _schema.GetTypeDefinition("Bundle");
+        var schema = _builder.BuildSchema(typeDefinition!, _schema);
+
+        var json = JsonNode.Parse($$"""
+            {
+                "resourceType": "Bundle",
+                "id": "b1",
+                "type": "collection",
+                "{{propertyName}}": {{propertyValueJson}}
+            }
+            """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+
+        var result = schema.Validate(element, new ValidationSettings { Depth = ValidationDepth.Spec });
+
+        result.Issues.ShouldContain(i => i.Code == "unknown-property" && i.Message.Contains(propertyName));
+    }
+
+    [Trait("Category", "Regression")]
     [Fact]
     public void GivenPatientWithText_WhenValidating_ThenAllowed()
     {

--- a/test/Ignixa.Validation.Tests/Schema/ResourceOnlyUniversalPropertyTests.cs
+++ b/test/Ignixa.Validation.Tests/Schema/ResourceOnlyUniversalPropertyTests.cs
@@ -1,0 +1,75 @@
+// <copyright file="ResourceOnlyUniversalPropertyTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+//     Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// </copyright>
+
+using System.Text.Json.Nodes;
+using Ignixa.Abstractions;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification;
+using Ignixa.Specification.Generated;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Schema;
+using Ignixa.Validation.Tests.TestHelpers;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Validation.Tests.Schema;
+
+/// <summary>
+/// Regression tests for GH #323: <see cref="Ignixa.Validation.Checks.UnknownPropertyCheck"/> used to
+/// universally permit <c>text</c>, <c>contained</c>, <c>extension</c>, and <c>modifierExtension</c> for
+/// every resource type, even a bare <see cref="Resource"/> like <c>Bundle</c> that is not a
+/// <c>DomainResource</c> and has none of those elements in its own StructureDefinition metadata.
+/// </summary>
+public class ResourceOnlyUniversalPropertyTests
+{
+    private readonly ISchema _schema = new R4CoreSchemaProvider();
+    private readonly StructureDefinitionSchemaBuilder _builder = new();
+
+    [Trait("Category", "Regression")]
+    [Fact]
+    public void GivenBundleWithDomainResourceOnlyText_WhenValidating_ThenReportsUnknownProperty()
+    {
+        var typeDefinition = _schema.GetTypeDefinition("Bundle");
+        var schema = _builder.BuildSchema(typeDefinition!, _schema);
+
+        var json = JsonNode.Parse("""
+            {
+                "resourceType": "Bundle",
+                "id": "b1",
+                "type": "collection",
+                "text": { "status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">x</div>" }
+            }
+            """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+
+        var result = schema.Validate(element, new ValidationSettings { Depth = ValidationDepth.Spec });
+
+        result.Issues.ShouldContain(i => i.Code == "unknown-property" && i.Message.Contains("text"));
+    }
+
+    [Trait("Category", "Regression")]
+    [Fact]
+    public void GivenPatientWithText_WhenValidating_ThenAllowed()
+    {
+        // Sanity guard: Patient IS a DomainResource, so `text` must remain legal there.
+        var typeDefinition = _schema.GetTypeDefinition("Patient");
+        var schema = _builder.BuildSchema(typeDefinition!, _schema);
+
+        var json = JsonNode.Parse("""
+            {
+                "resourceType": "Patient",
+                "id": "p1",
+                "text": { "status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">x</div>" }
+            }
+            """);
+        var sourceNode = JsonNodeSourceNode.Create(json);
+        var element = sourceNode.ToElement(TestSchemaProvider.GetR4Schema());
+
+        var result = schema.Validate(element, new ValidationSettings { Depth = ValidationDepth.Spec });
+
+        result.Issues.ShouldNotContain(i => i.Code == "unknown-property");
+    }
+}


### PR DESCRIPTION
## Summary
Part 1/2 of GH #323 (recursive structural-member validation for `ResourceJsonNode`) - covers 2 of the 4 reproduction scenarios in that issue, scoped as a standalone fix inside the existing `Ignixa.Validation` architecture (no parallel validation stack).

- **Null-valued unknown members were invisible.** `UnknownPropertyCheck.GetAllPropertyNames` only enumerated `IElement.Children()`, but `JsonNodeSourceNode` never constructs a child node for a JSON member whose value is a literal `null` (`ProcessObjectProperties` filters them). So `{"bogus": null}` on any resource silently passed. Fixed by unioning in null-valued keys directly from the element's own raw JSON (`element.Meta<JsonNode>()`) - scoped to *only* null-valued keys, not all raw keys, because a shadow-only property (e.g. `"_unknownField"` with no `"unknownField"`) is already represented under its trimmed base name by `Children()`, and re-adding its literal underscore-prefixed raw key would double-report it.
- **Bundle (and any bare `Resource`) accepted `DomainResource`-only members.** `UnknownPropertyCheck` hardcoded `id/meta/implicitRules/language/text/contained/extension/modifierExtension` as universally allowed, so `Bundle.text`, `Bundle.contained`, `Bundle.extension` etc. passed even though Bundle's own StructureDefinition doesn't declare them. Verified against the generated schema that every type which legitimately has these elements already carries them in its own metadata-driven `allowedPropertyNames` (Patient does; Bundle doesn't) - so the only property that still needs unconditional allowance is `"resourceType"` itself (the JSON discriminator, not a FHIR element). Removed the rest of the hardcoded list.

Nested/choice-variant recursion into closed datatypes (Reference/CodeableConcept/Coding) and dynamic `resourceType` dispatch for Bundle entries/Parameters remain as follow-up work (tracked separately, ADR-2607 already lists the recursion gap).

## Test plan
- [x] New regression tests: null-valued unknown member (`UnknownPropertyCheckTests`), Bundle rejecting `text` while Patient still allows it (`ResourceOnlyUniversalPropertyTests`)
- [x] Updated existing `UnknownPropertyCheckTests` that previously relied on the removed hardcoded leniency to instead supply realistic, StructureDefinition-shaped allowed-property lists (matching what `StructureDefinitionSchemaBuilder` actually passes in production)
- [x] `dotnet test test/Ignixa.Validation.Tests/Ignixa.Validation.Tests.csproj` - 673/673 passing (net9.0 and net10.0), including the existing zero-over-strict conformance suite
- [x] `dotnet test test/Ignixa.Application.Tests` - 695/696 passing (1 pre-existing unrelated skip)
- [x] `dotnet test test/Ignixa.Api.Tests` - 114/114 passing
- [x] `dotnet build All.sln` - 0 errors, 0 new warnings

Part of #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)