### PR TITLE
feat(testscript): waitFor operation extension for polling async jobs

### DIFF
--- a/docs/features/testscript/investigations/async-job-polling.md
+++ b/docs/features/testscript/investigations/async-job-polling.md
@@ -1,0 +1,67 @@
+# Investigation: Async Job Polling Assertions
+
+**Feature**: testscript
+**Status**: In Progress
+**Created**: 2026-07-11
+
+## Approach
+
+FHIR TestScript has no native concept of a long-running operation. Every `operation`/`assert` pair is
+synchronous request-response. That's a real gap for testing `$export`, `$import`, and (once built)
+`$reindex`, all of which return `202 Accepted` + `Content-Location` immediately and require polling a
+status endpoint until the job reaches a terminal state — exactly the `WaitForJobCompletionAsync` pattern
+`microsoft/fhir-server`'s C# E2E tests hand-roll per call site (see
+[`ReindexTests.cs`](https://github.com/microsoft/fhir-server/blob/main/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs)).
+
+Proposed: a new operation-level custom extension, `http://ignixa.io/testscript/waitFor`, following the
+same pattern already established by `assertionAnyOfGroup` / `assertionWhenResponseStatus`
+(ADR 2607) — parse into a typed condition on `OperationExpression`, evaluate it as a loop in
+`TestScriptEvaluator.VisitOperationAsync`.
+
+**Extension shape** (child extensions, same style as `assertionWhenResponseStatus`):
+
+| Child | Type | Meaning |
+|---|---|---|
+| `sourceId` | valueString | Optional. Poll the URL from an earlier response's `Content-Location` header (the `$export`/`$import` kickoff response), instead of the operation's own `url`/`params`. |
+| `statusPath` | valueString | Path to the status field in the polled response body. Default `status` — both `GetJobStatusResult`-backed export/import status bodies expose a top-level `status` string (`ExportEndpoints.cs:360-395`, `ImportEndpoints.cs:206-281`). |
+| `terminalStatus` | valueString (repeatable) | Statuses that stop polling, e.g. `Completed`, `Failed`, `Cancelled`. |
+| `maxAttempts` | valueInteger | Default ~60. |
+| `intervalMs` | valueInteger | Default ~1000. |
+
+**Evaluator change**: `VisitOperationAsync` gains a branch — if the operation carries a `WaitFor`
+condition, resolve the polling URL once (from `sourceId`'s stored `Content-Location`/`Location` header,
+via the same `context.ResponseHistory` lookup `ResolveAssertionResponse` already uses), then loop:
+`GET`, extract status, compare to `terminalStatus`, sleep `intervalMs` (cooperating with
+`cancellationToken`) if not terminal and attempts remain. Store the final response under the operation's
+`responseId` exactly as today, so downstream `assert` actions work unmodified. On attempt exhaustion,
+record an `OperationOutcome` failure ("timed out waiting for job completion after N attempts") through
+the existing recorder — no new reporting plumbing needed.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Reuses the exact extension-parsing pattern already proven and merged for `assertionAnyOfGroup`/`assertionWhenResponseStatus` (PR #330) — reviewers already know the shape | Status body isn't a FHIR resource (it's a Bulk-Data-flavored ad hoc JSON), so `statusPath` can't reuse the FHIRPath-over-typed-element machinery (`element.ToElement(schemaProvider)`) that every other assertion uses — needs a raw-JSON-pointer style extractor, a genuinely new code path |
+| Keeps `operation`/`assert` actions unchanged downstream — the rest of the test just sees a normal completed response | `$reindex` isn't implemented server-side yet (`BackgroundJobType.Reindex` is a placeholder enum value, no endpoint) — this investigation can only be validated end-to-end against `$export`/`$import` today |
+| No new fixture/provider abstraction required — reuses `ITestRequestProvider` as-is | No existing polling helper anywhere in the C# test suite to crib from (`grep` for `WaitForJob*`/`PollUntil*` across `test/` = 0 hits) — this is genuinely greenfield design, not a port of an existing internal pattern |
+| Generic across any 202+Content-Location job, not just reindex | Polling inside a single `operation` action call blocks that action's execution for up to `maxAttempts * intervalMs` — needs a sane default ceiling so a hung server doesn't hang the whole TestScript run past normal CI timeouts |
+
+## Alignment
+
+- [x] Follows architectural layering rules — stays entirely inside `Ignixa.TestScript` (Core), no `Ignixa.Api`/`Hl7.Fhir.*` dependency introduced
+- [x] Developer Experience — a TestScript author writes one extension block, gets retry-until-terminal for free; no C# code needed
+- [ ] Specification compliance — this is explicitly outside FHIR TestScript's spec (no such primitive exists); must be clearly documented as an Ignixa custom extension, same disclaimer as ADR 2607's other extensions
+- [x] Consistent with existing patterns — mirrors `assertionWhenResponseStatus`'s extension-tree parsing exactly (`TestScriptParser.cs` `ParseResponseStatusCondition`-style child-extension walk)
+
+## Evidence
+
+- `$export` kickoff: `src/Application/Ignixa.Api/Endpoints/ExportEndpoints.cs:28-45` — `POST /$export` (and tenant/Group variants), returns `Results.Accepted(statusUrl, { jobId, status: "queued" })` with `Content-Location` set (~line 200/320).
+- `$export` status: `GET /tenant/{tenantId}/_export/{jobId}` — `ExportEndpoints.cs:40,341-401`, backed by `GetJobStatusQuery` (`src/Application/Ignixa.Application.BackgroundOperations/Jobs/GetJobStatusQuery.cs:14-30`) — `JobType` is a plain string, not a shared enum, so `$reindex` support would slot in the same way once it exists.
+- `$import` mirrors `$export` exactly: `src/Application/Ignixa.Api/Endpoints/ImportEndpoints.cs:33-42` (kickoff), `:37,179-287` (status), `:206-281` (response body shape).
+- `$reindex` does not exist server-side: no endpoint under `src/Application/Ignixa.Api/Endpoints`; `BackgroundJobType.Reindex = 4` is a forward-declared enum value only (`src/Application/Ignixa.Domain/Models/BackgroundJobType.cs:37`). `docs/features/reindex/readme.md` has picked DurableTask orchestration (same pattern as export/import) but implementation hasn't started.
+- `TestScriptParser.cs:387` reads `type.code` as a free string with no whitelist — no parser change needed to accept an operation `type` of `$export`/`$reindex`; only Evaluator-side handling is missing.
+- No existing async-job polling test helper anywhere in `test/` (checked `WaitForJob*`, `PollUntil*`, `_export/`, `_import/`, `GetExportStatus`, `GetImportStatus` — zero hits); `test/Ignixa.Api.E2ETests` has no export/import tests yet either.
+
+## Verdict
+
+*Pending evaluation.* Viable pattern, consistent with the recently-merged extension precedent, but two things should be resolved before committing to an ADR: (1) how `statusPath` extracts from a non-FHIR-resource JSON body without a parallel raw-JSON evaluator, and (2) whether this is worth building against `$export`/`$import` now or should wait until `$reindex` actually exists, since reindex was the motivating example.

--- a/docs/features/testscript/investigations/async-job-polling.md
+++ b/docs/features/testscript/investigations/async-job-polling.md
@@ -1,7 +1,7 @@
 # Investigation: Async Job Polling Assertions
 
 **Feature**: testscript
-**Status**: In Progress
+**Status**: Superseded
 **Created**: 2026-07-11
 
 ## Approach
@@ -63,5 +63,7 @@ the existing recorder — no new reporting plumbing needed.
 - No existing async-job polling test helper anywhere in `test/` (checked `WaitForJob*`, `PollUntil*`, `_export/`, `_import/`, `GetExportStatus`, `GetImportStatus` — zero hits); `test/Ignixa.Api.E2ETests` has no export/import tests yet either.
 
 ## Verdict
+
+**Superseded** — the actual implementation (see [design spec](../../../superpowers/specs/2026-07-11-testscript-waitfor-operation-design.md)) took a simpler approach: polling keys off the response's HTTP status code directly rather than a body `statusPath`, and the polling URL comes from TestScript's existing header-extraction `variable` mechanism rather than a new `sourceId`-based lookup. Both simplifications avoid problems this investigation raised (the non-FHIR-resource body, and duplicating existing variable-extraction logic). The rest of this document is retained as historical record of the alternatives considered.
 
 *Pending evaluation.* Viable pattern, consistent with the recently-merged extension precedent, but two things should be resolved before committing to an ADR: (1) how `statusPath` extracts from a non-FHIR-resource JSON body without a parallel raw-JSON evaluator, and (2) whether this is worth building against `$export`/`$import` now or should wait until `$reindex` actually exists, since reindex was the motivating example.

--- a/docs/features/testscript/investigations/subscription-callback-verification.md
+++ b/docs/features/testscript/investigations/subscription-callback-verification.md
@@ -1,0 +1,67 @@
+# Investigation: Subscription Callback Verification
+
+**Feature**: testscript
+**Status**: In Progress
+**Created**: 2026-07-11
+
+## Approach
+
+FHIR TestScript is pure request/response — there is no spec primitive for "wait for an inbound
+notification" (confirmed against the actual model, not just spec reading: `OperationExpression` and
+`AssertExpression` in `Ignixa.TestScript` are entirely outbound-request-shaped; zero
+callback/webhook/notification hits anywhere in `src/Core/Ignixa.TestScript`). Testing rest-hook
+subscription delivery needs something outside that model entirely, on two tracks:
+
+**Track A — mock rest-hook receiver as a TestScript fixture.** Add a new fixture provider,
+`ITestCallbackReceiver`, that spins up an in-process HTTP listener (Kestrel `WebApplication` or a
+lightweight `HttpListener`, matching the DI-injected-provider style `IFixtureProvider`/
+`ITestRequestProvider` already use) exposing a base URL a TestScript can reference as a
+`Subscription.channel.endpoint`. It records every inbound POST (body + headers) keyed by a
+correlation value (e.g. the subscription id or a header the test sets).
+
+**Track B — a new assertion extension to query it.** `http://ignixa.io/testscript/assertionCallbackReceived`,
+reusing the polling primitive from [async-job-polling](async-job-polling.md): poll the receiver's captured
+requests for one matching a FHIRPath predicate (e.g. `header.value = '${subscriptionId}'`) within
+`maxAttempts * intervalMs`, pass/fail like any other assertion. Unlike Track A's job-status polling this
+polls in-memory state, not HTTP, so it's cheaper and doesn't need the raw-JSON-vs-FHIRPath problem noted
+in that investigation — the captured body is a real FHIR resource (the delivered payload) and can go
+through the normal `element.ToElement(schemaProvider)` path.
+
+**Longer term**, once Subscriptions is actually implemented (`ISubscriptionChannel`/`RestHookChannel` per
+the existing design docs), the cleaner seam is having the test harness register an in-process channel
+implementation directly — no real HTTP round-trip needed — mirroring how `ITestRequestProvider` already
+supports in-process execution for the FHIR server itself. That's strictly better than Track A once it's
+available, but Track A is what's buildable *today* since subscriptions delivery doesn't exist yet.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Track A/B are independently useful even without Subscriptions being built — any future feature that does outbound webhook-style delivery gets a reusable test receiver | Building `ITestCallbackReceiver` now is pure speculation: Subscriptions has no ADR yet (status is "Investigation Complete", explicitly "no ADR yet"), so there's real risk designing a receiver against an `ISubscriptionChannel` shape that doesn't exist yet |
+| `assertionCallbackReceived` reuses the polling mechanism from the async-job investigation rather than inventing a second one | This is two new pieces of infrastructure (a receiver + an assertion extension) for a feature that's still pre-implementation — against this project's own YAGNI guidance, this is arguably premature |
+| The in-process-channel version (long-term option) avoids real network sockets in tests entirely, which is faster and avoids port-binding flakiness in CI | No existing mock-webhook test infra to build on at all — `grep -r "WireMock"` = 0 hits, the only `HttpListener` usage in the whole repo is an unrelated CLI report viewer |
+| Keeps callback testing inside the same TestScript authoring model developers already use for CRUD tests | Even with a receiver + assertion built, this only tests *that Ignixa POSTed something* — verifying content correctness, retry/backoff behavior, and channel error handling likely still needs targeted C# integration tests, not TestScript |
+
+## Alignment
+
+- [ ] Follows architectural layering rules — `ITestCallbackReceiver` would live in `Ignixa.TestScript` (Core), fine, but it has no consumer yet since Subscriptions isn't implemented — can't fully validate the layering until there's a real channel to plug into
+- [x] Developer Experience — if built, authoring a subscription-delivery test would look like any other TestScript test
+- [ ] Specification compliance — same as the async-job investigation, this is 100% a custom Ignixa extension; TestScript has no spec answer here at all
+- [ ] Consistent with existing patterns — partially: the assertion-extension half matches ADR 2607 precedent, but the receiver-fixture half has no existing analog to compare against
+
+## Evidence
+
+- Subscriptions status: `docs/features/subscriptions/readme.md:3,27` — "Investigation Complete", "No ADR yet - implementation planning based on research findings." Design docs (`subscription-engine.md`, `transaction-table.md`, ~1900 lines combined) are illustrative pseudocode referencing a legacy Microsoft implementation and `fhir-candle`, not Ignixa source — `grep -r "Subscription"` under `src/` only hits generated FHIR model/schema files, no channel/sender classes exist.
+- Roadmap placement: `subscription-engine.md:1165` targets "Phase 23"; `transaction-table.md:850-866` targets "Phase 7/12" — well beyond current repo state.
+- No mock webhook receiver infra exists: only `HttpListener` usage repo-wide is `test/Ignixa.Tests.Compatibility.CLI/TestResultsViewerCommand.cs:65,94,111,121`, an HTML test-report viewer, unrelated. Zero `WireMock` references.
+- Confirmed no callback primitive in the TestScript model itself: `src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs` fields are entirely outbound (`Type`, `Url`, `Params`, `Method`, `Headers`); `AssertExpression`/`AssertCriteria`/`AssertOperator` only assert against the last in-context response. `grep` for callback/webhook/notification/inbound across `src/Core/Ignixa.TestScript` = 0 hits.
+- No Subscriptions ADR: `docs/adr/*.md` (23 files) has none named `*subscription*`. The investigation doc header references "Original ADR: 2600" (`subscription-engine.md:6`) but `adr-2600-*.md` doesn't exist — reserved/placeholder number only. Closest implemented ADR is `adr-2607-testscript-extensions.md`, which documents today's extension points (`parametrize`, `fhirVersions`, `requiresCapability`, fhirfakes generation) — none touch async/callback testing.
+
+## Verdict
+
+*Pending evaluation — recommend deferring implementation.* The assertion-extension half (Track B) is
+low-risk and reuses established patterns, but the receiver half (Track A) is speculative against an
+unimplemented feature. Suggest holding this investigation as design input for whenever the Subscriptions
+ADR is actually written, rather than building `ITestCallbackReceiver` now — build it once
+`ISubscriptionChannel`'s real shape is known, so the receiver is designed against the actual interface
+instead of a guess.

--- a/docs/features/testscript/readme.md
+++ b/docs/features/testscript/readme.md
@@ -27,3 +27,5 @@ A pure C# / Ignixa-native TestScript execution engine to parse and execute FHIR 
 | Investigation | Status | Summary |
 |--------------|--------|---------|
 | [execution-engine](investigations/execution-engine.md) | Viable | Architecture, ecosystem analysis, implementation plan |
+| [async-job-polling](investigations/async-job-polling.md) | In Progress | Custom `waitFor` operation extension to poll `$export`/`$import`/`$reindex`-style 202+Content-Location jobs to a terminal state, mirroring `microsoft/fhir-server`'s `WaitForJobCompletionAsync` pattern |
+| [subscription-callback-verification](investigations/subscription-callback-verification.md) | In Progress | Mock rest-hook receiver fixture + `assertionCallbackReceived` extension to verify subscription delivery from within a TestScript; recommends deferring build until Subscriptions has an ADR |

--- a/docs/site/docs/core-sdk/testscript.md
+++ b/docs/site/docs/core-sdk/testscript.md
@@ -157,6 +157,76 @@ The FhirFakes extension must be declared inside the `resource` object in the fix
 
 `IFhirSchemaProvider` must be supplied to `TestScriptEvaluator` — the schema is passed through `FixtureResolutionContext` and is required by `SchemaBasedFhirResourceFaker` to generate valid fake resources.
 
+## Polling Long-Running Operations (waitFor)
+
+FHIR TestScript has no native way to express polling a long-running job (`$export`, `$import`, and
+similar operations that return `202 Accepted` immediately and require polling a status endpoint until
+the job completes). The `http://ignixa.io/testscript/waitFor` extension fills this gap: place it on an
+`operation` action's `extension` array, and that operation is retried — the same request, resent —
+while the response's HTTP status code matches a configurable "still working" code, up to a configurable
+number of attempts, sleeping a configurable interval between attempts. Once the status stops matching,
+or the attempt ceiling is reached, execution proceeds as normal — to whatever action comes next (typically
+an `assert`), or, if the ceiling was reached while still polling, the operation is recorded as a failed
+outcome instead.
+
+The extension has three optional child extensions, all `valueInteger`, each with a default:
+
+| Child extension | Meaning | Default |
+|---|---|---|
+| `pollingStatusCode` | HTTP status that means "still working" — keep retrying while the response matches it | `202` |
+| `maxAttempts` | Maximum number of attempts (including the first) before giving up | `60` |
+| `intervalMs` | Delay between attempts, in milliseconds | `1000` |
+
+Values are validated at parse time, not clamped: `pollingStatusCode` must be in the 100-599 range,
+`maxAttempts` must be at least 1, and `intervalMs` must be non-negative. Out-of-range values are parse
+errors — the script never reaches the evaluator.
+
+If the attempt ceiling is reached while the response still matches `pollingStatusCode`, the operation is
+recorded as a failed outcome with a message like `Timed out waiting for job completion after 60 attempts
+(last status: 202)`, rather than silently proceeding to the next action.
+
+`waitFor` does not resolve a status URL for you — it only controls *retry* behavior for whatever request
+the operation already builds. To poll a kickoff job's status endpoint, pair it with TestScript's existing
+header-extraction `variable` mechanism: extract the kickoff response's `Content-Location` (or `Location`)
+header into a variable, then target the polling operation's `url` at that variable.
+
+```json
+{
+  "test": [{
+    "name": "export completes",
+    "action": [
+      {
+        "operation": {
+          "type": { "code": "create" },
+          "url": "$export",
+          "responseId": "export-kickoff"
+        }
+      },
+      {
+        "operation": {
+          "url": "${statusUrl}",
+          "extension": [{
+            "url": "http://ignixa.io/testscript/waitFor",
+            "extension": [
+              { "url": "pollingStatusCode", "valueInteger": 202 },
+              { "url": "maxAttempts", "valueInteger": 30 },
+              { "url": "intervalMs", "valueInteger": 2000 }
+            ]
+          }]
+        }
+      },
+      { "assert": { "response": "okay" } }
+    ]
+  }],
+  "variable": [
+    { "name": "statusUrl", "sourceId": "export-kickoff", "headerField": "Content-Location" }
+  ]
+}
+```
+
+The `variable` extraction runs after every `operation` action, so `${statusUrl}` is populated by the
+time the polling operation executes.
+
 ## xUnit Integration
 
 Discover and run TestScript files as xUnit theories:

--- a/docs/superpowers/plans/2026-07-11-testscript-waitfor-operation.md
+++ b/docs/superpowers/plans/2026-07-11-testscript-waitfor-operation.md
@@ -1,0 +1,521 @@
+# TestScript `waitFor` Operation Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a custom TestScript operation extension, `http://ignixa.io/testscript/waitFor`, that retries an operation while its response's HTTP status code stays at a configurable "still working" value, so a TestScript can poll `$export`/`$import`-style async jobs to completion.
+
+**Architecture:** Follows the existing `assertionWhenResponseStatus` precedent exactly: a new immutable record (`WaitForCondition`) parsed from a child-extension tree onto `OperationExpression`, evaluated as a bounded retry loop inside `TestScriptEvaluator.VisitOperationAsync`. No new assertion type, no new fixture/provider abstraction — the polling URL comes from TestScript's existing header-to-variable extraction, and the final status is checked with the existing `response`/`responseCode` assertion criteria.
+
+**Tech Stack:** C# / .NET (net9.0 + net10.0 multi-target), `System.Text.Json.Nodes` for parsing, xUnit + Shouldly + NSubstitute for tests.
+
+## Global Constraints
+
+- Extension URL is exactly `http://ignixa.io/testscript/waitFor` — do not add a package-canonical prefix.
+- Defaults when a child extension is omitted: `pollingStatusCode` = 202, `maxAttempts` = 60, `intervalMs` = 1000.
+- Validation ranges: `pollingStatusCode` must be 100-599, `maxAttempts` must be >= 1, `intervalMs` must be >= 0. Violations are parse-time `ParseError`s (severity `Error`), not silently clamped.
+- Timeout (attempts exhausted while still polling) is a hard operation failure recorded via the existing `OperationOutcome`/`RecordOperationResult` path — no new reporting type.
+- No JSON-body inspection of any kind — polling is decided purely by `TestResponse.StatusCode`.
+- No `sourceId`-based header lookup — the polling URL is resolved the same way every other operation's `Url` is (via `VariableResolver`/`BuildUrl`), relying on the test author having extracted the status URL into a variable using TestScript's existing `variable` mechanism.
+- One type per file (matches `ResponseStatusCondition.cs` precedent for `WaitForCondition.cs`).
+- Every async method keeps propagating `CancellationToken` — no new method introduces a call that drops it.
+
+---
+
+### Task 1: `WaitForCondition` model + parsing
+
+**Files:**
+- Create: `src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs`
+- Modify: `src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs`
+- Modify: `src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs`
+- Test: `test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs`
+
+**Interfaces:**
+- Consumes: nothing new — this task only touches the parser layer.
+- Produces: `Ignixa.TestScript.Expressions.WaitForCondition` (record: `PollingStatusCode` (int), `MaxAttempts` (int), `IntervalMs` (int)) and `OperationExpression.WaitFor` (nullable `WaitForCondition`). Task 2's evaluator work reads `expression.WaitFor` and its three properties by exactly these names.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Add these to the end of the `TestScriptParserTests` class in
+`test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs` (just inside the closing `}` of the class,
+after the existing tests):
+
+```csharp
+[Fact]
+public void GivenWaitForExtensionWithNoChildren_WhenParsing_ThenDefaultsApply()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"WaitForDefaults","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+              "extension":[{"url":"http://ignixa.io/testscript/waitFor"}]}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeTrue();
+    var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+    op.WaitFor.ShouldNotBeNull();
+    op.WaitFor!.PollingStatusCode.ShouldBe(202);
+    op.WaitFor.MaxAttempts.ShouldBe(60);
+    op.WaitFor.IntervalMs.ShouldBe(1000);
+}
+
+[Fact]
+public void GivenWaitForExtensionWithExplicitChildren_WhenParsing_ThenValuesOverrideDefaults()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"WaitForExplicit","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+              "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                {"url":"pollingStatusCode","valueInteger":404},
+                {"url":"maxAttempts","valueInteger":5},
+                {"url":"intervalMs","valueInteger":250}
+              ]}]}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeTrue();
+    var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+    op.WaitFor!.PollingStatusCode.ShouldBe(404);
+    op.WaitFor.MaxAttempts.ShouldBe(5);
+    op.WaitFor.IntervalMs.ShouldBe(250);
+}
+
+[Fact]
+public void GivenWaitForPollingStatusCodeOutOfRange_WhenParsing_ThenReturnsParseError()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"WaitForInvalidStatus","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+              "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                {"url":"pollingStatusCode","valueInteger":999}
+              ]}]}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeFalse();
+    result.Errors.ShouldContain(e => e.Message.Contains("100") && e.Message.Contains("599"));
+}
+
+[Fact]
+public void GivenWaitForMaxAttemptsLessThanOne_WhenParsing_ThenReturnsParseError()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"WaitForInvalidMaxAttempts","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+              "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                {"url":"maxAttempts","valueInteger":0}
+              ]}]}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeFalse();
+    result.Errors.ShouldContain(e => e.Message.Contains("at least 1"));
+}
+
+[Fact]
+public void GivenWaitForIntervalMsNegative_WhenParsing_ThenReturnsParseError()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"WaitForInvalidInterval","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+              "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                {"url":"intervalMs","valueInteger":-1}
+              ]}]}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeFalse();
+    result.Errors.ShouldContain(e => e.Message.Contains("non-negative"));
+}
+
+[Fact]
+public void GivenOperationWithNoWaitForExtension_WhenParsing_ThenWaitForIsNull()
+{
+    var json = """
+        {
+          "resourceType":"TestScript","name":"NoWaitFor","status":"active",
+          "test":[{"name":"t","action":[
+            {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1"}}
+          ]}]
+        }
+        """;
+
+    var result = TestScriptParser.Parse(json);
+
+    result.IsSuccess.ShouldBeTrue();
+    var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+    op.WaitFor.ShouldBeNull();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error is expected — `WaitFor` doesn't exist yet)**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj --filter "FullyQualifiedName~WaitFor"`
+Expected: build FAILS — `OperationExpression` has no member `WaitFor`.
+
+- [ ] **Step 3: Create the `WaitForCondition` record**
+
+Create `src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs`:
+
+```csharp
+namespace Ignixa.TestScript.Expressions;
+
+/// <summary>
+/// Parsed form of the <c>http://ignixa.io/testscript/waitFor</c> extension: an operation carrying
+/// this is retried — the same request, sent again — while its response's HTTP status equals
+/// <paramref name="PollingStatusCode"/>, up to <paramref name="MaxAttempts"/> times, sleeping
+/// <paramref name="IntervalMs"/> between attempts.
+/// </summary>
+public sealed record WaitForCondition(int PollingStatusCode, int MaxAttempts, int IntervalMs);
+```
+
+- [ ] **Step 4: Add the `WaitFor` property to `OperationExpression`**
+
+In `src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs`, add this property (after
+`EncodeRequestUrl`, before the closing brace of the record body — i.e. right before the
+`AcceptAsync` method):
+
+```csharp
+    public WaitForCondition? WaitFor { get; init; }
+```
+
+- [ ] **Step 5: Add parsing support in `TestScriptParser.cs`**
+
+Add this constant next to the other extension URL constants (near
+`private const string RequiresCapabilityUrl = ...` at the top of the class):
+
+```csharp
+    private const string WaitForUrl = "http://ignixa.io/testscript/waitFor";
+```
+
+Add this new private method anywhere among the other `Parse*` helper methods in the same file:
+
+```csharp
+    private static WaitForCondition? ParseWaitForCondition(JsonArray? extensions, string path, List<ParseError> errors)
+    {
+        var ext = extensions?.OfType<JsonObject>().FirstOrDefault(e => e["url"]?.GetValue<string>() == WaitForUrl);
+        if (ext is null) return null;
+
+        var pollingStatusCode = ReadWaitForIntChild(ext, "pollingStatusCode", 202);
+        var maxAttempts = ReadWaitForIntChild(ext, "maxAttempts", 60);
+        var intervalMs = ReadWaitForIntChild(ext, "intervalMs", 1000);
+
+        if (pollingStatusCode is < 100 or > 599)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor pollingStatusCode {pollingStatusCode} is outside the valid HTTP status range 100-599", path));
+
+        if (maxAttempts < 1)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor maxAttempts must be at least 1, was {maxAttempts}", path));
+
+        if (intervalMs < 0)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor intervalMs must be non-negative, was {intervalMs}", path));
+
+        return new WaitForCondition(pollingStatusCode, maxAttempts, intervalMs);
+    }
+
+    private static int ReadWaitForIntChild(JsonObject waitForExtension, string childUrl, int defaultValue)
+    {
+        var child = waitForExtension["extension"]?.AsArray()?.OfType<JsonObject>()
+            .FirstOrDefault(c => c["url"]?.GetValue<string>() == childUrl);
+        if (child?["valueInteger"] is JsonValue v && v.TryGetValue<int>(out var value))
+            return value;
+        return defaultValue;
+    }
+```
+
+In `ParseOperation` (the method returning `new OperationExpression { ... }`), add one line to the object
+initializer, right after `Headers = ParseHeaders(op["requestHeader"]?.AsArray(), path, errors)`:
+
+```csharp
+            Headers = ParseHeaders(op["requestHeader"]?.AsArray(), path, errors),
+            WaitFor = ParseWaitForCondition(op["extension"]?.AsArray(), path, errors)
+```
+
+(Note the trailing comma moves to the `Headers` line since `WaitFor` is now the last initializer.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj --filter "FullyQualifiedName~WaitFor"`
+Expected: PASS (6 new tests, 0 failed).
+
+- [ ] **Step 7: Run the full TestScript test suite to check for regressions**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj`
+Expected: PASS, 0 failed (all pre-existing tests plus the 6 new ones, across both net9.0 and net10.0 targets).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
+git commit -m "feat(testscript): parse waitFor operation extension"
+```
+
+---
+
+### Task 2: Evaluator polling loop
+
+**Files:**
+- Modify: `src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs`
+- Test: `test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs`
+
+**Interfaces:**
+- Consumes: `OperationExpression.WaitFor` (nullable `WaitForCondition` with `PollingStatusCode`, `MaxAttempts`, `IntervalMs` int properties) from Task 1. `ITestRequestProvider.ExecuteAsync(TestRequest, CancellationToken) : Task<TestResponse>` and `TestResponse.StatusCode` (int) — both pre-existing, unchanged.
+- Produces: no new public surface — this task only changes `VisitOperationAsync`'s internal behavior. Downstream `assert` actions (already implemented) consume the final response exactly as before via `context.ResponseHistory`/`context.LastResponse`.
+
+- [ ] **Step 1: Write the failing evaluator tests**
+
+Add these to the end of the `TestScriptEvaluatorTests` class in
+`test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs` (just inside the closing `}` of the
+class):
+
+```csharp
+[Fact]
+public async Task GivenWaitForOperation_WhenStatusLeavesPollingCode_ThenStopsPollingAndRecordsSuccess()
+{
+    var responses = new Queue<TestResponse>(new[]
+    {
+        new TestResponse { StatusCode = 202 },
+        new TestResponse { StatusCode = 202 },
+        new TestResponse { StatusCode = 200 }
+    });
+    var callCount = 0;
+    _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+        .Returns(call => { callCount++; return responses.Dequeue(); });
+
+    var definition = new TestScriptDefinition
+    {
+        Metadata = new TestScriptMetadata { Name = "WaitForSuccess" },
+        Tests =
+        [
+            new TestPhaseDefinition
+            {
+                Name = "PollUntilDone",
+                Actions =
+                [
+                    new OperationExpression
+                    {
+                        Type = "read",
+                        Url = "_export/job-1",
+                        WaitFor = new WaitForCondition(PollingStatusCode: 202, MaxAttempts: 10, IntervalMs: 0)
+                    },
+                    new AssertExpression { Criteria = new ResponseStatusCriteria("okay") }
+                ]
+            }
+        ]
+    };
+
+    var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+    var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+    callCount.ShouldBe(3);
+    report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+}
+
+[Fact]
+public async Task GivenWaitForOperation_WhenNeverLeavesPollingCode_ThenFailsAfterMaxAttempts()
+{
+    var callCount = 0;
+    _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+        .Returns(call => { callCount++; return new TestResponse { StatusCode = 202 }; });
+
+    var definition = new TestScriptDefinition
+    {
+        Metadata = new TestScriptMetadata { Name = "WaitForTimeout" },
+        Tests =
+        [
+            new TestPhaseDefinition
+            {
+                Name = "PollForever",
+                Actions =
+                [
+                    new OperationExpression
+                    {
+                        Type = "read",
+                        Url = "_export/job-1",
+                        WaitFor = new WaitForCondition(PollingStatusCode: 202, MaxAttempts: 3, IntervalMs: 0)
+                    }
+                ]
+            }
+        ]
+    };
+
+    var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+    var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+    callCount.ShouldBe(3);
+    report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+    report.TestResults[0].Actions[0].Message!.ShouldContain("Timed out waiting for job completion after 3 attempts");
+}
+
+[Fact]
+public async Task GivenOperationWithNoWaitFor_WhenExecuting_ThenSendsExactlyOnce()
+{
+    var callCount = 0;
+    _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+        .Returns(call => { callCount++; return new TestResponse { StatusCode = 200 }; });
+
+    var definition = new TestScriptDefinition
+    {
+        Metadata = new TestScriptMetadata { Name = "NoWaitForRegression" },
+        Tests =
+        [
+            new TestPhaseDefinition
+            {
+                Name = "PlainRead",
+                Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+            }
+        ]
+    };
+
+    var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+    var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+    callCount.ShouldBe(1);
+    report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj --filter "FullyQualifiedName~WaitFor"`
+Expected: the two new `GivenWaitForOperation_*` tests FAIL (no polling behavior implemented yet — the
+first assertion after the timeout test, `callCount.ShouldBe(3)`, will see `callCount == 1` for the
+success-path test, or a similar early mismatch for the timeout-path test). The regression test
+(`GivenOperationWithNoWaitFor_WhenExecuting_ThenSendsExactlyOnce`) PASSES already — it exercises unchanged
+behavior and confirms the baseline before you touch `VisitOperationAsync`.
+
+- [ ] **Step 3: Implement the polling loop in `VisitOperationAsync`**
+
+In `src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs`, replace the entire body of
+`VisitOperationAsync` (the method starting at `public async ValueTask<TestScriptContext>
+VisitOperationAsync(...)`) with:
+
+```csharp
+    public async ValueTask<TestScriptContext> VisitOperationAsync(
+        OperationExpression expression,
+        TestScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        TestRequest? request = null;
+        try
+        {
+            if (expression.Destination is not null and > 1)
+                throw new NotSupportedException(
+                    $"Multi-server destinations are not supported. Destination '{expression.Destination}' was requested but only a single provider is configured.");
+
+            if (!expression.EncodeRequestUrl)
+                context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
+                    new AssertionOutcome(false, WarningOnly: true,
+                        "encodeRequestUrl=false is not supported; URL was encoded"));
+
+            request = BuildRequest(expression, context);
+            context = context.WithRequest(expression.RequestId, request);
+
+            var response = await _provider.ExecuteAsync(request, cancellationToken);
+
+            if (expression.WaitFor is { } waitFor)
+            {
+                var attempts = 1;
+                while (response.StatusCode == waitFor.PollingStatusCode && attempts < waitFor.MaxAttempts)
+                {
+                    await Task.Delay(waitFor.IntervalMs, cancellationToken);
+                    response = await _provider.ExecuteAsync(request, cancellationToken);
+                    attempts++;
+                }
+
+                if (response.StatusCode == waitFor.PollingStatusCode)
+                {
+                    context = context.WithResponse(expression.ResponseId, response);
+                    sw.Stop();
+                    context.Recorder.RecordOperationResult(expression.Label, expression.Description,
+                        new OperationOutcome(
+                            false,
+                            response.StatusCode,
+                            ErrorMessage: $"Timed out waiting for job completion after {attempts} attempts (last status: {response.StatusCode})",
+                            Duration: sw.Elapsed,
+                            Request: request,
+                            Response: response));
+                    return context;
+                }
+            }
+
+            context = context.WithResponse(expression.ResponseId, response);
+
+            sw.Stop();
+            context.Recorder.RecordOperationResult(expression.Label, expression.Description,
+                new OperationOutcome(true, response.StatusCode, Duration: sw.Elapsed, Request: request, Response: response));
+            return context;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            sw.Stop();
+            context.Recorder.RecordOperationResult(expression.Label, expression.Description,
+                new OperationOutcome(false, ErrorMessage: $"Request timed out or was aborted: {ex.Message}", Duration: sw.Elapsed, Request: request));
+            return context;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            context.Recorder.RecordOperationResult(expression.Label, expression.Description,
+                new OperationOutcome(false, ErrorMessage: ex.Message, Duration: sw.Elapsed, Request: request));
+            return context;
+        }
+    }
+```
+
+The only behavioral change versus the original method: when `expression.WaitFor` is set, the same
+already-built `request` is resent (via `Task.Delay` + another `_provider.ExecuteAsync` call) while the
+response's status code keeps matching `PollingStatusCode`, up to `MaxAttempts` total sends. When
+`WaitFor` is `null`, execution falls straight through exactly as it did before this change — the
+`if (expression.WaitFor is { } waitFor)` block is skipped entirely.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj --filter "FullyQualifiedName~WaitFor"`
+Expected: PASS (all `WaitFor`-named tests across both parser and evaluator files).
+
+- [ ] **Step 5: Run the full TestScript test suite to check for regressions**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj`
+Expected: PASS, 0 failed, across both net9.0 and net10.0 targets. This is the critical regression check
+for the `VisitOperationAsync` rewrite — every existing operation test (destination validation,
+cancellation, autocreate/autodelete, header/path variable extraction, etc.) must still pass unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+git commit -m "feat(testscript): poll waitFor operations until status leaves the polling code"
+```

--- a/docs/superpowers/specs/2026-07-11-testscript-waitfor-operation-design.md
+++ b/docs/superpowers/specs/2026-07-11-testscript-waitfor-operation-design.md
@@ -1,0 +1,162 @@
+# Design: `waitFor` Operation Extension for TestScript
+
+**Date**: 2026-07-11
+**Status**: Approved for implementation
+**Related**: [async-job-polling investigation](../../features/testscript/investigations/async-job-polling.md), [ADR 2607: TestScript Extensions](../../adr/adr-2607-testscript-extensions.md), PR #330 (`assertionAnyOfGroup`/`assertionWhenResponseStatus`)
+
+## Problem
+
+FHIR TestScript has no primitive for testing long-running async operations (`$export`, `$import`,
+eventually `$reindex`). These return `202 Accepted` immediately and require polling a status endpoint
+until the job completes — the same pattern `microsoft/fhir-server`'s C# E2E tests implement by hand via a
+`WaitForJobCompletionAsync` helper. Ignixa's TestScript engine has no equivalent, so authoring a test for
+these operations isn't currently possible without writing custom C# around the TestScript engine.
+
+## Decision
+
+Add a new operation-level custom extension, `http://ignixa.io/testscript/waitFor`, following the same
+extension-parsing precedent already established by `assertionAnyOfGroup`/`assertionWhenResponseStatus`
+(merged in PR #330). An operation carrying this extension is retried — the exact same request, sent again
+— while its response's HTTP status code equals a configurable "still working" code, up to a configurable
+attempt ceiling, sleeping a configurable interval between attempts.
+
+**Key simplification over the original investigation doc**: `$export`/`$import`'s status endpoint signals
+completion via the HTTP status code itself (`202` while running, `200` once the manifest is ready) — not
+via a JSON body field. Polling on status code means the response body never needs inspecting during the
+loop, avoiding the problem the investigation flagged (the job-status body isn't a FHIR resource, so
+FHIRPath-based assertions don't apply to it). Once polling stops, the *existing* `response`/`responseCode`
+assertion criteria already handle checking the final status — no new assertion type needed.
+
+**Also simplified**: the polling URL is not resolved via a new `sourceId`-based header lookup. TestScript
+already supports extracting a response header into a variable (the existing `variable` mechanism). A test
+author extracts `Content-Location` from the kickoff operation into `${statusUrl}` using that
+already-working feature, then the polling operation just targets `url: "${statusUrl}"` like any normal
+operation. `waitFor` only adds the retry-until-status-changes behavior — it doesn't touch URL resolution
+at all.
+
+## Data Model
+
+New file `src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs`, mirroring the existing
+`ResponseStatusCondition.cs` one-record-per-file style:
+
+```csharp
+namespace Ignixa.TestScript.Expressions;
+
+/// <summary>
+/// Parsed form of the <c>http://ignixa.io/testscript/waitFor</c> extension: an operation carrying
+/// this is retried — the same request, sent again — while its response's HTTP status equals
+/// <paramref name="PollingStatusCode"/>, up to <paramref name="MaxAttempts"/> times, sleeping
+/// <paramref name="IntervalMs"/> between attempts.
+/// </summary>
+public sealed record WaitForCondition(int PollingStatusCode, int MaxAttempts, int IntervalMs);
+```
+
+`OperationExpression` (`src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs`) gains one new
+property:
+
+```csharp
+public WaitForCondition? WaitFor { get; init; }
+```
+
+## Parsing
+
+`TestScriptParser.ParseOperation` (`src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs:385`) does not
+currently read `op["extension"]` at all. Add that, plus:
+
+```csharp
+private const string WaitForUrl = "http://ignixa.io/testscript/waitFor";
+```
+
+New helper, modeled on `ParseResponseStatusCondition`'s child-extension walk:
+
+```csharp
+private static WaitForCondition? ParseWaitForCondition(JsonArray? extensions, string path, List<ParseError> errors)
+{
+    var ext = extensions?.OfType<JsonObject>().FirstOrDefault(e => e["url"]?.GetValue<string>() == WaitForUrl);
+    if (ext is null) return null;
+
+    var pollingStatusCode = ReadIntChild(ext, "pollingStatusCode", 202);
+    var maxAttempts = ReadIntChild(ext, "maxAttempts", 60);
+    var intervalMs = ReadIntChild(ext, "intervalMs", 1000);
+
+    if (pollingStatusCode is < 100 or > 599)
+        errors.Add(new ParseError(ParseSeverity.Error,
+            $"waitFor pollingStatusCode {pollingStatusCode} is outside the valid HTTP status range 100-599", path));
+    if (maxAttempts < 1)
+        errors.Add(new ParseError(ParseSeverity.Error,
+            $"waitFor maxAttempts must be at least 1, was {maxAttempts}", path));
+    if (intervalMs < 0)
+        errors.Add(new ParseError(ParseSeverity.Error,
+            $"waitFor intervalMs must be non-negative, was {intervalMs}", path));
+
+    return new WaitForCondition(pollingStatusCode, maxAttempts, intervalMs);
+}
+```
+
+(`ReadIntChild` is a small local helper reading a named child extension's `valueInteger`, falling back to
+the given default when the child is absent — exact signature is an implementation detail, not a design
+decision.)
+
+Wire into `ParseOperation`: `WaitFor = ParseWaitForCondition(op["extension"]?.AsArray(), path, errors)`.
+
+## Evaluation
+
+`TestScriptEvaluator.VisitOperationAsync` (`src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs:318`)
+currently builds the request once, sends it once, records the outcome. Restructure so the
+build-once/send-and-record-one-attempt logic is reusable, then loop when `WaitFor` is set:
+
+- Build the request once (unchanged — URL/headers/body don't change between polling attempts).
+- Send it. If `expression.WaitFor is null`, behave exactly as today (no behavior change for existing
+  tests).
+- If `expression.WaitFor is { } waitFor`: after each send, if `response.StatusCode == waitFor.PollingStatusCode`
+  and attempts remain, `await Task.Delay(waitFor.IntervalMs, cancellationToken)` and send again. Otherwise
+  stop polling and record the normal success outcome (same as today — store request/response, extract
+  variables, etc.).
+- If attempts are exhausted while still polling: record an `OperationOutcome` failure via the existing
+  `context.Recorder.RecordOperationResult` call — `"Timed out waiting for job completion after {N}
+  attempts (last status: {code})"` — no new reporting type needed, this is the same failure path every
+  other operation failure already uses.
+
+`OperationCanceledException` from `Task.Delay` when `cancellationToken` fires propagates the same way
+existing `OperationCanceledException` handling in this method already does — no special casing.
+
+## Error Handling
+
+- Malformed extension values (out-of-range `pollingStatusCode`, non-positive `maxAttempts`, negative
+  `intervalMs`) are parse-time errors, matching the existing pattern for `assertionWhenResponseStatus`'s
+  status range validation — fail the parse, don't silently clamp.
+- A timeout (attempts exhausted, still polling) is an operation-time failure, not a parse-time one —
+  recorded as a normal failed `OperationOutcome`, which fails the test the same way any other failed
+  operation does today.
+- Network/transport exceptions during any individual polling attempt are handled by the existing
+  try/catch in `VisitOperationAsync` — no new exception handling path; a transient network blip during
+  polling surfaces as today's existing operation-failure behavior, it does not get its own retry-on-error
+  semantics (only retry-on-specific-status-code is in scope here).
+
+## Testing
+
+**Parser** (`test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs`):
+- Extension present with no children → all three fields default to 202/60/1000.
+- Extension present with explicit children → values parsed correctly.
+- Each of the three fields out of range individually → a `ParseError` mentioning that field.
+- Operation with no `waitFor` extension → `WaitFor` is `null` (no regression in existing operation
+  parsing tests).
+
+**Evaluator** (new test file alongside existing evaluator tests):
+- Fake `ITestRequestProvider` returning 202 for the first N sends, then 200 → assert exactly N+1 sends
+  occurred and the final stored response is the 200 one.
+- Fake provider that always returns 202 → assert exactly `MaxAttempts` sends occurred and the operation's
+  recorded outcome is a failure mentioning "Timed out".
+- Operation with no `WaitFor` → assert exactly one send occurs (regression check for the
+  `VisitOperationAsync` refactor — existing behavior must be provably unchanged).
+
+## Out of Scope (per investigation + brainstorming decisions)
+
+- `$reindex` itself — doesn't exist server-side yet; this feature is generic and will work against it
+  once it does, but isn't validated against it in this round.
+- Any JSON-body-based terminal-status check (`statusPath`) — rejected in favor of HTTP-status-code
+  polling; can be revisited later if a future job signals completion only through its body, but no such
+  case exists in this codebase today.
+- Subscription/callback verification — separate investigation
+  ([subscription-callback-verification.md](../../features/testscript/investigations/subscription-callback-verification.md)),
+  explicitly deferred pending a Subscriptions ADR.

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -334,9 +334,36 @@ public sealed class TestScriptEvaluator(
                         "encodeRequestUrl=false is not supported; URL was encoded"));
 
             request = BuildRequest(expression, context);
-
             context = context.WithRequest(expression.RequestId, request);
+
             var response = await _provider.ExecuteAsync(request, cancellationToken);
+
+            if (expression.WaitFor is { } waitFor)
+            {
+                var attempts = 1;
+                while (response.StatusCode == waitFor.PollingStatusCode && attempts < waitFor.MaxAttempts)
+                {
+                    await Task.Delay(waitFor.IntervalMs, cancellationToken);
+                    response = await _provider.ExecuteAsync(request, cancellationToken);
+                    attempts++;
+                }
+
+                if (response.StatusCode == waitFor.PollingStatusCode)
+                {
+                    context = context.WithResponse(expression.ResponseId, response);
+                    sw.Stop();
+                    context.Recorder.RecordOperationResult(expression.Label, expression.Description,
+                        new OperationOutcome(
+                            false,
+                            response.StatusCode,
+                            ErrorMessage: $"Timed out waiting for job completion after {attempts} attempts (last status: {response.StatusCode})",
+                            Duration: sw.Elapsed,
+                            Request: request,
+                            Response: response));
+                    return context;
+                }
+            }
+
             context = context.WithResponse(expression.ResponseId, response);
 
             sw.Stop();

--- a/src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs
+++ b/src/Core/Ignixa.TestScript/Expressions/OperationExpression.cs
@@ -25,6 +25,7 @@ public sealed record OperationExpression : ActionExpression
     public int? Origin { get; init; }
     public IReadOnlyList<HeaderExpression> Headers { get; init; } = [];
     public bool EncodeRequestUrl { get; init; } = true;
+    public WaitForCondition? WaitFor { get; init; }
 
     public override ValueTask<TestScriptContext> AcceptAsync(
         ITestScriptActionVisitor visitor,

--- a/src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs
+++ b/src/Core/Ignixa.TestScript/Expressions/WaitForCondition.cs
@@ -1,0 +1,9 @@
+namespace Ignixa.TestScript.Expressions;
+
+/// <summary>
+/// Parsed form of the <c>http://ignixa.io/testscript/waitFor</c> extension: an operation carrying
+/// this is retried — the same request, sent again — while its response's HTTP status equals
+/// <paramref name="PollingStatusCode"/>, up to <paramref name="MaxAttempts"/> times, sleeping
+/// <paramref name="IntervalMs"/> between attempts.
+/// </summary>
+public sealed record WaitForCondition(int PollingStatusCode, int MaxAttempts, int IntervalMs);

--- a/src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs
+++ b/src/Core/Ignixa.TestScript/Parsing/TestScriptParser.cs
@@ -236,6 +236,7 @@ public static class TestScriptParser
     private const string ParametrizeUrl = "http://ignixa.io/testscript/parametrize";
     private const string FhirVersionsUrl = "http://ignixa.io/testscript/fhirVersions";
     private const string RequiresCapabilityUrl = "http://ignixa.io/testscript/requiresCapability";
+    private const string WaitForUrl = "http://ignixa.io/testscript/waitFor";
 
     private static string? ParseRequiresCapability(JsonArray? extensions)
     {
@@ -262,6 +263,39 @@ public static class TestScriptParser
                 return versions.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         }
         return [];
+    }
+
+    private static WaitForCondition? ParseWaitForCondition(JsonArray? extensions, string path, List<ParseError> errors)
+    {
+        var ext = extensions?.OfType<JsonObject>().FirstOrDefault(e => e["url"]?.GetValue<string>() == WaitForUrl);
+        if (ext is null) return null;
+
+        var pollingStatusCode = ReadWaitForIntChild(ext, "pollingStatusCode", 202);
+        var maxAttempts = ReadWaitForIntChild(ext, "maxAttempts", 60);
+        var intervalMs = ReadWaitForIntChild(ext, "intervalMs", 1000);
+
+        if (pollingStatusCode is < 100 or > 599)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor pollingStatusCode {pollingStatusCode} is outside the valid HTTP status range 100-599", path));
+
+        if (maxAttempts < 1)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor maxAttempts must be at least 1, was {maxAttempts}", path));
+
+        if (intervalMs < 0)
+            errors.Add(new ParseError(ParseSeverity.Error,
+                $"waitFor intervalMs must be non-negative, was {intervalMs}", path));
+
+        return new WaitForCondition(pollingStatusCode, maxAttempts, intervalMs);
+    }
+
+    private static int ReadWaitForIntChild(JsonObject waitForExtension, string childUrl, int defaultValue)
+    {
+        var child = waitForExtension["extension"]?.AsArray()?.OfType<JsonObject>()
+            .FirstOrDefault(c => c["url"]?.GetValue<string>() == childUrl);
+        if (child?["valueInteger"] is JsonValue v && v.TryGetValue<int>(out var value))
+            return value;
+        return defaultValue;
     }
 
     private static ParametrizeDefinition? ParseParametrize(JsonArray? extensions, string testName, List<ParseError> errors)
@@ -409,7 +443,8 @@ public static class TestScriptParser
             Destination = op["destination"] is JsonValue dv && dv.TryGetValue<int>(out var dest) ? dest : null,
             Origin = op["origin"] is JsonValue ov && ov.TryGetValue<int>(out var orig) ? orig : null,
             EncodeRequestUrl = JsonFieldReader.GetBool(op, "encodeRequestUrl", path, errors) ?? true,
-            Headers = ParseHeaders(op["requestHeader"]?.AsArray(), path, errors)
+            Headers = ParseHeaders(op["requestHeader"]?.AsArray(), path, errors),
+            WaitFor = ParseWaitForCondition(op["extension"]?.AsArray(), path, errors)
         };
     }
 

--- a/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs
@@ -1701,4 +1701,109 @@ public class TestScriptEvaluatorTests
 
         report.TestResults[0].Actions[1].Outcome.ShouldBe(TestScriptOutcome.Pass);
     }
