### PR TITLE
fix(fhirfakes): correct R5/R6 CodeableReference shapes for Procedure.complication and CarePlan.addresses

### DIFF
--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/CarePlanState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/CarePlanState.cs
@@ -234,16 +234,17 @@ public sealed class CarePlanState : ScenarioState
         }
 
         // Set addresses (related conditions)
+        // R4: Reference(Condition)[]. R5+: CodeableReference(Condition)[], whose reference value
+        // moves under "reference" - a Reference object, not a bare reference string.
         if (!string.IsNullOrEmpty(RelatedConditionAttribute) &&
             context.HasAttribute(RelatedConditionAttribute))
         {
             var conditionId = context.GetAttribute<string>(RelatedConditionAttribute);
+            var conditionReference = new JsonObject { ["reference"] = $"Condition/{conditionId}" };
+            var isR5Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R5;
             node["addresses"] = new JsonArray
             {
-                new JsonObject
-                {
-                    ["reference"] = $"Condition/{conditionId}"
-                }
+                isR5Plus ? new JsonObject { ["reference"] = conditionReference } : conditionReference
             };
         }
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/CarePlanState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/CarePlanState.cs
@@ -234,14 +234,14 @@ public sealed class CarePlanState : ScenarioState
         }
 
         // Set addresses (related conditions)
-        // R4: Reference(Condition)[]. R5+: CodeableReference(Condition)[], whose reference value
-        // moves under "reference" - a Reference object, not a bare reference string.
+        // R4/R4B/STU3: Reference(Condition)[]. R5+: CodeableReference(Condition)[], whose reference
+        // value moves under "reference" - a Reference object, not a bare reference string.
         if (!string.IsNullOrEmpty(RelatedConditionAttribute) &&
             context.HasAttribute(RelatedConditionAttribute))
         {
             var conditionId = context.GetAttribute<string>(RelatedConditionAttribute);
             var conditionReference = new JsonObject { ["reference"] = $"Condition/{conditionId}" };
-            var isR5Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R5;
+            var isR5Plus = faker.SchemaProvider.IsR5OrLater();
             node["addresses"] = new JsonArray
             {
                 isR5Plus ? new JsonObject { ["reference"] = conditionReference } : conditionReference

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
@@ -270,14 +270,15 @@ public sealed class ProcedureState : ScenarioState
         }
 
         // Set complication if provided
+        // R4: CodeableConcept[]. R5+: CodeableReference[], whose coded value moves under "concept"
+        // (CodeableReference has no "text" of its own). Note this boundary is R5, not R6.
         if (!string.IsNullOrEmpty(Complication))
         {
+            var isR5Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R5;
+            var complicationConcept = new JsonObject { ["text"] = Complication };
             node["complication"] = new JsonArray
             {
-                new JsonObject
-                {
-                    ["text"] = Complication
-                }
+                isR5Plus ? new JsonObject { ["concept"] = complicationConcept } : complicationConcept
             };
         }
 

--- a/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
+++ b/src/Core/Ignixa.FhirFakes/Scenarios/States/ProcedureState.cs
@@ -270,11 +270,11 @@ public sealed class ProcedureState : ScenarioState
         }
 
         // Set complication if provided
-        // R4: CodeableConcept[]. R5+: CodeableReference[], whose coded value moves under "concept"
-        // (CodeableReference has no "text" of its own). Note this boundary is R5, not R6.
+        // R4/R4B/STU3: CodeableConcept[]. R5+: CodeableReference[], whose coded value moves under
+        // "concept" (CodeableReference has no "text" of its own). Note this boundary is R5, not R6.
         if (!string.IsNullOrEmpty(Complication))
         {
-            var isR5Plus = faker.SchemaProvider.Version >= Ignixa.Abstractions.FhirVersion.R5;
+            var isR5Plus = faker.SchemaProvider.IsR5OrLater();
             var complicationConcept = new JsonObject { ["text"] = Complication };
             node["complication"] = new JsonArray
             {

--- a/test/Ignixa.FhirFakes.Tests/R5R6ShapeRegressionTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/R5R6ShapeRegressionTests.cs
@@ -12,6 +12,9 @@ using Ignixa.FhirFakes.Scenarios.States;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification;
 using Ignixa.Specification.Generated;
+using Ignixa.Validation;
+using Ignixa.Validation.Abstractions;
+using Ignixa.Validation.Schema;
 using Xunit.Abstractions;
 using FhirCode = Ignixa.FhirFakes.Scenarios.Codes.FhirCode;
 using Ignixa.Serialization.TestSupport;
@@ -382,7 +385,8 @@ public class R5R6ShapeRegressionTests
                 })
                 .Build();
 
