### PR TITLE
fix(models): clear _value[x] primitive-extension shadow when switching choice variants

### DIFF
--- a/codegen/Ignixa.Specification.Generators/CSharpTypedModelLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpTypedModelLanguage.cs
@@ -850,6 +850,7 @@ public sealed class CSharpTypedModelLanguage : ILanguage
         body.AppendLine("            if (variant != key)");
         body.AppendLine("            {");
         body.AppendLine("                MutableNode.Remove(variant);");
+        body.AppendLine("                MutableNode.Remove(\"_\" + variant);");
         body.AppendLine("            }");
         body.AppendLine("        }");
         body.AppendLine();

--- a/src/Core/Ignixa.Serialization/Generated/Models/Annotation.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/Annotation.cs
@@ -90,6 +90,7 @@ public sealed partial class Annotation : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/DataRequirement.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/DataRequirement.cs
@@ -125,6 +125,7 @@ public partial class DataRequirement : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/DataRequirementDateFilter.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/DataRequirementDateFilter.cs
@@ -135,6 +135,7 @@ public sealed partial class DataRequirementDateFilter : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/DataRequirementValueFilter.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/DataRequirementValueFilter.cs
@@ -145,6 +145,7 @@ public partial class DataRequirementValueFilter : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/DosageDoseAndRate.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/DosageDoseAndRate.cs
@@ -90,6 +90,7 @@ public sealed partial class DosageDoseAndRate : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -190,6 +191,7 @@ public sealed partial class DosageDoseAndRate : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/Observation.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/Observation.cs
@@ -163,6 +163,7 @@ public partial class Observation : DomainResourceJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/Patient.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/Patient.cs
@@ -125,6 +125,7 @@ public partial class Patient : DomainResourceJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -246,6 +247,7 @@ public partial class Patient : DomainResourceJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/Population.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/Population.cs
@@ -90,6 +90,7 @@ public partial class Population : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/SubstanceAmount.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/SubstanceAmount.cs
@@ -102,6 +102,7 @@ public partial class SubstanceAmount : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/TimingRepeat.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/TimingRepeat.cs
@@ -102,6 +102,7 @@ public sealed partial class TimingRepeat : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/TriggerDefinition.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/TriggerDefinition.cs
@@ -147,6 +147,7 @@ public partial class TriggerDefinition : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/UsageContext.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/UsageContext.cs
@@ -134,6 +134,7 @@ public sealed partial class UsageContext : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Generated/Models/VirtualServiceDetail.cs
+++ b/src/Core/Ignixa.Serialization/Generated/Models/VirtualServiceDetail.cs
@@ -117,6 +117,7 @@ public partial class VirtualServiceDetail : BaseJsonNode
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Ignixa.Serialization/Models/Extension.cs
+++ b/src/Core/Ignixa.Serialization/Models/Extension.cs
@@ -25,13 +25,15 @@ public partial class Extension
     /// FHIR's <c>value[x]</c> wire convention names every choice-type key <c>"value"</c> + PascalCase(type
     /// name) in every version, and <see cref="Extension"/> has no other property that begins with
     /// <c>"value"</c> (only <c>url</c>, <c>id</c>, <c>extension</c> do not) -- so "remove every existing
-    /// property whose name starts with <c>value</c>, then set the new one" is exactly equivalent to the
-    /// generated per-version <c>SetValueVariant</c>'s enumerated clear, without needing to know which
-    /// variants exist for a given FHIR version. That means this method is safe to call more than once, or
-    /// after a different <c>value[x]</c> variant is already present -- unlike a bare low-level property set,
-    /// it can never leave two <c>value[x]</c> keys behind. If you can reference the R4/R5 packages and need
-    /// the ergonomics of a typed property (not just clearing correctness), construct the version-specific
-    /// subclass directly and use its typed accessor instead.
+    /// property whose name starts with <c>value</c> or <c>_value</c> (its primitive-extension shadow, per
+    /// FHIR's underscore-prefixed sibling mechanism, https://hl7.org/fhir/json.html#primitive), then set
+    /// the new one" is exactly equivalent to the generated per-version <c>SetValueVariant</c>'s enumerated
+    /// clear (including its shadow), without needing to know which variants exist for a given FHIR version.
+    /// That means this method is safe to call more than once, or after a different <c>value[x]</c> variant
+    /// is already present -- unlike a bare low-level property set, it can never leave two <c>value[x]</c>
+    /// keys (or an orphaned <c>_value[x]</c> shadow) behind. If you can reference the R4/R5 packages and
+    /// need the ergonomics of a typed property (not just clearing correctness), construct the
+    /// version-specific subclass directly and use its typed accessor instead.
     /// </remarks>
     internal void SetValueChoiceRaw(string valueElementName, string? value)
     {
@@ -43,8 +45,11 @@ public partial class Extension
                 nameof(valueElementName));
         }
 