+
+    [Fact]
+    public async Task GivenWaitForOperation_WhenStatusLeavesPollingCode_ThenStopsPollingAndRecordsSuccess()
+    {
+        var responses = new Queue<TestResponse>(new[]
+        {
+            new TestResponse { StatusCode = 202 },
+            new TestResponse { StatusCode = 202 },
+            new TestResponse { StatusCode = 200 }
+        });
+        var callCount = 0;
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => { callCount++; return responses.Dequeue(); });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "WaitForSuccess" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PollUntilDone",
+                    Actions =
+                    [
+                        new OperationExpression
+                        {
+                            Type = "read",
+                            Url = "_export/job-1",
+                            WaitFor = new WaitForCondition(PollingStatusCode: 202, MaxAttempts: 10, IntervalMs: 0)
+                        },
+                        new AssertExpression { Criteria = new ResponseStatusCriteria("okay") }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        callCount.ShouldBe(3);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
+    public async Task GivenWaitForOperation_WhenNeverLeavesPollingCode_ThenFailsAfterMaxAttempts()
+    {
+        var callCount = 0;
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => { callCount++; return new TestResponse { StatusCode = 202 }; });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "WaitForTimeout" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PollForever",
+                    Actions =
+                    [
+                        new OperationExpression
+                        {
+                            Type = "read",
+                            Url = "_export/job-1",
+                            WaitFor = new WaitForCondition(PollingStatusCode: 202, MaxAttempts: 3, IntervalMs: 0)
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        callCount.ShouldBe(3);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        report.TestResults[0].Actions[0].Message!.ShouldContain("Timed out waiting for job completion after 3 attempts");
+    }
+
+    [Fact]
+    public async Task GivenOperationWithNoWaitFor_WhenExecuting_ThenSendsExactlyOnce()
+    {
+        var callCount = 0;
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => { callCount++; return new TestResponse { StatusCode = 200 }; });
+
+        var definition = new TestScriptDefinition
+        {
+            Metadata = new TestScriptMetadata { Name = "NoWaitForRegression" },
+            Tests =
+            [
+                new TestPhaseDefinition
+                {
+                    Name = "PlainRead",
+                    Actions = [new OperationExpression { Type = "read", Resource = "Patient", Params = "/1" }]
+                }
+            ]
+        };
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        callCount.ShouldBe(1);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
 }

--- a/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
+++ b/test/Ignixa.TestScript.Tests/Parsing/TestScriptParserTests.cs
@@ -790,4 +790,135 @@ public class TestScriptParserTests
             && e.Path.Contains("variable[0]")
             && e.Message.Contains("name"));
     }