-            var complication = scenario.Procedures[0].MutableNode()["complication"]?[0];
+            var procedureNode = scenario.Procedures[0].MutableNode();
+            var complication = procedureNode["complication"]?[0];
             complication.ShouldNotBeNull($"complication should exist in {schema.Version}");
 
             // R5 changed Procedure.complication from CodeableConcept to CodeableReference: the
@@ -399,6 +403,58 @@ public class R5R6ShapeRegressionTests
                 complication!["text"]?.GetValue<string>()
                     .ShouldBe("Post-operative bleeding", $"complication text should be direct in {schema.Version}");
             }
+
+            AssertNoValidationErrors(procedureNode, schema);
+        }
+    }
+
+    [Fact]
+    public void GivenProcedureWithOutcomeAndFollowUp_WhenGeneratedAcrossAllVersions_ThenUsesVersionCorrectShape()
+    {
+        foreach (var schema in _schemaProviders)
+        {
+            _output.WriteLine($"Testing Procedure.outcome/followUp with {schema.Version}");
+
+            var scenario = new ScenarioBuilder(schema)
+                .WithPatient()
+                .AddEncounter("Surgery")
+                .AddProcedure(new ProcedureState
+                {
+                    Name = "Outcome_Procedure",
+                    Code = Procedures.CABG,
+                    Outcome = "Successful",
+                    FollowUp = "Return in 2 weeks"
+                })
+                .Build();
+
+            var procedureNode = scenario.Procedures[0].MutableNode();
+            // Pre-R6, outcome is 0..1 (a single object, not an array); followUp has always been 0..*.
+            var outcome = schema.Version >= FhirVersion.R6 ? procedureNode["outcome"]?[0] : procedureNode["outcome"];
+            var followUp = procedureNode["followUp"]?[0];
+            outcome.ShouldNotBeNull($"outcome should exist in {schema.Version}");
+            followUp.ShouldNotBeNull($"followUp should exist in {schema.Version}");
+
+            // R6 changed both Procedure.outcome and Procedure.followUp from CodeableConcept to
+            // CodeableReference: the coded value moves from .text directly to .concept.text. Note
+            // this boundary is R6, unlike Procedure.complication which switches at R5.
+            if (schema.Version >= FhirVersion.R6)
+            {
+                outcome!["text"].ShouldBeNull($"{schema.Version} CodeableReference has no direct '.text'");
+                outcome["concept"]?["text"]?.GetValue<string>()
+                    .ShouldBe("Successful", $"outcome text should be under concept.text in {schema.Version}");
+                followUp!["text"].ShouldBeNull($"{schema.Version} CodeableReference has no direct '.text'");
+                followUp["concept"]?["text"]?.GetValue<string>()
+                    .ShouldBe("Return in 2 weeks", $"followUp text should be under concept.text in {schema.Version}");
+            }
+            else
+            {
+                outcome!["text"]?.GetValue<string>()
+                    .ShouldBe("Successful", $"outcome text should be direct in {schema.Version}");
+                followUp!["text"]?.GetValue<string>()
+                    .ShouldBe("Return in 2 weeks", $"followUp text should be direct in {schema.Version}");
+            }
+
+            AssertNoValidationErrors(procedureNode, schema);
         }
     }
 
@@ -421,7 +477,8 @@ public class R5R6ShapeRegressionTests
                 .Build();
 
             var conditionId = scenario.Conditions[0].Id;
-            var addresses = scenario.CarePlans[0].MutableNode()["addresses"]?[0];
+            var carePlanNode = scenario.CarePlans[0].MutableNode();
+            var addresses = carePlanNode["addresses"]?[0];
             addresses.ShouldNotBeNull($"addresses should exist in {schema.Version}");
 
             // R5 changed CarePlan.addresses from Reference to CodeableReference: the reference
@@ -432,15 +489,25 @@ public class R5R6ShapeRegressionTests
                 addresses!["reference"].ShouldNotBeNull($"{schema.Version} CodeableReference wraps 'reference'");
                 var reference = addresses["reference"]?["reference"]?.GetValue<string>();
                 // KNOWN GAP (see the MedicationRequest/Procedure reason tests above): the generated