+        string shadowElementName = "_" + valueElementName;
+
         foreach (string key in MutableNode.Select(property => property.Key)
-            .Where(key => key.StartsWith("value", StringComparison.Ordinal) && key != valueElementName)
+            .Where(key => (key.StartsWith("value", StringComparison.Ordinal) && key != valueElementName)
+                || (key.StartsWith("_value", StringComparison.Ordinal) && key != shadowElementName))
             .ToList())
         {
             MutableNode.Remove(key);

--- a/src/Core/Models/Ignixa.Models.R4/Generated/Dosage.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/Dosage.cs
@@ -91,6 +91,7 @@ public sealed partial class Dosage : Ignixa.Models.Dosage
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/ElementDefinition.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/ElementDefinition.cs
@@ -667,6 +667,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1318,6 +1319,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1477,6 +1479,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1636,6 +1639,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -2287,6 +2291,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/ElementDefinitionExample.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/ElementDefinitionExample.cs
@@ -667,6 +667,7 @@ public sealed partial class ElementDefinitionExample : Ignixa.Models.ElementDefi
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/Extension.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/Extension.cs
@@ -667,6 +667,7 @@ public sealed partial class Extension : Ignixa.Models.Extension
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/Observation.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/Observation.cs
@@ -215,6 +215,7 @@ public sealed partial class Observation : Ignixa.Models.Observation
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/ObservationComponent.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/ObservationComponent.cs
@@ -199,6 +199,7 @@ public sealed partial class ObservationComponent : Ignixa.Models.ObservationComp
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R4/Generated/ParametersParameter.cs
+++ b/src/Core/Models/Ignixa.Models.R4/Generated/ParametersParameter.cs
@@ -667,6 +667,7 @@ public sealed partial class ParametersParameter : Ignixa.Models.ParametersParame
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/ElementDefinition.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/ElementDefinition.cs
@@ -715,6 +715,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1414,6 +1415,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1585,6 +1587,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -1756,6 +1759,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -2462,6 +2466,7 @@ public sealed partial class ElementDefinition : Ignixa.Models.ElementDefinition
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/ElementDefinitionExample.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/ElementDefinitionExample.cs
@@ -715,6 +715,7 @@ public sealed partial class ElementDefinitionExample : Ignixa.Models.ElementDefi
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/Extension.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/Extension.cs
@@ -715,6 +715,7 @@ public sealed partial class Extension : Ignixa.Models.Extension
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/Observation.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/Observation.cs
@@ -104,6 +104,7 @@ public sealed partial class Observation : Ignixa.Models.Observation
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 
@@ -324,6 +325,7 @@ public sealed partial class Observation : Ignixa.Models.Observation
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/ObservationComponent.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/ObservationComponent.cs
@@ -223,6 +223,7 @@ public sealed partial class ObservationComponent : Ignixa.Models.ObservationComp
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/ParametersParameter.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/ParametersParameter.cs
@@ -715,6 +715,7 @@ public sealed partial class ParametersParameter : Ignixa.Models.ParametersParame
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/src/Core/Models/Ignixa.Models.R5/Generated/ProductShelfLife.cs
+++ b/src/Core/Models/Ignixa.Models.R5/Generated/ProductShelfLife.cs
@@ -91,6 +91,7 @@ public sealed partial class ProductShelfLife : Ignixa.Models.ProductShelfLife
             if (variant != key)
             {
                 MutableNode.Remove(variant);
+                MutableNode.Remove("_" + variant);
             }
         }
 