+
+    [Fact]
+    public void GivenWaitForExtensionWithNoChildren_WhenParsing_ThenDefaultsApply()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"WaitForDefaults","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+                  "extension":[{"url":"http://ignixa.io/testscript/waitFor"}]}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+        op.WaitFor.ShouldNotBeNull();
+        op.WaitFor!.PollingStatusCode.ShouldBe(202);
+        op.WaitFor.MaxAttempts.ShouldBe(60);
+        op.WaitFor.IntervalMs.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void GivenWaitForExtensionWithExplicitChildren_WhenParsing_ThenValuesOverrideDefaults()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"WaitForExplicit","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+                  "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                    {"url":"pollingStatusCode","valueInteger":404},
+                    {"url":"maxAttempts","valueInteger":5},
+                    {"url":"intervalMs","valueInteger":250}
+                  ]}]}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+        op.WaitFor!.PollingStatusCode.ShouldBe(404);
+        op.WaitFor.MaxAttempts.ShouldBe(5);
+        op.WaitFor.IntervalMs.ShouldBe(250);
+    }
+
+    [Fact]
+    public void GivenWaitForPollingStatusCodeOutOfRange_WhenParsing_ThenReturnsParseError()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"WaitForInvalidStatus","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+                  "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                    {"url":"pollingStatusCode","valueInteger":999}
+                  ]}]}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Message.Contains("100") && e.Message.Contains("599"));
+    }
+
+    [Fact]
+    public void GivenWaitForMaxAttemptsLessThanOne_WhenParsing_ThenReturnsParseError()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"WaitForInvalidMaxAttempts","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+                  "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                    {"url":"maxAttempts","valueInteger":0}
+                  ]}]}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Message.Contains("at least 1"));
+    }
+
+    [Fact]
+    public void GivenWaitForIntervalMsNegative_WhenParsing_ThenReturnsParseError()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"WaitForInvalidInterval","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1",
+                  "extension":[{"url":"http://ignixa.io/testscript/waitFor","extension":[
+                    {"url":"intervalMs","valueInteger":-1}
+                  ]}]}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Message.Contains("non-negative"));
+    }
+
+    [Fact]
+    public void GivenOperationWithNoWaitForExtension_WhenParsing_ThenWaitForIsNull()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"NoWaitFor","status":"active",
+              "test":[{"name":"t","action":[
+                {"operation":{"type":{"code":"read"},"resource":"Patient","params":"/1"}}
+              ]}]
+            }
+            """;
+
+        var result = TestScriptParser.Parse(json);
+
+        result.IsSuccess.ShouldBeTrue();
+        var op = result.Value!.Tests[0].Actions[0].ShouldBeOfType<OperationExpression>();
+        op.WaitFor.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a custom TestScript operation extension, `http://ignixa.io/testscript/waitFor`, that retries an operation (same request resent) while its response's HTTP status matches a configurable "still working" code, up to a configurable attempt ceiling, sleeping a configurable interval between attempts
- Lets a TestScript poll `$export`/`$import`-style async jobs (202 Accepted, later 200 when done) to completion, mirroring `microsoft/fhir-server`'s `WaitForJobCompletionAsync` E2E test helper
- Polling decision is based purely on HTTP status code — no JSON body inspection needed, so the existing `response`/`responseCode` assertions handle checking the final result
- Polling URL is resolved via TestScript's existing header-extraction `variable` mechanism (no new sourceId-based lookup)
- Includes two investigation docs, a design spec, and user-facing SDK docs (`docs/site/docs/core-sdk/testscript.md`)

Developed via brainstorming → design spec → implementation plan → subagent-driven execution (2 tasks, each independently reviewed) → final whole-branch review. All review findings were either fixed (docs) or triaged as non-blocking Minor items (recorded in the branch's dev ledger for visibility).

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test test/Ignixa.TestScript.Tests` — 255/255 passing (net9.0 + net10.0), including 9 new tests (6 parser, 3 evaluator) covering defaults, explicit overrides, all three validation-range errors, the polling-to-success path, the timeout path, and a regression test locking in unchanged behavior when `waitFor` isn't used
- [x] Task-level spec-compliance + code-quality reviews (both approved, no Critical/Important findings)
- [x] Final whole-branch review (one Important doc finding, fixed in a follow-up commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)