-                // reference metadata has no entry for R5+'s CodeableReference-typed fields, so
-                // ReferenceRewriterService never rewrites this nested reference to urn:uuid. This
-                // asserts the current, unrewritten value rather than papering over the inconsistency.
+                // reference metadata has a "CarePlan.addresses" entry in STU3/R4/R4B, but it was
+                // dropped entirely in R5/R6 (verified against *ReferenceMetadata.g.cs) rather than
+                // updated for the new CodeableReference nesting, so ReferenceRewriterService never
+                // rewrites this nested reference to urn:uuid in R5+. This asserts the current,
+                // unrewritten value rather than papering over the inconsistency.
                 reference.ShouldBe($"Condition/{conditionId}", $"addresses.reference.reference in {schema.Version} (unrewritten — see comment above)");
             }
             else
             {
                 var reference = addresses!["reference"]?.GetValue<string>();
                 reference.ShouldBe($"urn:uuid:{conditionId}", $"addresses.reference should point at the condition in {schema.Version}");
+            }
+
+            // Only validated for R5+, where this PR's fix applies. Pre-R5 CarePlan generation has
+            // an unrelated, pre-existing issue (CarePlan.created isn't defined in STU3) that's out
+            // of scope here.
+            if (schema.Version >= FhirVersion.R5)
+            {
+                AssertNoValidationErrors(carePlanNode, schema);
             }
         }
     }
@@ -493,5 +560,25 @@ public class R5R6ShapeRegressionTests
             var expected = schema.Version >= FhirVersion.R5 ? "on-hold" : "onleave";
             status.ShouldBe(expected, $"status should be '{expected}' in {schema.Version}");
         }
+    }
+
+    private static void AssertNoValidationErrors(JsonNode resourceNode, IFhirSchemaProvider schemaProvider)
+    {
+        var sourceNode = JsonNodeSourceNode.Create(resourceNode);
+        var resourceType = sourceNode.ResourceType ?? sourceNode.Name;
+        var canonicalUrl = $"http://hl7.org/fhir/StructureDefinition/{resourceType}";
+        var resolver = new CachedValidationSchemaResolver(new StructureDefinitionSchemaResolver(schemaProvider));
+        var schema = resolver.GetSchema(canonicalUrl);
+        schema.ShouldNotBeNull($"no schema found for resource type '{resourceType}' in {schemaProvider.Version}");
+
+        var settings = new ValidationSettings { Depth = ValidationDepth.Spec };
+        var element = sourceNode.ToElement(schemaProvider);
+        var result = schema!.Validate(element, settings, new ValidationState());
+
+        var errors = result.Issues
+            .Where(i => i.Severity is IssueSeverity.Error or IssueSeverity.Fatal)
+            .Select(i => $"@{i.Path}: {i.Message}")
+            .ToList();
+        errors.ShouldBeEmpty($"{resourceType} should pass schema validation in {schemaProvider.Version}, but got: {string.Join("; ", errors)}");
     }
 }

--- a/test/Ignixa.FhirFakes.Tests/R5R6ShapeRegressionTests.cs
+++ b/test/Ignixa.FhirFakes.Tests/R5R6ShapeRegressionTests.cs
@@ -364,6 +364,87 @@ public class R5R6ShapeRegressionTests
         }
     }
 