--- a/test/Ignixa.Models.R4.Tests/ChoiceTypeTests.cs
+++ b/test/Ignixa.Models.R4.Tests/ChoiceTypeTests.cs
@@ -39,6 +39,17 @@ public sealed class ChoiceTypeTests
         }
         """;
 
+    private const string ObservationStringWithShadowJson =
+        """
+        {
+          "resourceType": "Observation",
+          "id": "obs-s",
+          "status": "final",
+          "valueString": "borderline",
+          "_valueString": { "extension": [ { "url": "http://example.org/note", "valueString": "flagged" } ] }
+        }
+        """;
+
     [Fact]
     public void GivenValueQuantity_WhenRead_ThenVariantAndDiscriminatorReportQuantity()
     {
@@ -110,5 +121,36 @@ public sealed class ChoiceTypeTests
         obs.MutableNode()["valueString"].ShouldBeNull();
         obs.ValueType.ShouldBe(Ignixa.Models.R4.ObservationValueType.CodeableConcept);
         obs.ValueCodeableConcept!.Text.ShouldBe("elevated");
+    }
+
+    [Fact]
+    public void GivenValueStringWithPrimitiveExtensionShadow_WhenSwitchingToValueQuantity_ThenShadowCompanionRemoved()
+    {
+        // valueString's sibling "_valueString" carries a primitive extension (FHIR's underscore-prefixed
+        // primitive-extension mechanism, https://hl7.org/fhir/json.html#primitive). Switching variants must
+        // clear that companion too, or it survives as an orphan with no primitive value to annotate --
+        // invalid FHIR JSON. Regression test for issue #334.
+        var obs = ResourceJsonNode.Parse(ObservationStringWithShadowJson).As<Ignixa.Models.R4.Observation>();
+
+        obs.ValueQuantity = new Ignixa.Models.R4.Quantity { Value = 185 };
+
+        obs.MutableNode()["valueString"].ShouldBeNull();
+        obs.MutableNode()["_valueString"].ShouldBeNull();
+        obs.ValueType.ShouldBe(Ignixa.Models.R4.ObservationValueType.Quantity);
+    }
+
+    [Fact]
+    public void GivenValueStringWithPrimitiveExtensionShadow_WhenSetToNull_ThenShadowPreserved()
+    {
+        // Clearing a choice variant's value while leaving its extension shadow in place is valid FHIR (an
+        // extension-only primitive with no value). Setting the variant to null must remove only the value
+        // key, never its "_"-prefixed companion.
+        var obs = ResourceJsonNode.Parse(ObservationStringWithShadowJson).As<Ignixa.Models.R4.Observation>();
+
+        obs.ValueString = null;
+
+        obs.MutableNode()["valueString"].ShouldBeNull();
+        obs.MutableNode()["_valueString"].ShouldNotBeNull();
+        obs.ValueType.ShouldBe(Ignixa.Models.R4.ObservationValueType.None);
     }
 }

--- a/test/Ignixa.Models.Tests/ExtensionFacadeTests.cs
+++ b/test/Ignixa.Models.Tests/ExtensionFacadeTests.cs
@@ -186,4 +186,23 @@ public sealed class ExtensionFacadeTests
         ext.MutableNode()["valueString"]!.GetValue<string>().ShouldBe("second");
         ext.MutableNode().ContainsKey("_valueString").ShouldBeTrue();
     }
+
+    [Fact]
+    public void GivenValueStringWithPrimitiveExtensionShadow_WhenSetValueChoiceRawCalledWithNullForSameVariant_ThenShadowPreserved()
+    {
+        // Clearing a variant's value while leaving its own extension shadow in place is valid FHIR (an
+        // extension-only primitive with no value) -- mirrors the generated SetValueVariant's
+        // null-preserves-shadow behavior for this independently-implemented raw escape hatch.
+        var ext = new Extension { Url = "http://example.org/ext1" };
+        ext.SetValueChoiceRaw("valueString", "first");
+        ext.MutableNode()["_valueString"] = new JsonObject
+        {
+            ["extension"] = new JsonArray(new JsonObject { ["url"] = "http://example.org/note", ["valueString"] = "flagged" }),
+        };
+
+        ext.SetValueChoiceRaw("valueString", null);
+
+        ext.MutableNode().ContainsKey("valueString").ShouldBeFalse();
+        ext.MutableNode().ContainsKey("_valueString").ShouldBeTrue();
+    }
 }

--- a/test/Ignixa.Models.Tests/ExtensionFacadeTests.cs
+++ b/test/Ignixa.Models.Tests/ExtensionFacadeTests.cs
@@ -148,4 +148,42 @@ public sealed class ExtensionFacadeTests
 
         Should.Throw<ArgumentException>(() => ext.SetValueChoiceRaw("url", "http://example.org/overwritten"));
     }
+
+    [Fact]
+    public void GivenValueStringWithPrimitiveExtensionShadow_WhenSetValueChoiceRawSwitchesVariant_ThenShadowCompanionRemoved()
+    {
+        // "_valueString" carries a primitive extension on the valueString variant (FHIR's underscore-
+        // prefixed primitive-extension mechanism, https://hl7.org/fhir/json.html#primitive). Switching to
+        // valueUri must clear that companion too, or it survives as an orphan with no primitive value to
+        // annotate -- invalid FHIR JSON. Regression test for issue #334.
+        var ext = new Extension { Url = "http://example.org/ext1" };
+        ext.SetValueChoiceRaw("valueString", "first");
+        ext.MutableNode()["_valueString"] = new JsonObject
+        {
+            ["extension"] = new JsonArray(new JsonObject { ["url"] = "http://example.org/note", ["valueString"] = "flagged" }),
+        };
+
+        ext.SetValueChoiceRaw("valueUri", "http://example.org/second");
+
+        ext.MutableNode().ContainsKey("valueString").ShouldBeFalse();
+        ext.MutableNode().ContainsKey("_valueString").ShouldBeFalse();
+        ext.MutableNode()["valueUri"]!.GetValue<string>().ShouldBe("http://example.org/second");
+    }
+
+    [Fact]
+    public void GivenValueStringWithPrimitiveExtensionShadow_WhenSetValueChoiceRawCalledForSameVariant_ThenShadowPreserved()
+    {
+        // Re-setting the same variant's value must never disturb its own extension shadow.
+        var ext = new Extension { Url = "http://example.org/ext1" };
+        ext.SetValueChoiceRaw("valueString", "first");
+        ext.MutableNode()["_valueString"] = new JsonObject
+        {
+            ["extension"] = new JsonArray(new JsonObject { ["url"] = "http://example.org/note", ["valueString"] = "flagged" }),
+        };
+
+        ext.SetValueChoiceRaw("valueString", "second");
+
+        ext.MutableNode()["valueString"]!.GetValue<string>().ShouldBe("second");
+        ext.MutableNode().ContainsKey("_valueString").ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

- `Extension.SetValueVariant` (generated, one emission site covering every choice group across all generated types) and `Extension.SetValueChoiceRaw` (hand-written) cleared the old `value[x]` key when switching a FHIR choice-type variant, but left its `"_"`-prefixed primitive-extension shadow (e.g. `_valueString`) behind -- an orphaned companion with no value to annotate, which is invalid FHIR JSON per the [primitive extension mechanism](https://hl7.org/fhir/json.html#primitive).
- Fixed both clearing loops to also remove the `"_" + variant` shadow when switching to a different variant.
- Setting a variant to `null` still preserves its own shadow, matching `PrimitiveElement<T>`'s existing null-preserves-shadow semantics (an extension-only primitive with no value is valid FHIR) -- pinned by a regression test.
- Regenerated typed models: 27 generated files across `Ignixa.Serialization`, `Ignixa.Models.R4`, and `Ignixa.Models.R5` picked up the one-line generator fix (`Extension.value`, `Observation.value`, `ElementDefinition.defaultValue/fixed/maxValue/minValue/pattern`, `UsageContext.value`, etc.) -- no other drift.

Fixes #334

## Test plan

- [x] Regression tests written first (TDD): confirmed RED against the pre-fix code, then GREEN after the fix, for both the generated `SetValueVariant` path (`ChoiceTypeTests`) and the hand-written `SetValueChoiceRaw` path (`ExtensionFacadeTests`)
- [x] Pinning tests confirming the null-preserves-shadow and same-variant-preserves-shadow edge cases are untouched
- [x] `dotnet build All.sln` -- 0 warnings, 0 errors
- [x] `dotnet test All.sln` -- all projects passing (Api.E2ETests, Application.Tests, Models/Models.R4, FhirFakes, Validation, SqlOnFhir, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)