+    [Fact]
+    public void GivenProcedureWithComplication_WhenGeneratedAcrossAllVersions_ThenUsesVersionCorrectComplicationShape()
+    {
+        foreach (var schema in _schemaProviders)
+        {
+            _output.WriteLine($"Testing Procedure.complication with {schema.Version}");
+
+            var scenario = new ScenarioBuilder(schema)
+                .WithPatient()
+                .AddEncounter("Surgery")
+                .AddProcedure(new ProcedureState
+                {
+                    Name = "Complicated_Procedure",
+                    Code = Procedures.CABG,
+                    Complication = "Post-operative bleeding"
+                })
+                .Build();
+
+            var complication = scenario.Procedures[0].MutableNode()["complication"]?[0];
+            complication.ShouldNotBeNull($"complication should exist in {schema.Version}");
+
+            // R5 changed Procedure.complication from CodeableConcept to CodeableReference: the
+            // coded value moves from .text directly to .concept.text. Note this boundary is R5,
+            // unlike Procedure.outcome/followUp which don't switch until R6.
+            if (schema.Version >= FhirVersion.R5)
+            {
+                complication!["text"].ShouldBeNull($"{schema.Version} CodeableReference has no direct '.text'");
+                complication["concept"]?["text"]?.GetValue<string>()
+                    .ShouldBe("Post-operative bleeding", $"complication text should be under concept.text in {schema.Version}");
+            }
+            else
+            {
+                complication!["text"]?.GetValue<string>()
+                    .ShouldBe("Post-operative bleeding", $"complication text should be direct in {schema.Version}");
+            }
+        }
+    }
+
+    [Fact]
+    public void GivenCarePlanWithRelatedCondition_WhenGeneratedAcrossAllVersions_ThenUsesVersionCorrectAddressesShape()
+    {
+        foreach (var schema in _schemaProviders)
+        {
+            _output.WriteLine($"Testing CarePlan.addresses with {schema.Version}");
+
+            var scenario = new ScenarioBuilder(schema)
+                .WithPatient()
+                .AddConditionOnset(FhirCode.Conditions.DiabetesType2, assignToAttribute: "care_plan_condition")
+                .AddCarePlan(new CarePlanState
+                {
+                    Name = "Conditioned_CarePlan",
+                    Title = "Diabetes Management",
+                    RelatedConditionAttribute = "care_plan_condition"
+                })
+                .Build();
+
+            var conditionId = scenario.Conditions[0].Id;
+            var addresses = scenario.CarePlans[0].MutableNode()["addresses"]?[0];
+            addresses.ShouldNotBeNull($"addresses should exist in {schema.Version}");
+
+            // R5 changed CarePlan.addresses from Reference to CodeableReference: the reference
+            // value moves under a nested "reference" object rather than sitting directly on the
+            // array entry.
+            if (schema.Version >= FhirVersion.R5)
+            {
+                addresses!["reference"].ShouldNotBeNull($"{schema.Version} CodeableReference wraps 'reference'");
+                var reference = addresses["reference"]?["reference"]?.GetValue<string>();
+                // KNOWN GAP (see the MedicationRequest/Procedure reason tests above): the generated
+                // reference metadata has no entry for R5+'s CodeableReference-typed fields, so
+                // ReferenceRewriterService never rewrites this nested reference to urn:uuid. This
+                // asserts the current, unrewritten value rather than papering over the inconsistency.
+                reference.ShouldBe($"Condition/{conditionId}", $"addresses.reference.reference in {schema.Version} (unrewritten — see comment above)");
+            }
+            else
+            {
+                var reference = addresses!["reference"]?.GetValue<string>();
+                reference.ShouldBe($"urn:uuid:{conditionId}", $"addresses.reference should point at the condition in {schema.Version}");
+            }
+        }
+    }
+
     [Theory]
     [InlineData("arrived")]
     [InlineData("triaged")]


### PR DESCRIPTION
## Summary
Follow-up to #329's principal-tier sign-off review, which flagged two latent instances of the same CodeableConcept/Reference → CodeableReference migration bug that PR #329 fixed for `Procedure.outcome`/`followUp`:

- `Procedure.complication` switches to `CodeableReference` at **R5** (not R6 like `outcome`/`followUp`), and was still emitting a bare `{"text": ...}` object instead of wrapping it under `.concept.text`.
- `CarePlan.addresses` switches from `Reference` to `CodeableReference` at R5, and was still emitting a bare `{"reference": "Condition/x"}` instead of wrapping it under a nested `reference` object.

Both were unexercised by any factory method or test before now (`Complication` and `RelatedConditionAttribute` were never set anywhere in the codebase), so neither was caught even by the R6 CI failure the #329 PR chain surfaced and fixed.

## Test plan
- [x] Added `GivenProcedureWithComplication_WhenGeneratedAcrossAllVersions_ThenUsesVersionCorrectComplicationShape` and `GivenCarePlanWithRelatedCondition_WhenGeneratedAcrossAllVersions_ThenUsesVersionCorrectAddressesShape` in `R5R6ShapeRegressionTests.cs`, mirroring the existing `Procedure.reason` shape-assertion pattern (including the documented "known gap" where R5+ CodeableReference fields aren't rewritten to `urn:uuid` by `ReferenceRewriterService`, unlike pre-R5 flat `Reference` fields).
- [x] `dotnet test test/Ignixa.FhirFakes.Tests/Ignixa.FhirFakes.Tests.csproj` — 1427/1427 passing (net9.0 and net10.0)
- [x] `dotnet build All.sln` — 0 errors, 0 new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)