### PR TITLE
feat(testscript): execute assertionAnyOfGroup and assertionWhenResponseStatus

### DIFF
--- a/docs/superpowers/plans/2026-07-11-testscript-assertion-alternatives-evaluator.md
+++ b/docs/superpowers/plans/2026-07-11-testscript-assertion-alternatives-evaluator.md
@@ -1,0 +1,1000 @@
+# TestScript Assertion Alternatives Evaluator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `TestScriptEvaluator` actually execute the `assertionAnyOfGroup` and `assertionWhenResponseStatus` extensions that PR #330 parses but never acts on, closing out issue #324's remaining checklist items.
+
+**Architecture:** A shared `EvaluateAssertionMember` primitive layers conditional applicability on top of the existing per-assertion evaluation. Standalone assertions record individually as today (now applicability-aware, mapping "condition didn't match" to a `Skip` outcome). Assertions sharing an `AnyOfGroupId` within one test are intercepted in `ExecuteActionsAsync`, evaluated via the same primitive, and aggregated into one reported result with per-member diagnostics, instead of each recording independently.
+
+**Tech Stack:** .NET (net9.0 + net10.0 multi-target), xUnit (`[Fact]`), Shouldly (`ShouldBe`/`ShouldContain`/etc.), NSubstitute for test doubles.
+
+**Design doc:** `docs/superpowers/specs/2026-07-11-testscript-assertion-alternatives-evaluator-design.md` — read it first if anything below is ambiguous; this plan implements it verbatim.
+
+## Global Constraints
+
+- Extension URLs are fixed values, do not invent alternatives: `http://ignixa.io/testscript/assertionAnyOfGroup`, `http://ignixa.io/testscript/assertionWhenResponseStatus` (both already parsed by PR #330, unchanged by this plan), and `http://ignixa.io/testscript/assertionGroupMember` (new — this plan's own FHIR `TestReport` rendering extension for group member diagnostics).
+- Every `dotnet test test/Ignixa.TestScript.Tests` run must report results for **both** `net9.0` and `net10.0` target frameworks, and the existing 264 tests must stay green after every task — no behavior change for ungrouped, unconditional assertions.
+- Test stack is xUnit `[Fact]` + Shouldly assertions (`ShouldBe`, `ShouldBeTrue`, `ShouldContain`, `ShouldNotBeNull`) + NSubstitute (`Substitute.For<T>()`, `.Returns(...)`) — match `test/Ignixa.TestScript.Tests/Evaluation/TestScriptEvaluatorTests.cs` and `test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs` conventions exactly.
+- New small value types (e.g. `AssertionGroupMemberResult`) go in their own file, one record per file — this repo's existing convention (see `src/Core/Ignixa.TestScript/Expressions/ResponseStatusCondition.cs`, `WaitForCondition.cs`).
+- `ImplicitUsings` is enabled project-wide — do not add `using System.Linq;`, `using System;`, etc. explicitly; only add usings for namespaces that aren't implicit (e.g. `Ignixa.TestScript.Reporting`, `Ignixa.TestScript.Parsing`).
+- **Known limitation, explicitly out of scope:** `TestScriptContext.ResponseHistory` is not scoped per-test (it threads across the whole run). A `WhenResponseStatus` condition referencing a different test's `responseId` will resolve instead of erroring, contrary to issue #324's "cross-test references are invalid" acceptance criterion. Do not attempt to fix this — it's a pre-existing property of `TestScriptContext` unrelated to this feature. Do not add per-test history scoping as a "nice to have."
+- Do not touch `ignixa-lab`'s workaround components (`WarningOnlyStatusAlternativeEnforcer`, etc.) — different repository, separate follow-up, not part of this plan.
+
+---
+
+### Task 1: Report model — group aggregation data shapes
+
+**Files:**
+- Modify: `src/Core/Ignixa.TestScript/Reporting/AssertionOutcome.cs`
+- Create: `src/Core/Ignixa.TestScript/Reporting/AssertionGroupMemberResult.cs`
+- Modify: `src/Core/Ignixa.TestScript/Reporting/ActionResult.cs`
+- Modify: `src/Core/Ignixa.TestScript/Reporting/ITestScriptResultRecorder.cs`
+- Modify: `src/Core/Ignixa.TestScript/Reporting/TestScriptResultRecorder.cs`
+- Test: `test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs`
+
+**Interfaces:**
+- Produces: `AssertionOutcome(bool Passed, bool WarningOnly, string? Message = null, bool IsError = false, bool Applicable = true)` — one new field, `Applicable`, defaulting to `true` so every existing call site (in `TestScriptEvaluatorTests.cs`, `TestScriptResultRecorderTests.cs`, and `TestScriptEvaluator.cs` itself) keeps compiling unchanged.
+- Produces: `AssertionGroupMemberResult(string? Description, bool Applicable, bool Passed, string? Message)`.
+- Produces: `ActionResult` gains `string? GroupId = null` and `IReadOnlyList<AssertionGroupMemberResult>? Members = null` — both default to `null`, every existing `new ActionResult(...)` call site keeps compiling unchanged.
+- Produces: `ITestScriptResultRecorder.RecordAssertionGroupResult(string groupId, string? label, string? description, AssertionOutcome outcome, IReadOnlyList<AssertionGroupMemberResult> members)`.
+- Consumes: nothing from other tasks — this task is the foundation the others build on.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these to `test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs`, inside the existing `TestScriptResultRecorderTests` class, just before the final closing `}`:
+
+```csharp
+    [Fact]
+    public void GivenInapplicableAssertion_WhenRecording_ThenOutcomeIsSkip()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+        recorder.RecordAssertionResult("a", "desc",
+            new AssertionOutcome(false, WarningOnly: false, Applicable: false));
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+    }
+
+    [Fact]
+    public void GivenPassingGroupResult_WhenRecording_ThenActionCarriesGroupIdAndMembers()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Preferred: 410 Gone", true, false, "Expected response 'gone' but got status 404"),
+            new("Alternative: 404 Not Found", true, true, null)
+        };
+        recorder.RecordAssertionGroupResult("deleted-resource-readback", "grp", "Deleted resource readback",
+            new AssertionOutcome(true, WarningOnly: false), members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        var action = report.TestResults[0].Actions[0];
+        action.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        action.GroupId.ShouldBe("deleted-resource-readback");
+        action.Members.ShouldNotBeNull();
+        action.Members!.Count.ShouldBe(2);
+        action.Members[1].Passed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenErroredGroupResult_WhenRecording_ThenOutcomeIsError()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Member A", false, false, null),
+            new("Member B", false, false, null)
+        };
+        recorder.RecordAssertionGroupResult("group-x", null, "Group X",
+            new AssertionOutcome(false, WarningOnly: false, Message: "no member was applicable", IsError: true),
+            members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+    }
+
+    [Fact]
+    public void GivenFailedGroupResult_WhenRecording_ThenOutcomeIsFail()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Member A", true, false, "expected X"),
+            new("Member B", true, false, "expected Y")
+        };
+        recorder.RecordAssertionGroupResult("group-y", null, "Group Y",
+            new AssertionOutcome(false, WarningOnly: false, Message: "no alternative matched"),
+            members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Fail);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~TestScriptResultRecorderTests"`
+Expected: build errors — `AssertionGroupMemberResult` does not exist, `AssertionOutcome` has no `Applicable` parameter, `RecordAssertionGroupResult` does not exist, `ActionResult` has no `GroupId`/`Members`.
+
+- [ ] **Step 3: Create `AssertionGroupMemberResult.cs`**
+
+```csharp
+namespace Ignixa.TestScript.Reporting;
+
+/// <summary>
+/// One member's outcome within an <c>assertionAnyOfGroup</c> aggregate. Surfaced as diagnostic detail
+/// alongside the group's single top-level <see cref="ActionResult"/> — members are never reported as
+/// independent top-level results.
+/// </summary>
+public sealed record AssertionGroupMemberResult(
+    string? Description,
+    bool Applicable,
+    bool Passed,
+    string? Message);
+```
+
+- [ ] **Step 4: Update `AssertionOutcome.cs`**
+
+Replace the whole file with:
+
+```csharp
+namespace Ignixa.TestScript.Reporting;
+
+public sealed record AssertionOutcome(
+    bool Passed,
+    bool WarningOnly,
+    string? Message = null,
+    bool IsError = false,
+    bool Applicable = true);
+```
+
+- [ ] **Step 5: Update `ActionResult.cs`**
+
+Replace the whole file with:
+
+```csharp
+namespace Ignixa.TestScript.Reporting;
+
+public sealed record ActionResult(
+    string? Label,
+    string? Description,
+    TestScriptOutcome Outcome,
+    string? Message = null,
+    TimeSpan Duration = default,
+    TestActionKind Kind = TestActionKind.Assertion,
+    HttpExchange? Exchange = null,
+    string? GroupId = null,
+    IReadOnlyList<AssertionGroupMemberResult>? Members = null);
+```
+
+- [ ] **Step 6: Update `ITestScriptResultRecorder.cs`**
+
+Replace the whole file with:
+
+```csharp
+namespace Ignixa.TestScript.Reporting;
+
+public interface ITestScriptResultRecorder
+{
+    TestScriptOutcome? SetupOutcome { get; }
+
+    void RecordOperationResult(string? label, string? description, OperationOutcome outcome);
+    void RecordAssertionResult(string? label, string? description, AssertionOutcome outcome);
+    void RecordAssertionGroupResult(
+        string groupId,
+        string? label,
+        string? description,
+        AssertionOutcome outcome,
+        IReadOnlyList<AssertionGroupMemberResult> members);
+    void BeginPhase(TestPhaseType phase, string? name = null, string? description = null);
+    void EndPhase();
+    void RecordSkippedTest(string name, string? description, string reason);
+    TestScriptReport Build(string testScriptName, DateTimeOffset startTime, DateTimeOffset endTime);
+}
+```
+
+- [ ] **Step 7: Update `TestScriptResultRecorder.cs`**
+
+Replace the existing `RecordAssertionResult` method (currently lines 53-71) with:
+
+```csharp
+    public void RecordAssertionResult(string? label, string? description, AssertionOutcome outcome)
+    {
+        if (_isBuilt)
+            throw new InvalidOperationException("Cannot record results after Build() has been called.");
+        if (!_inPhase)
+            throw new InvalidOperationException("RecordAssertionResult called without an open phase. Call BeginPhase first.");
+
+        _currentActions.Add(new ActionResult(label, description, DetermineOutcome(outcome), outcome.Message));
+    }
+
+    public void RecordAssertionGroupResult(
+        string groupId,
+        string? label,
+        string? description,
+        AssertionOutcome outcome,
+        IReadOnlyList<AssertionGroupMemberResult> members)
+    {
+        if (_isBuilt)
+            throw new InvalidOperationException("Cannot record results after Build() has been called.");
+        if (!_inPhase)
+            throw new InvalidOperationException("RecordAssertionGroupResult called without an open phase. Call BeginPhase first.");
+
+        _currentActions.Add(new ActionResult(
+            label, description, DetermineOutcome(outcome), outcome.Message,
+            GroupId: groupId, Members: members));
+    }
+
+    private static TestScriptOutcome DetermineOutcome(AssertionOutcome outcome)
+    {
+        if (!outcome.Applicable)
+            return TestScriptOutcome.Skip;
+        if (outcome.IsError)
+            return TestScriptOutcome.Error;
+        if (outcome.Passed)
+            return TestScriptOutcome.Pass;
+        if (outcome.WarningOnly)
+            return TestScriptOutcome.Warning;
+        return TestScriptOutcome.Fail;
+    }
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~TestScriptResultRecorderTests"`
+Expected: all pass, including the 4 new tests, on both `net9.0` and `net10.0`.
+
+- [ ] **Step 9: Run the full test project to confirm no regression**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests`
+Expected: all 264 existing tests plus the 4 new ones pass (268 total × 2 target frameworks).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Core/Ignixa.TestScript/Reporting/AssertionOutcome.cs \
+        src/Core/Ignixa.TestScript/Reporting/AssertionGroupMemberResult.cs \
+        src/Core/Ignixa.TestScript/Reporting/ActionResult.cs \
+        src/Core/Ignixa.TestScript/Reporting/ITestScriptResultRecorder.cs \
+        src/Core/Ignixa.TestScript/Reporting/TestScriptResultRecorder.cs \
+        test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs
+git commit -m "feat(testscript): add group-aggregate reporting shapes to the recorder"
+```
+
+---
+
+### Task 2: Evaluator execution — conditional applicability and OR-group aggregation
+
+**Files:**
+- Modify: `src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs`
+- Test: Create `test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs`
+
+**Interfaces:**
+- Consumes (from Task 1): `AssertionOutcome(bool Passed, bool WarningOnly, string? Message = null, bool IsError = false, bool Applicable = true)`, `AssertionGroupMemberResult(string? Description, bool Applicable, bool Passed, string? Message)`, `ITestScriptResultRecorder.RecordAssertionGroupResult(string groupId, string? label, string? description, AssertionOutcome outcome, IReadOnlyList<AssertionGroupMemberResult> members)`.
+- Consumes (already exists): `AssertExpression.AnyOfGroupId` (`string?`), `AssertExpression.WhenResponseStatus` (`ResponseStatusCondition?`), `ResponseStatusCondition(string SourceId, IReadOnlyList<int> Statuses)`, `TestScriptContext.ResponseHistory` (`ImmutableDictionary<string, TestResponse>`), `TestResponse.StatusCode` (`int`).
+- Produces: nothing new for later tasks — Task 3 only needs Task 1's `ActionResult.Members` shape, not anything from this task.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs`:
+
+```csharp
+using Ignixa.Abstractions;
+using Ignixa.TestScript.Client;
+using Ignixa.TestScript.Evaluation;
+using Ignixa.TestScript.Expressions;
+using Ignixa.TestScript.Fixtures;
+using Ignixa.TestScript.Model;
+using Ignixa.TestScript.Reporting;
+using NSubstitute;
+
+namespace Ignixa.TestScript.Tests.Evaluation;
+
+public class AssertionAlternativesTests
+{
+    private readonly ITestRequestProvider _mockProvider;
+    private readonly IFixtureProvider _fixtureProvider;
+    private readonly IFhirSchemaProvider _schema;
+
+    public AssertionAlternativesTests()
+    {
+        _mockProvider = Substitute.For<ITestRequestProvider>();
+        _fixtureProvider = new InlineFixtureProvider();
+        _schema = Substitute.For<IFhirSchemaProvider>();
+    }
+
+    private static TestScriptDefinition SingleTestDefinition(string name, params ActionExpression[] actions) =>
+        new()
+        {
+            Metadata = new TestScriptMetadata { Name = name },
+            Tests = [new TestPhaseDefinition { Name = "t", Actions = actions }]
+        };
+
+    [Fact]
+    public async Task GivenGroupWherePreferredMemberPasses_WhenExecuting_ThenAggregatePassesAndCarriesBothMembers()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 410 });
+
+        var definition = SingleTestDefinition("GroupPreferred",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        report.TestResults[0].Actions.Count.ShouldBe(2);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        groupAction.GroupId.ShouldBe("deleted-resource-readback");
+        groupAction.Members!.Count.ShouldBe(2);
+        groupAction.Members[0].Passed.ShouldBeTrue();
+        groupAction.Members[1].Passed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereOnlyFallbackMemberPasses_WhenExecuting_ThenAggregatePassesWithoutWarning()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 404 });
+
+        var definition = SingleTestDefinition("GroupFallback",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        groupAction.Members![0].Passed.ShouldBeFalse();
+        groupAction.Members[1].Passed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereNoMemberPasses_WhenExecuting_ThenAggregateFails()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 500 });
+
+        var definition = SingleTestDefinition("GroupNoneMatch",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Fail);
+        report.TestResults[0].Actions[1].Outcome.ShouldBe(TestScriptOutcome.Fail);
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereNoMemberIsApplicable_WhenExecuting_ThenAggregateErrors()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = SingleTestDefinition("GroupNoneApplicable",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/deleted-id", ResponseId = "delete-response" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                AnyOfGroupId = "conditional-group",
+                WarningOnly = true,
+                Description = "Only applies if delete returned 202",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "conditional-group",
+                WarningOnly = true,
+                Description = "Only applies if delete returned 204",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [204])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Error);
+        groupAction.Message.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GivenGroupMemberWithUnresolvableSourceId_WhenExecuting_ThenAggregateErrorsNamingMember()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 404 });
+
+        var definition = SingleTestDefinition("GroupBadSourceId",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "bad-group",
+                WarningOnly = true,
+                Description = "Broken conditional member",
+                WhenResponseStatus = new ResponseStatusCondition("does-not-exist", [202])
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "bad-group",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Error);
+        groupAction.Message.ShouldContain("Broken conditional member");
+    }
+
+    [Fact]
+    public async Task GivenStandaloneConditionalAssertionWhoseConditionMatches_WhenExecuting_ThenEvaluatedNormally()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 202 : 200
+            });
+
+        var definition = SingleTestDefinition("StandaloneConditionMatches",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/async-id", ResponseId = "delete-response" },
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/async-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                WarningOnly = true,
+                Description = "An asynchronous delete may still be readable immediately",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        report.TestResults[0].Actions[2].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
+    public async Task GivenStandaloneConditionalAssertionWhoseConditionDoesNotMatch_WhenExecuting_ThenRecordedAsSkip()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 204 : 404
+            });
+
+        var definition = SingleTestDefinition("StandaloneConditionMismatch",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/async-id", ResponseId = "delete-response" },
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/async-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                WarningOnly = true,
+                Description = "An asynchronous delete may still be readable immediately",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Actions[2].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~AssertionAlternativesTests"`
+Expected: compiles (Task 1 already landed the types this references), but assertions fail — today every assert in a group still records independently, so `Actions.Count` is 3 not 2, group members never match "matched", conditions are silently ignored (no `Skip`, no `Error` for bad sourceId).
+
+- [ ] **Step 3: Add the shared evaluation primitive**
+
+In `src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs`, add this new private method immediately before `EvaluateAssertionWithMessage` (currently at line 575):
+
+```csharp
+    private (bool Applicable, bool Passed, string? Message) EvaluateAssertionMember(
+        AssertExpression assertion, TestScriptContext context)
+    {
+        if (assertion.WhenResponseStatus is { } condition)
+        {
+            if (!context.ResponseHistory.TryGetValue(condition.SourceId, out var response))
+                throw new InvalidOperationException(
+                    $"assertionWhenResponseStatus sourceId '{condition.SourceId}' refers to no known response");
+
+            if (!condition.Statuses.Contains(response.StatusCode))
+                return (false, false, null);
+        }
+
+        var (passed, message) = EvaluateAssertionWithMessage(assertion, context);
+        return (true, passed, message);
+    }
+```
+
+- [ ] **Step 4: Update `VisitAssertAsync` for the standalone conditional path**
+
+Replace the existing `VisitAssertAsync` method (currently lines 395-416) with:
+
+```csharp
+    public ValueTask<TestScriptContext> VisitAssertAsync(
+        AssertExpression expression,
+        TestScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (applicable, passed, message) = EvaluateAssertionMember(expression, context);
+            context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
+                new AssertionOutcome(passed, expression.WarningOnly, applicable ? message : null, Applicable: applicable));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
+                new AssertionOutcome(false, expression.WarningOnly, ex.Message, IsError: true));
+        }
+        return ValueTask.FromResult(context);
+    }
+```
+
+This method now only ever fires for assertions with **no** `AnyOfGroupId` — Step 5 intercepts grouped assertions one level up and they never reach the per-action visitor dispatch.
+
+- [ ] **Step 5: Restructure `ExecuteActionsAsync` to intercept and aggregate groups**
+
+Replace the existing `ExecuteActionsAsync` method (currently lines 302-316) with:
+
+```csharp
+    private async Task<TestScriptContext> ExecuteActionsAsync(
+        IReadOnlyList<ActionExpression> actions,
+        IReadOnlyList<VariableDefinition> variables,
+        TestScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        var lastGroupIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < actions.Count; i++)
+            if (actions[i] is AssertExpression { AnyOfGroupId: { } gid })
+                lastGroupIndex[gid] = i;
+
+        var pendingGroups = new Dictionary<string, List<(AssertExpression Assertion, bool Applicable, bool Passed, string? Message, bool IsError)>>(
+            StringComparer.Ordinal);
+
+        for (var i = 0; i < actions.Count; i++)
+        {
+            var action = actions[i];
+
+            if (action is AssertExpression { AnyOfGroupId: { } groupId } assertion)
+            {
+                var member = EvaluateGroupMemberSafe(assertion, context);
+                if (!pendingGroups.TryGetValue(groupId, out var members))
+                    pendingGroups[groupId] = members = [];
+                members.Add((assertion, member.Applicable, member.Passed, member.Message, member.IsError));
+
+                if (i == lastGroupIndex[groupId])
+                    RecordGroupResult(context, groupId, members);
+
+                continue;
+            }
+
+            context = await action.AcceptAsync(this, context, cancellationToken);
+            if (action is OperationExpression)
+                context = VariableExtractor.ExtractFromResponse(variables, context, schemaProvider);
+        }
+
+        return context;
+    }
+
+    private (bool Applicable, bool Passed, string? Message, bool IsError) EvaluateGroupMemberSafe(
+        AssertExpression assertion, TestScriptContext context)
+    {
+        try
+        {
+            var (applicable, passed, message) = EvaluateAssertionMember(assertion, context);
+            return (applicable, passed, message, false);
+        }
+        catch (Exception ex)
+        {
+            return (false, false, ex.Message, true);
+        }
+    }
+
+    private static void RecordGroupResult(
+        TestScriptContext context,
+        string groupId,
+        List<(AssertExpression Assertion, bool Applicable, bool Passed, string? Message, bool IsError)> members)
+    {
+        var reportMembers = members
+            .Select(m => new AssertionGroupMemberResult(m.Assertion.Description, m.Applicable, m.Passed, m.Message))
+            .ToList();
+
+        var first = members[0].Assertion;
+        var errored = members.FirstOrDefault(m => m.IsError);
+        var applicableMembers = members.Where(m => m.Applicable).ToList();
+        var matched = applicableMembers.FirstOrDefault(m => m.Passed);
+
+        AssertionOutcome outcome;
+        if (errored.IsError)
+        {
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': member '{errored.Assertion.Description}' failed to evaluate: {errored.Message}",
+                IsError: true);
+        }
+        else if (applicableMembers.Count == 0)
+        {
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': no member was applicable — condition(s) never matched",
+                IsError: true);
+        }
+        else if (matched.Passed)
+        {
+            outcome = new AssertionOutcome(true, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': matched alternative '{matched.Assertion.Description}'");
+        }
+        else
+        {
+            var summary = string.Join("; ", applicableMembers.Select(m => $"{m.Assertion.Description}: {m.Message}"));
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': no alternative matched ({summary})");
+        }
+
+        var label = matched.Passed ? matched.Assertion.Label : first.Label;
+        var description = matched.Passed ? matched.Assertion.Description : first.Description;
+
+        context.Recorder.RecordAssertionGroupResult(groupId, label, description, outcome, reportMembers);
+    }
+```
+
+`EvaluateGroupMemberSafe` and `RecordGroupResult` have no async work and no `CancellationToken` parameter — assertion evaluation here is synchronous (no I/O), matching `EvaluateAssertionWithMessage`'s existing signature. Do not add a `CancellationToken` parameter to either; that would be scope the design doesn't call for.
+
+- [ ] **Step 6: Run the new tests**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~AssertionAlternativesTests"`
+Expected: all 7 tests pass on both `net9.0` and `net10.0`.
+
+- [ ] **Step 7: Run the full test project to confirm no regression**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests`
+Expected: all 268 previously-passing tests (264 baseline + 4 from Task 1) plus the 7 new ones pass — 275 total × 2 target frameworks. This is the critical regression check: every existing test that has zero grouped/conditional assertions must produce byte-identical results to before this task.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs \
+        test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs
+git commit -m "feat(testscript): execute assertionAnyOfGroup and assertionWhenResponseStatus in the evaluator"
+```
+
+---
+
+### Task 3: FHIR `TestReport` rendering of group members
+
+**Files:**
+- Modify: `src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs`
+- Test: `test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs`
+
+**Interfaces:**
+- Consumes (from Task 1): `ActionResult.GroupId` (`string?`), `ActionResult.Members` (`IReadOnlyList<AssertionGroupMemberResult>?`), `AssertionGroupMemberResult(string? Description, bool Applicable, bool Passed, string? Message)`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these to `test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs`, inside the existing `TestReportResourceGeneratorTests` class, just before the final closing `}`:
+
+```csharp
+    [Fact]
+    public void GivenGroupActionWithMembers_WhenGenerating_ThenMembersRenderAsChildExtensions()
+    {
+        var report = new TestScriptReport
+        {
+            TestScriptName = "GroupReport",
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            TestResults =
+            [
+                new TestCaseResult("DeletedResourceReadback", null, [
+                    new ActionResult("grp", "Deleted resource readback", TestScriptOutcome.Pass,
+                        "assertionAnyOfGroup 'grp': matched alternative 'Alternative: 404 Not Found'",
+                        GroupId: "grp",
+                        Members:
+                        [
+                            new AssertionGroupMemberResult("Preferred: 410 Gone", true, false, "Expected response 'gone' but got status 404"),
+                            new AssertionGroupMemberResult("Alternative: 404 Not Found", true, true, null)
+                        ])
+                ], TestScriptOutcome.Pass)
+            ]
+        };
+
+        var json = TestReportResourceGenerator.Generate(report);
+
+        var action = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!;
+        action["result"]!.GetValue<string>().ShouldBe("pass");
+        var extensions = action["extension"]!.AsArray();
+        extensions.Count.ShouldBe(2);
+        extensions[0]!["url"]!.GetValue<string>().ShouldBe("http://ignixa.io/testscript/assertionGroupMember");
+        var firstChildren = extensions[0]!["extension"]!.AsArray();
+        firstChildren.Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == false)
+            .ShouldBeTrue();
+        extensions[1]!["extension"]!.AsArray()
+            .Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == true)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenActionWithoutMembers_WhenGenerating_ThenNoExtensionEmitted()
+    {
+        var report = new TestScriptReport
+        {
+            TestScriptName = "PlainReport",
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            TestResults =
+            [
+                new TestCaseResult("Plain", null, [
+                    new ActionResult("a", null, TestScriptOutcome.Pass)
+                ], TestScriptOutcome.Pass)
+            ]
+        };
+
+        var json = TestReportResourceGenerator.Generate(report);
+
+        var action = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!;
+        action.AsObject().ContainsKey("extension").ShouldBeFalse();
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~TestReportResourceGeneratorTests"`
+Expected: the first new test fails (`action["extension"]` is null — nothing renders members today); the second passes already (no regression risk there, but keep it since it locks in the "no `Members`, no `extension` key" behavior going forward).
+
+- [ ] **Step 3: Update `TestReportResourceGenerator.cs`**
+
+Replace the existing `GenerateAction` method (currently lines 59-69) with:
+
+```csharp
+    private const string AssertionGroupMemberUrl = "http://ignixa.io/testscript/assertionGroupMember";
+
+    private static JsonObject GenerateAction(ActionResult action)
+    {
+        var obj = new JsonObject
+        {
+            ["result"] = MapActionResult(action.Outcome)
+        };
+        if (action.Label is not null) obj["id"] = action.Label;
+        if (action.Message is not null) obj["message"] = action.Message;
+        if (action.Description is not null) obj["detail"] = action.Description;
+
+        if (action.Members is { Count: > 0 })
+            obj["extension"] = GenerateGroupMemberExtensions(action.Members);
+
+        return obj;
+    }
+
+    private static JsonArray GenerateGroupMemberExtensions(IReadOnlyList<AssertionGroupMemberResult> members)
+    {
+        var array = new JsonArray();
+        foreach (var member in members)
+        {
+            var children = new JsonArray
+            {
+                new JsonObject { ["url"] = "applicable", ["valueBoolean"] = member.Applicable },
+                new JsonObject { ["url"] = "passed", ["valueBoolean"] = member.Passed }
+            };
+            if (member.Description is not null)
+                children.Add(new JsonObject { ["url"] = "description", ["valueString"] = member.Description });
+            if (member.Message is not null)
+                children.Add(new JsonObject { ["url"] = "message", ["valueString"] = member.Message });
+
+            array.Add(new JsonObject
+            {
+                ["url"] = AssertionGroupMemberUrl,
+                ["extension"] = children
+            });
+        }
+        return array;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~TestReportResourceGeneratorTests"`
+Expected: both new tests pass, plus every existing `TestReportResourceGeneratorTests` test still passes.
+
+- [ ] **Step 5: Run the full test project to confirm no regression**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests`
+Expected: 277 total tests pass × 2 target frameworks (275 from Task 2 + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs \
+        test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+git commit -m "feat(testscript): render assertion group members as child extensions in TestReport"
+```
+
+---
+
+### Task 4: Worked-example end-to-end fixture
+
+**Files:**
+- Test: Create `test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesEndToEndTests.cs`
+
+**Interfaces:**
+- Consumes (from Task 2, already merged by the time this runs): the evaluator behavior implemented there.
+- Consumes (existing, unchanged): `TestScriptParser.Parse(string json) : ParseResult<TestScriptDefinition>` (`Ignixa.TestScript.Parsing`), `ParseResult<T>.IsSuccess`, `ParseResult<T>.Value`.
+- Produces: nothing — this is the final task, a living usage reference exercised through the full parse → evaluate → report pipeline.
+
+This test parses a real TestScript JSON document (not hand-built C# expressions like Task 2's tests) mirroring issue #324's own worked example: a Subscription delete whose status is one of an OR group (`200`/`202`/`204`), followed by an immediate readback whose acceptable statuses depend on which delete status actually occurred.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesEndToEndTests.cs`:
+
+```csharp
+using Ignixa.Abstractions;
+using Ignixa.TestScript.Client;
+using Ignixa.TestScript.Evaluation;
+using Ignixa.TestScript.Fixtures;
+using Ignixa.TestScript.Parsing;
+using Ignixa.TestScript.Reporting;
+using NSubstitute;
+
+namespace Ignixa.TestScript.Tests.Evaluation;
+
+public class AssertionAlternativesEndToEndTests
+{
+    private readonly ITestRequestProvider _mockProvider;
+    private readonly IFixtureProvider _fixtureProvider;
+    private readonly IFhirSchemaProvider _schema;
+
+    public AssertionAlternativesEndToEndTests()
+    {
+        _mockProvider = Substitute.For<ITestRequestProvider>();
+        _fixtureProvider = new InlineFixtureProvider();
+        _schema = Substitute.For<IFhirSchemaProvider>();
+    }
+
+    [Fact]
+    public async Task GivenSubscriptionDeleteReadbackWorkedExample_WhenExecutingEndToEnd_ThenBothGroupsPassViaMatchedAlternative()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"SubscriptionDeleteReadback","status":"active",
+              "test":[{"name":"delete then readback","action":[
+                {"operation":{"type":{"code":"delete"},"url":"Subscription/sub-1","responseId":"delete-response"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"200","warningOnly":true,"description":"Completed synchronously"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"202","warningOnly":true,"description":"Accepted asynchronously"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"204","warningOnly":true,"description":"Completed with no content"}},
+                {"operation":{"type":{"code":"read"},"url":"Subscription/sub-1"}},
+                {"assert":{
+                  "extension":[
+                    {"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"},
+                    {"url":"http://ignixa.io/testscript/assertionWhenResponseStatus","extension":[
+                      {"url":"sourceId","valueString":"delete-response"},
+                      {"url":"status","valueInteger":202}
+                    ]}
+                  ],
+                  "responseCode":"200","warningOnly":true,
+                  "description":"An asynchronous delete may still be readable immediately"
+                }},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"}],
+                  "response":"notFound","warningOnly":true,"description":"404 when tracked as gone"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"}],
+                  "response":"gone","warningOnly":true,"description":"410 when tracked as deleted"}}
+              ]}]
+            }
+            """;
+
+        var parseResult = TestScriptParser.Parse(json);
+        parseResult.IsSuccess.ShouldBeTrue();
+
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 202 : 200
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(parseResult.Value!, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+        var actions = report.TestResults[0].Actions;
+        actions.Count.ShouldBe(4);
+
+        var deleteStatusGroup = actions[1];
+        deleteStatusGroup.GroupId.ShouldBe("delete-status");
+        deleteStatusGroup.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        deleteStatusGroup.Members!.Single(m => m.Passed).Description.ShouldBe("Accepted asynchronously");
+
+        var readbackGroup = actions[3];
+        readbackGroup.GroupId.ShouldBe("readback");
+        readbackGroup.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        readbackGroup.Members!.Single(m => m.Passed).Description
+            .ShouldBe("An asynchronous delete may still be readable immediately");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests --filter "FullyQualifiedName~AssertionAlternativesEndToEndTests"`
+
+If Tasks 1-3 are already merged into this branch (they should be, since this task runs after them), this test should **pass immediately** — it exercises only already-implemented behavior through a new entry point (parsed JSON instead of hand-built C# expressions). If it fails, that's a real gap: something about parsing + evaluating together doesn't match hand-built-expression behavior, and must be root-caused before proceeding — do not adjust the test's expectations to make it pass without understanding why.
+
+- [ ] **Step 3: Run the full test project to confirm no regression**
+
+Run: `dotnet test test/Ignixa.TestScript.Tests`
+Expected: 278 total tests pass × 2 target frameworks (277 from Task 3 + 1 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesEndToEndTests.cs
+git commit -m "test(testscript): add worked end-to-end example for assertion alternatives"
+```

--- a/docs/superpowers/specs/2026-07-11-testscript-assertion-alternatives-evaluator-design.md
+++ b/docs/superpowers/specs/2026-07-11-testscript-assertion-alternatives-evaluator-design.md
@@ -1,0 +1,292 @@
+# Design: Evaluator Execution for `assertionAnyOfGroup` / `assertionWhenResponseStatus`
+
+**Date**: 2026-07-11
+**Status**: Approved for implementation
+**Related**: [Issue #324](https://github.com/brendankowitz/ignixa-fhir/issues/324) (umbrella design + acceptance criteria), PR #330 (parsing/validation of these two extensions, merged), `ignixa-lab`'s `docs/superpowers/specs/2026-07-10-ignixa-testscript-engine-gaps-design.md`
+
+## Problem
+
+PR #330 added parsing and structural validation for `assertionAnyOfGroup` and
+`assertionWhenResponseStatus` — `AssertExpression.AnyOfGroupId` and `.WhenResponseStatus` are populated,
+and the parser rejects malformed groups (fewer than 2 members, mismatched sourceId/direction). But
+`TestScriptEvaluator` doesn't act on either field yet: `VisitAssertAsync` evaluates and records every
+assertion independently, so a group of `warningOnly` alternatives still fails open on an unexpected
+status — exactly the problem issue #324 was opened to fix. Until this lands, authoring a suite against
+these extensions expecting strict OR semantics is a trap: the JSON parses cleanly and silently does
+nothing beyond what plain adjacent `warningOnly` asserts already did.
+
+## Decision
+
+Add evaluator-side execution: assertions sharing a non-null `AnyOfGroupId` within one test aggregate into
+a single strict OR result. `WhenResponseStatus` is evaluated generically for *any* assertion (grouped or
+not) — an assertion whose condition doesn't match is **not applicable** (skipped, not failed or passed),
+independent of whether it belongs to a group. This is broader than issue #324's motivating example
+(Subscription delete readback, always paired with a group) but the parser doesn't enforce that pairing,
+and a standalone conditional assertion is a reasonable, useful primitive on its own.
+
+Both paths — standalone and grouped — route through one new evaluation primitive so conditional semantics
+behave identically either way (see Evaluation below).
+
+## Data Model
+
+### `Ignixa.TestScript.Reporting.AssertionOutcome` (`src/Core/Ignixa.TestScript/Reporting/AssertionOutcome.cs`)
+
+Add one field, default preserves every existing call site:
+
+```csharp
+public sealed record AssertionOutcome(
+    bool Passed,
+    bool WarningOnly,
+    string? Message = null,
+    bool IsError = false,
+    bool Applicable = true);
+```
+
+### New: `AssertionGroupMemberResult` (`src/Core/Ignixa.TestScript/Reporting/AssertionGroupMemberResult.cs`)
+
+One-record-per-file style, matching `ResponseStatusCondition.cs`/`WaitForCondition.cs` precedent:
+
+```csharp
+namespace Ignixa.TestScript.Reporting;
+
+/// <summary>
+/// One member's outcome within an <c>assertionAnyOfGroup</c> aggregate. Surfaced as diagnostic detail
+/// alongside the group's single top-level <see cref="ActionResult"/> — members are never reported as
+/// independent top-level results.
+/// </summary>
+public sealed record AssertionGroupMemberResult(
+    string? Description,
+    bool Applicable,
+    bool Passed,
+    string? Message);
+```
+
+### `Ignixa.TestScript.Reporting.ActionResult` (`src/Core/Ignixa.TestScript/Reporting/ActionResult.cs`)
+
+Add two optional fields, defaults preserve every existing call site:
+
+```csharp
+public sealed record ActionResult(
+    string? Label,
+    string? Description,
+    TestScriptOutcome Outcome,
+    string? Message = null,
+    TimeSpan Duration = default,
+    TestActionKind Kind = TestActionKind.Assertion,
+    HttpExchange? Exchange = null,
+    string? GroupId = null,
+    IReadOnlyList<AssertionGroupMemberResult>? Members = null);
+```
+
+### `Ignixa.TestScript.Reporting.ITestScriptResultRecorder` / `TestScriptResultRecorder`
+
+One new method (only one implementer in the codebase today — `TestScriptResultRecorder` — so this is a
+low-blast-radius interface change). It takes the same `AssertionOutcome` shape `RecordAssertionResult`
+already does, rather than a raw `TestScriptOutcome`, so the two methods share one
+pass/warning/fail/error decision rule instead of duplicating it:
+
+```csharp
+void RecordAssertionGroupResult(
+    string groupId,
+    string? label,
+    string? description,
+    AssertionOutcome outcome,
+    IReadOnlyList<AssertionGroupMemberResult> members);
+```
+
+`TestScriptResultRecorder.RecordAssertionResult` (line 53) has its `outcome.IsError`/`Passed`/
+`WarningOnly` → `TestScriptOutcome` mapping extracted into a small private static helper (e.g.
+`DetermineOutcome(AssertionOutcome)`); `RecordAssertionGroupResult` calls the same helper, then appends an
+`ActionResult` with `Kind = TestActionKind.Assertion`, `GroupId = groupId`, `Members = members`. The
+aggregate's own `Applicable` is always `true` — inapplicability lives on individual members, not the
+group result itself. A "no member was applicable" or "a member's sourceId failed to resolve" aggregate
+uses `IsError: true`; a resolved-but-all-failed aggregate uses plain `Passed: false`.
+
+## Evaluation
+
+### Shared primitive
+
+New private method on `TestScriptEvaluator`
+(`src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs`), sitting alongside
+`EvaluateAssertionWithMessage` (currently at line 575):
+
+```csharp
+private (bool Applicable, bool Passed, string? Message) EvaluateAssertionMember(
+    AssertExpression assertion, TestScriptContext context)
+{
+    if (assertion.WhenResponseStatus is { } condition)
+    {
+        if (!context.ResponseHistory.TryGetValue(condition.SourceId, out var response))
+            throw new InvalidOperationException(
+                $"assertionWhenResponseStatus sourceId '{condition.SourceId}' refers to no known response");
+
+        if (!condition.Statuses.Contains(response.StatusCode))
+            return (false, false, null);
+    }
+
+    var (passed, message) = EvaluateAssertionWithMessage(assertion, context);
+    return (true, passed, message);
+}
+```
+
+Throwing on an unresolvable `sourceId` reuses the exact pattern `ResolveAssertionResponse` (line ~607) and
+`ResolveAssertionRequest` (line ~616) already use for missing sourceIds elsewhere in this file — it's
+caught by `VisitAssertAsync`'s existing `catch (Exception ex)` (line 410) and recorded as
+`IsError: true`. This is what makes a forward reference (an operation later in the test, not yet in
+`ResponseHistory` when this assert runs) surface as an execution error rather than silently "not
+applicable" — matching issue #324's acceptance criteria.
+
+### Standalone path (`VisitAssertAsync`, currently line 395)
+
+```csharp
+public ValueTask<TestScriptContext> VisitAssertAsync(
+    AssertExpression expression, TestScriptContext context, CancellationToken cancellationToken)
+{
+    try
+    {
+        var (applicable, passed, message) = EvaluateAssertionMember(expression, context);
+        context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
+            new AssertionOutcome(passed, expression.WarningOnly, applicable ? message : null,
+                Applicable: applicable));
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+    catch (Exception ex)
+    {
+        context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
+            new AssertionOutcome(false, expression.WarningOnly, ex.Message, IsError: true));
+    }
+    return ValueTask.FromResult(context);
+}
+```
+
+This only fires for assertions with **no** `AnyOfGroupId` — grouped assertions are intercepted one level
+up, in `ExecuteActionsAsync`, and never reach the per-action visitor dispatch for recording purposes (see
+below). `TestScriptResultRecorder.RecordAssertionResult` (line 53) gets one new line: when
+`!outcome.Applicable`, the outcome maps to `TestScriptOutcome.Skip` ahead of the existing
+error/pass/warning/fail checks — this is the only recorder-side change needed for the standalone case.
+
+### Grouped path (`ExecuteActionsAsync`, currently line 302)
+
+Restructure to precompute group membership up front (mirrors what
+`TestScriptParser.ValidateAssertionGroups` already does at parse time) and special-case grouped asserts:
+
+```csharp
+private async Task<TestScriptContext> ExecuteActionsAsync(
+    IReadOnlyList<ActionExpression> actions,
+    IReadOnlyList<VariableDefinition> variables,
+    TestScriptContext context,
+    CancellationToken cancellationToken)
+{
+    var lastGroupIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+    for (var i = 0; i < actions.Count; i++)
+        if (actions[i] is AssertExpression { AnyOfGroupId: { } gid })
+            lastGroupIndex[gid] = i;
+
+    var pendingGroups = new Dictionary<string, List<(AssertExpression Assertion, bool Applicable, bool Passed, string? Message)>>(
+        StringComparer.Ordinal);
+
+    for (var i = 0; i < actions.Count; i++)
+    {
+        var action = actions[i];
+
+        if (action is AssertExpression { AnyOfGroupId: { } groupId } assertion)
+        {
+            var (applicable, passed, message) = EvaluateGroupMemberSafe(assertion, context);
+            if (!pendingGroups.TryGetValue(groupId, out var members))
+                pendingGroups[groupId] = members = [];
+            members.Add((assertion, applicable, passed, message));
+
+            if (i == lastGroupIndex[groupId])
+                RecordGroupResult(context, groupId, members);
+
+            continue;
+        }
+
+        context = await action.AcceptAsync(this, context, cancellationToken);
+        if (action is OperationExpression)
+            context = VariableExtractor.ExtractFromResponse(variables, context, schemaProvider);
+    }
+
+    return context;
+}
+```
+
+`EvaluateGroupMemberSafe` wraps `EvaluateAssertionMember` with the same try/catch shape
+`VisitAssertAsync` uses today, so a `sourceId` resolution failure on one member surfaces as that member's
+`Message` with an error flag rather than throwing out of `ExecuteActionsAsync` — the group's aggregate
+outcome computation (below) treats an errored member as inapplicable-with-error, distinct from
+not-applicable-by-condition, so "one member's condition referenced a bad sourceId" doesn't get silently
+absorbed into "no applicable member passed."
+
+`RecordGroupResult` aggregates:
+
+- Any member recorded an evaluation error → aggregate `Error`, message names the failing member.
+- No member is applicable (all conditions failed to match, none errored) → aggregate `Error`,
+  `"assertionAnyOfGroup '{groupId}': no member was applicable — condition(s) never matched"` (issue #324:
+  "an OR group with no applicable members is an execution error").
+- At least one applicable member passed → aggregate `Pass`, message names the matched member's
+  description. Individual members' own `warningOnly` flags never weaken this — issue #324's core
+  requirement.
+- Applicable members exist but none passed → aggregate `Fail`, message summarizes each applicable
+  member's actual result.
+
+Each branch constructs the appropriate `AssertionOutcome` (see above) and calls
+`recorder.RecordAssertionGroupResult(groupId, label, description, outcome, members.Select(ToGroupMemberResult).ToList())`.
+Label/description use the group's **matched** member on pass, otherwise the first member — there's no
+independently meaningful "group label" in the source TestScript, so this keeps the top-level entry
+human-readable without inventing new authoring surface.
+
+## Known Limitation (explicitly out of scope for this PR)
+
+Issue #324 states cross-test `sourceId` references should be invalid. `TestScriptContext.ResponseHistory`
+is not scoped per-test today — `context` threads across the whole `ExecuteAsync` run, including from one
+test's actions into the next's (`TestScriptEvaluator.cs` line ~124). A condition referencing a prior
+test's `responseId` will resolve rather than error. This is a pre-existing property of `TestScriptContext`
+un­related to the OR-group/conditional feature itself, and scoping `ResponseHistory` per test is a larger,
+separately-motivated change (it would also affect plain `sourceId` assertion/response resolution, which
+already has the same cross-test-reachability behavior today, group feature or not). Called out here and
+in the PR description rather than silently left undocumented; not fixed in this change.
+
+## Reporting: FHIR `TestReport` Rendering
+
+`TestReportResourceGenerator.GenerateAction` (`src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs`,
+line 59) gains: when `action.Members is { Count: > 0 }`, attach each member as a child `extension` on the
+action's JSON object (url `http://ignixa.io/testscript/assertionGroupMember`, each carrying the member's
+description/applicable/passed/message as nested extensions) rather than emitting them as separate
+top-level `action` entries. This keeps `TestReport.setup/test[].action` a valid FHIR resource — the spec
+has no native concept of a grouped assertion result — while member diagnostics remain inspectable rather
+than disappearing into the aggregate's single `message` string.
+
+## Testing
+
+**Evaluator** (new test file, e.g. `test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs`,
+following the existing `TestScriptEvaluatorTests.cs` fixture-building conventions):
+
+- Group where the preferred (first) member passes → aggregate `Pass`, matched member is the first.
+- Group where only the fallback member passes → aggregate `Pass`, matched member is the fallback, no
+  warning noise recorded despite the fallback's own `warningOnly: true`.
+- Group where no member passes → aggregate `Fail`, message lists all applicable members' actual results.
+- Group where a conditional member's condition never matches and no other member passes → aggregate
+  `Error` ("no member was applicable").
+- Group with a member whose `WhenResponseStatus.SourceId` doesn't resolve → aggregate `Error` naming that
+  member, not silently treated as inapplicable.
+- Standalone (no group) assertion with `WhenResponseStatus` whose condition matches → evaluated and
+  recorded normally (`Pass`/`Fail` per its own criteria).
+- Standalone assertion with `WhenResponseStatus` whose condition doesn't match → recorded as `Skip`, not
+  `Pass` or `Fail`.
+- Regression: a test with zero grouped/conditional assertions → byte-identical recorded results to today
+  (no behavior change for the other 264 existing tests).
+
+**Worked example fixture**: one `.json` TestScript fixture (mirroring issue #324's own
+`deleted-resource-readback`/`subscription-delete-readback` example) exercised through
+`TestScriptEvaluator.ExecuteAsync` end-to-end via a fake `ITestRequestProvider`, asserting on the final
+`TestScriptReport` shape — a living usage reference beyond the unit-level tests above.
+
+## Out of Scope
+
+- Migrating any of `ignixa-lab`'s workaround components (`WarningOnlyStatusAlternativeEnforcer`,
+  `StatusAlternativeEnforcementPlan`, `TestScriptContentNormalizer`, `RunScopedDefinitionPreparer`) — those
+  live in a different repository and are a separate follow-up once this ships in a release.
+- Shorthand normalization and consistent variable interpolation (issue #324's other two gaps) — untouched
+  by this change.
+- Scoping `TestScriptContext.ResponseHistory` per test (see Known Limitation above).

--- a/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
+++ b/src/Core/Ignixa.TestScript/Evaluation/TestScriptEvaluator.cs
@@ -305,14 +305,96 @@ public sealed class TestScriptEvaluator(
         TestScriptContext context,
         CancellationToken cancellationToken)
     {
-        foreach (var action in actions)
+        var lastGroupIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < actions.Count; i++)
+            if (actions[i] is AssertExpression { AnyOfGroupId: { } gid })
+                lastGroupIndex[gid] = i;
+
+        var pendingGroups = new Dictionary<string, List<(AssertExpression Assertion, bool Applicable, bool Passed, string? Message, bool IsError)>>(
+            StringComparer.Ordinal);
+
+        for (var i = 0; i < actions.Count; i++)
         {
+            var action = actions[i];
+
+            if (action is AssertExpression { AnyOfGroupId: { } groupId } assertion)
+            {
+                var member = EvaluateGroupMemberSafe(assertion, context);
+                if (!pendingGroups.TryGetValue(groupId, out var members))
+                    pendingGroups[groupId] = members = [];
+                members.Add((assertion, member.Applicable, member.Passed, member.Message, member.IsError));
+
+                if (i == lastGroupIndex[groupId])
+                    RecordGroupResult(context, groupId, members);
+
+                continue;
+            }
+
             context = await action.AcceptAsync(this, context, cancellationToken);
             if (action is OperationExpression)
                 context = VariableExtractor.ExtractFromResponse(variables, context, schemaProvider);
         }
 
         return context;
+    }
+
+    private (bool Applicable, bool Passed, string? Message, bool IsError) EvaluateGroupMemberSafe(
+        AssertExpression assertion, TestScriptContext context)
+    {
+        try
+        {
+            var (applicable, passed, message) = EvaluateAssertionMember(assertion, context);
+            return (applicable, passed, message, false);
+        }
+        catch (Exception ex)
+        {
+            return (false, false, ex.Message, true);
+        }
+    }
+
+    private static void RecordGroupResult(
+        TestScriptContext context,
+        string groupId,
+        List<(AssertExpression Assertion, bool Applicable, bool Passed, string? Message, bool IsError)> members)
+    {
+        var reportMembers = members
+            .Select(m => new AssertionGroupMemberResult(m.Assertion.Description, m.Applicable, m.Passed, m.Message))
+            .ToList();
+
+        var first = members[0].Assertion;
+        var errored = members.FirstOrDefault(m => m.IsError);
+        var applicableMembers = members.Where(m => m.Applicable).ToList();
+        var matched = applicableMembers.FirstOrDefault(m => m.Passed);
+
+        AssertionOutcome outcome;
+        if (errored.IsError)
+        {
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': member '{errored.Assertion.Description}' failed to evaluate: {errored.Message}",
+                IsError: true);
+        }
+        else if (applicableMembers.Count == 0)
+        {
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': no member was applicable — condition(s) never matched",
+                IsError: true);
+        }
+        else if (matched.Passed)
+        {
+            outcome = new AssertionOutcome(true, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': matched alternative '{matched.Assertion.Description}'");
+        }
+        else
+        {
+            var summary = string.Join("; ", applicableMembers.Select(m => $"{m.Assertion.Description}: {m.Message}"));
+            outcome = new AssertionOutcome(false, WarningOnly: false,
+                Message: $"assertionAnyOfGroup '{groupId}': no alternative matched ({summary})");
+        }
+
+        var label = matched.Passed ? matched.Assertion.Label : first.Label;
+        var description = matched.Passed ? matched.Assertion.Description : first.Description;
+
+        context.Recorder.RecordAssertionGroupResult(groupId, label, description, outcome, reportMembers);
     }
 
     public async ValueTask<TestScriptContext> VisitOperationAsync(
@@ -399,9 +481,9 @@ public sealed class TestScriptEvaluator(
     {
         try
         {
-            var (passed, message) = EvaluateAssertionWithMessage(expression, context);
+            var (applicable, passed, message) = EvaluateAssertionMember(expression, context);
             context.Recorder.RecordAssertionResult(expression.Label, expression.Description,
-                new AssertionOutcome(passed, expression.WarningOnly, passed ? null : message));
+                new AssertionOutcome(passed, expression.WarningOnly, applicable ? message : null, Applicable: applicable));
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -571,6 +653,23 @@ public sealed class TestScriptEvaluator(
         "delete" => HttpMethod.Delete,
         _ => HttpMethod.Post
     };
+
+    private (bool Applicable, bool Passed, string? Message) EvaluateAssertionMember(
+        AssertExpression assertion, TestScriptContext context)
+    {
+        if (assertion.WhenResponseStatus is { } condition)
+        {
+            if (!context.ResponseHistory.TryGetValue(condition.SourceId, out var response))
+                throw new InvalidOperationException(
+                    $"assertionWhenResponseStatus sourceId '{condition.SourceId}' refers to no known response");
+
+            if (!condition.Statuses.Contains(response.StatusCode))
+                return (false, false, null);
+        }
+
+        var (passed, message) = EvaluateAssertionWithMessage(assertion, context);
+        return (true, passed, message);
+    }
 
     private (bool Passed, string? Message) EvaluateAssertionWithMessage(
         AssertExpression assertion, TestScriptContext context)

--- a/src/Core/Ignixa.TestScript/Reporting/ActionResult.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/ActionResult.cs
@@ -7,4 +7,6 @@ public sealed record ActionResult(
     string? Message = null,
     TimeSpan Duration = default,
     TestActionKind Kind = TestActionKind.Assertion,
-    HttpExchange? Exchange = null);
+    HttpExchange? Exchange = null,
+    string? GroupId = null,
+    IReadOnlyList<AssertionGroupMemberResult>? Members = null);

--- a/src/Core/Ignixa.TestScript/Reporting/AssertionGroupMemberResult.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/AssertionGroupMemberResult.cs
@@ -1,0 +1,12 @@
+namespace Ignixa.TestScript.Reporting;
+
+/// <summary>
+/// One member's outcome within an <c>assertionAnyOfGroup</c> aggregate. Surfaced as diagnostic detail
+/// alongside the group's single top-level <see cref="ActionResult"/> — members are never reported as
+/// independent top-level results.
+/// </summary>
+public sealed record AssertionGroupMemberResult(
+    string? Description,
+    bool Applicable,
+    bool Passed,
+    string? Message);

--- a/src/Core/Ignixa.TestScript/Reporting/AssertionOutcome.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/AssertionOutcome.cs
@@ -4,4 +4,5 @@ public sealed record AssertionOutcome(
     bool Passed,
     bool WarningOnly,
     string? Message = null,
-    bool IsError = false);
+    bool IsError = false,
+    bool Applicable = true);

--- a/src/Core/Ignixa.TestScript/Reporting/ITestScriptResultRecorder.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/ITestScriptResultRecorder.cs
@@ -6,6 +6,12 @@ public interface ITestScriptResultRecorder
 
     void RecordOperationResult(string? label, string? description, OperationOutcome outcome);
     void RecordAssertionResult(string? label, string? description, AssertionOutcome outcome);
+    void RecordAssertionGroupResult(
+        string groupId,
+        string? label,
+        string? description,
+        AssertionOutcome outcome,
+        IReadOnlyList<AssertionGroupMemberResult> members);
     void BeginPhase(TestPhaseType phase, string? name = null, string? description = null);
     void EndPhase();
     void RecordSkippedTest(string name, string? description, string reason);

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -56,6 +56,7 @@ public static class TestReportResourceGenerator
         return array;
     }
 
+    private const string AssertionAnyOfGroupUrl = "http://ignixa.io/testscript/assertionAnyOfGroup";
     private const string AssertionGroupMemberUrl = "http://ignixa.io/testscript/assertionGroupMember";
 
     private static JsonObject GenerateAction(ActionResult action)
@@ -68,15 +69,22 @@ public static class TestReportResourceGenerator
         if (action.Message is not null) obj["message"] = action.Message;
         if (action.Description is not null) obj["detail"] = action.Description;
 
+        var extensions = new JsonArray();
+        if (action.GroupId is not null)
+            extensions.Add(new JsonObject { ["url"] = AssertionAnyOfGroupUrl, ["valueString"] = action.GroupId });
         if (action.Members is { Count: > 0 })
-            obj["extension"] = GenerateGroupMemberExtensions(action.Members);
+            foreach (var member in GenerateGroupMemberExtensions(action.Members))
+                extensions.Add(member);
+
+        if (extensions.Count > 0)
+            obj["extension"] = extensions;
 
         return obj;
     }
 
-    private static JsonArray GenerateGroupMemberExtensions(IReadOnlyList<AssertionGroupMemberResult> members)
+    private static List<JsonObject> GenerateGroupMemberExtensions(IReadOnlyList<AssertionGroupMemberResult> members)
     {
-        var array = new JsonArray();
+        var result = new List<JsonObject>();
         foreach (var member in members)
         {
             var children = new JsonArray
@@ -89,13 +97,13 @@ public static class TestReportResourceGenerator
             if (member.Message is not null)
                 children.Add(new JsonObject { ["url"] = "message", ["valueString"] = member.Message });
 
-            array.Add(new JsonObject
+            result.Add(new JsonObject
             {
                 ["url"] = AssertionGroupMemberUrl,
                 ["extension"] = children
             });
         }
-        return array;
+        return result;
     }
 
     // Action-level results bind to the FHIR action-result valueset (pass | skip | fail | warning | error).

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -56,6 +56,8 @@ public static class TestReportResourceGenerator
         return array;
     }
 
+    private const string AssertionGroupMemberUrl = "http://ignixa.io/testscript/assertionGroupMember";
+
     private static JsonObject GenerateAction(ActionResult action)
     {
         var obj = new JsonObject
@@ -65,7 +67,35 @@ public static class TestReportResourceGenerator
         if (action.Label is not null) obj["id"] = action.Label;
         if (action.Message is not null) obj["message"] = action.Message;
         if (action.Description is not null) obj["detail"] = action.Description;
+
+        if (action.Members is { Count: > 0 })
+            obj["extension"] = GenerateGroupMemberExtensions(action.Members);
+
         return obj;
+    }
+
+    private static JsonArray GenerateGroupMemberExtensions(IReadOnlyList<AssertionGroupMemberResult> members)
+    {
+        var array = new JsonArray();
+        foreach (var member in members)
+        {
+            var children = new JsonArray
+            {
+                new JsonObject { ["url"] = "applicable", ["valueBoolean"] = member.Applicable },
+                new JsonObject { ["url"] = "passed", ["valueBoolean"] = member.Passed }
+            };
+            if (member.Description is not null)
+                children.Add(new JsonObject { ["url"] = "description", ["valueString"] = member.Description });
+            if (member.Message is not null)
+                children.Add(new JsonObject { ["url"] = "message", ["valueString"] = member.Message });
+
+            array.Add(new JsonObject
+            {
+                ["url"] = AssertionGroupMemberUrl,
+                ["extension"] = children
+            });
+        }
+        return array;
     }
 
     // Action-level results bind to the FHIR action-result valueset (pass | skip | fail | warning | error).

--- a/src/Core/Ignixa.TestScript/Reporting/TestScriptResultRecorder.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestScriptResultRecorder.cs
@@ -57,17 +57,37 @@ public sealed class TestScriptResultRecorder : ITestScriptResultRecorder
         if (!_inPhase)
             throw new InvalidOperationException("RecordAssertionResult called without an open phase. Call BeginPhase first.");
 
-        TestScriptOutcome resultOutcome;
-        if (outcome.IsError)
-            resultOutcome = TestScriptOutcome.Error;
-        else if (outcome.Passed)
-            resultOutcome = TestScriptOutcome.Pass;
-        else if (outcome.WarningOnly)
-            resultOutcome = TestScriptOutcome.Warning;
-        else
-            resultOutcome = TestScriptOutcome.Fail;
+        _currentActions.Add(new ActionResult(label, description, DetermineOutcome(outcome), outcome.Message));
+    }
 
-        _currentActions.Add(new ActionResult(label, description, resultOutcome, outcome.Message));
+    public void RecordAssertionGroupResult(
+        string groupId,
+        string? label,
+        string? description,
+        AssertionOutcome outcome,
+        IReadOnlyList<AssertionGroupMemberResult> members)
+    {
+        if (_isBuilt)
+            throw new InvalidOperationException("Cannot record results after Build() has been called.");
+        if (!_inPhase)
+            throw new InvalidOperationException("RecordAssertionGroupResult called without an open phase. Call BeginPhase first.");
+
+        _currentActions.Add(new ActionResult(
+            label, description, DetermineOutcome(outcome), outcome.Message,
+            GroupId: groupId, Members: members));
+    }
+
+    private static TestScriptOutcome DetermineOutcome(AssertionOutcome outcome)
+    {
+        if (!outcome.Applicable)
+            return TestScriptOutcome.Skip;
+        if (outcome.IsError)
+            return TestScriptOutcome.Error;
+        if (outcome.Passed)
+            return TestScriptOutcome.Pass;
+        if (outcome.WarningOnly)
+            return TestScriptOutcome.Warning;
+        return TestScriptOutcome.Fail;
     }
 
     public void EndPhase()

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesEndToEndTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesEndToEndTests.cs
@@ -1,0 +1,85 @@
+using Ignixa.Abstractions;
+using Ignixa.TestScript.Client;
+using Ignixa.TestScript.Evaluation;
+using Ignixa.TestScript.Fixtures;
+using Ignixa.TestScript.Parsing;
+using Ignixa.TestScript.Reporting;
+using NSubstitute;
+
+namespace Ignixa.TestScript.Tests.Evaluation;
+
+public class AssertionAlternativesEndToEndTests
+{
+    private readonly ITestRequestProvider _mockProvider;
+    private readonly IFixtureProvider _fixtureProvider;
+    private readonly IFhirSchemaProvider _schema;
+
+    public AssertionAlternativesEndToEndTests()
+    {
+        _mockProvider = Substitute.For<ITestRequestProvider>();
+        _fixtureProvider = new InlineFixtureProvider();
+        _schema = Substitute.For<IFhirSchemaProvider>();
+    }
+
+    [Fact]
+    public async Task GivenSubscriptionDeleteReadbackWorkedExample_WhenExecutingEndToEnd_ThenBothGroupsPassViaMatchedAlternative()
+    {
+        var json = """
+            {
+              "resourceType":"TestScript","name":"SubscriptionDeleteReadback","status":"active",
+              "test":[{"name":"delete then readback","action":[
+                {"operation":{"type":{"code":"delete"},"url":"Subscription/sub-1","responseId":"delete-response"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"200","warningOnly":true,"description":"Completed synchronously"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"202","warningOnly":true,"description":"Accepted asynchronously"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"delete-status"}],
+                  "responseCode":"204","warningOnly":true,"description":"Completed with no content"}},
+                {"operation":{"type":{"code":"read"},"url":"Subscription/sub-1"}},
+                {"assert":{
+                  "extension":[
+                    {"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"},
+                    {"url":"http://ignixa.io/testscript/assertionWhenResponseStatus","extension":[
+                      {"url":"sourceId","valueString":"delete-response"},
+                      {"url":"status","valueInteger":202}
+                    ]}
+                  ],
+                  "responseCode":"200","warningOnly":true,
+                  "description":"An asynchronous delete may still be readable immediately"
+                }},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"}],
+                  "response":"notFound","warningOnly":true,"description":"404 when tracked as gone"}},
+                {"assert":{"extension":[{"url":"http://ignixa.io/testscript/assertionAnyOfGroup","valueString":"readback"}],
+                  "response":"gone","warningOnly":true,"description":"410 when tracked as deleted"}}
+              ]}]
+            }
+            """;
+
+        var parseResult = TestScriptParser.Parse(json);
+        parseResult.IsSuccess.ShouldBeTrue();
+
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 202 : 200
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(parseResult.Value!, CancellationToken.None);
+
+        report.OverallOutcome.ShouldBe(TestScriptOutcome.Pass);
+        var actions = report.TestResults[0].Actions;
+        actions.Count.ShouldBe(4);
+
+        var deleteStatusGroup = actions[1];
+        deleteStatusGroup.GroupId.ShouldBe("delete-status");
+        deleteStatusGroup.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        deleteStatusGroup.Members!.Single(m => m.Passed).Description.ShouldBe("Accepted asynchronously");
+
+        var readbackGroup = actions[3];
+        readbackGroup.GroupId.ShouldBe("readback");
+        readbackGroup.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        readbackGroup.Members!.Single(m => m.Passed).Description
+            .ShouldBe("An asynchronous delete may still be readable immediately");
+    }
+}

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs
@@ -1,0 +1,251 @@
+using Ignixa.Abstractions;
+using Ignixa.TestScript.Client;
+using Ignixa.TestScript.Evaluation;
+using Ignixa.TestScript.Expressions;
+using Ignixa.TestScript.Fixtures;
+using Ignixa.TestScript.Model;
+using Ignixa.TestScript.Reporting;
+using NSubstitute;
+
+namespace Ignixa.TestScript.Tests.Evaluation;
+
+public class AssertionAlternativesTests
+{
+    private readonly ITestRequestProvider _mockProvider;
+    private readonly IFixtureProvider _fixtureProvider;
+    private readonly IFhirSchemaProvider _schema;
+
+    public AssertionAlternativesTests()
+    {
+        _mockProvider = Substitute.For<ITestRequestProvider>();
+        _fixtureProvider = new InlineFixtureProvider();
+        _schema = Substitute.For<IFhirSchemaProvider>();
+    }
+
+    private static TestScriptDefinition SingleTestDefinition(string name, params ActionExpression[] actions) =>
+        new()
+        {
+            Metadata = new TestScriptMetadata { Name = name },
+            Tests = [new TestPhaseDefinition { Name = "t", Actions = actions }]
+        };
+
+    [Fact]
+    public async Task GivenGroupWherePreferredMemberPasses_WhenExecuting_ThenAggregatePassesAndCarriesBothMembers()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 410 });
+
+        var definition = SingleTestDefinition("GroupPreferred",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        report.TestResults[0].Actions.Count.ShouldBe(2);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        groupAction.GroupId.ShouldBe("deleted-resource-readback");
+        groupAction.Members!.Count.ShouldBe(2);
+        groupAction.Members[0].Passed.ShouldBeTrue();
+        groupAction.Members[1].Passed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereOnlyFallbackMemberPasses_WhenExecuting_ThenAggregatePassesWithoutWarning()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 404 });
+
+        var definition = SingleTestDefinition("GroupFallback",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        groupAction.Members![0].Passed.ShouldBeFalse();
+        groupAction.Members[1].Passed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereNoMemberPasses_WhenExecuting_ThenAggregateFails()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 500 });
+
+        var definition = SingleTestDefinition("GroupNoneMatch",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Preferred: 410 Gone"
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "deleted-resource-readback",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Fail);
+        report.TestResults[0].Actions[1].Outcome.ShouldBe(TestScriptOutcome.Fail);
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereNoMemberIsApplicable_WhenExecuting_ThenAggregateErrors()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = SingleTestDefinition("GroupNoneApplicable",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/deleted-id", ResponseId = "delete-response" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                AnyOfGroupId = "conditional-group",
+                WarningOnly = true,
+                Description = "Only applies if delete returned 202",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "conditional-group",
+                WarningOnly = true,
+                Description = "Only applies if delete returned 204",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [204])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Error);
+        groupAction.Message.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GivenGroupMemberWithUnresolvableSourceId_WhenExecuting_ThenAggregateErrorsNamingMember()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 404 });
+
+        var definition = SingleTestDefinition("GroupBadSourceId",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/deleted-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("gone"),
+                AnyOfGroupId = "bad-group",
+                WarningOnly = true,
+                Description = "Broken conditional member",
+                WhenResponseStatus = new ResponseStatusCondition("does-not-exist", [202])
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "bad-group",
+                WarningOnly = true,
+                Description = "Alternative: 404 Not Found"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Outcome.ShouldBe(TestScriptOutcome.Error);
+        groupAction.Message!.ShouldContain("Broken conditional member");
+    }
+
+    [Fact]
+    public async Task GivenStandaloneConditionalAssertionWhoseConditionMatches_WhenExecuting_ThenEvaluatedNormally()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 202 : 200
+            });
+
+        var definition = SingleTestDefinition("StandaloneConditionMatches",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/async-id", ResponseId = "delete-response" },
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/async-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                WarningOnly = true,
+                Description = "An asynchronous delete may still be readable immediately",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        report.TestResults[0].Actions[2].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
+    public async Task GivenStandaloneConditionalAssertionWhoseConditionDoesNotMatch_WhenExecuting_ThenRecordedAsSkip()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new TestResponse
+            {
+                StatusCode = call.Arg<TestRequest>().Method == HttpMethod.Delete ? 204 : 404
+            });
+
+        var definition = SingleTestDefinition("StandaloneConditionMismatch",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/async-id", ResponseId = "delete-response" },
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/async-id" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                WarningOnly = true,
+                Description = "An asynchronous delete may still be readable immediately",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Actions[2].Outcome.ShouldBe(TestScriptOutcome.Skip);
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+}

--- a/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs
+++ b/test/Ignixa.TestScript.Tests/Evaluation/AssertionAlternativesTests.cs
@@ -96,6 +96,7 @@ public class AssertionAlternativesTests
         groupAction.Outcome.ShouldBe(TestScriptOutcome.Pass);
         groupAction.Members![0].Passed.ShouldBeFalse();
         groupAction.Members[1].Passed.ShouldBeTrue();
+        groupAction.Description.ShouldBe("Alternative: 404 Not Found");
     }
 
     [Fact]
@@ -247,5 +248,62 @@ public class AssertionAlternativesTests
 
         report.TestResults[0].Actions[2].Outcome.ShouldBe(TestScriptOutcome.Skip);
         report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+    }
+
+    [Fact]
+    public async Task GivenGroupWhereFirstMemberIsInapplicableAndLaterMemberPasses_WhenExecuting_ThenAggregatePassesViaLaterMember()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 404 });
+
+        var definition = SingleTestDefinition("GroupFirstInapplicable",
+            new OperationExpression { Type = "delete", Resource = "Patient", Params = "/async-id", ResponseId = "delete-response" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                AnyOfGroupId = "readback",
+                WarningOnly = true,
+                Description = "Only applies if delete returned 202",
+                WhenResponseStatus = new ResponseStatusCondition("delete-response", [202])
+            },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("notFound"),
+                AnyOfGroupId = "readback",
+                WarningOnly = true,
+                Description = "404 when tracked as gone"
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Pass);
+        var groupAction = report.TestResults[0].Actions[1];
+        groupAction.Members![0].Applicable.ShouldBeFalse();
+        groupAction.Members[1].Passed.ShouldBeTrue();
+        groupAction.Description.ShouldBe("404 when tracked as gone");
+    }
+
+    [Fact]
+    public async Task GivenStandaloneAssertionWithUnresolvableSourceId_WhenExecuting_ThenRecordedAsError()
+    {
+        _mockProvider.ExecuteAsync(Arg.Any<TestRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TestResponse { StatusCode = 200 });
+
+        var definition = SingleTestDefinition("StandaloneBadSourceId",
+            new OperationExpression { Type = "read", Resource = "Patient", Params = "/123" },
+            new AssertExpression
+            {
+                Criteria = new ResponseStatusCriteria("okay"),
+                WarningOnly = true,
+                Description = "Broken conditional assertion",
+                WhenResponseStatus = new ResponseStatusCondition("does-not-exist", [202])
+            });
+
+        var evaluator = new TestScriptEvaluator(_mockProvider, _fixtureProvider, _schema);
+        var report = await evaluator.ExecuteAsync(definition, CancellationToken.None);
+
+        report.TestResults[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+        report.TestResults[0].Actions[1].Outcome.ShouldBe(TestScriptOutcome.Error);
     }
 }

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -137,4 +137,64 @@ public class TestReportResourceGeneratorTests
         var actionResult = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!["result"]!.GetValue<string>();
         actionResult.ShouldBe("skip");
     }
+
+    [Fact]
+    public void GivenGroupActionWithMembers_WhenGenerating_ThenMembersRenderAsChildExtensions()
+    {
+        var report = new TestScriptReport
+        {
+            TestScriptName = "GroupReport",
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            TestResults =
+            [
+                new TestCaseResult("DeletedResourceReadback", null, [
+                    new ActionResult("grp", "Deleted resource readback", TestScriptOutcome.Pass,
+                        "assertionAnyOfGroup 'grp': matched alternative 'Alternative: 404 Not Found'",
+                        GroupId: "grp",
+                        Members:
+                        [
+                            new AssertionGroupMemberResult("Preferred: 410 Gone", true, false, "Expected response 'gone' but got status 404"),
+                            new AssertionGroupMemberResult("Alternative: 404 Not Found", true, true, null)
+                        ])
+                ], TestScriptOutcome.Pass)
+            ]
+        };
+
+        var json = TestReportResourceGenerator.Generate(report);
+
+        var action = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!;
+        action["result"]!.GetValue<string>().ShouldBe("pass");
+        var extensions = action["extension"]!.AsArray();
+        extensions.Count.ShouldBe(2);
+        extensions[0]!["url"]!.GetValue<string>().ShouldBe("http://ignixa.io/testscript/assertionGroupMember");
+        var firstChildren = extensions[0]!["extension"]!.AsArray();
+        firstChildren.Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == false)
+            .ShouldBeTrue();
+        extensions[1]!["extension"]!.AsArray()
+            .Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == true)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenActionWithoutMembers_WhenGenerating_ThenNoExtensionEmitted()
+    {
+        var report = new TestScriptReport
+        {
+            TestScriptName = "PlainReport",
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            TestResults =
+            [
+                new TestCaseResult("Plain", null, [
+                    new ActionResult("a", null, TestScriptOutcome.Pass)
+                ], TestScriptOutcome.Pass)
+            ]
+        };
+
+        var json = TestReportResourceGenerator.Generate(report);
+
+        var action = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!;
+        action.AsObject().ContainsKey("extension").ShouldBeFalse();
+    }
 }

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -166,12 +166,14 @@ public class TestReportResourceGeneratorTests
         var action = json["test"]!.AsArray()[0]!["action"]!.AsArray()[0]!;
         action["result"]!.GetValue<string>().ShouldBe("pass");
         var extensions = action["extension"]!.AsArray();
-        extensions.Count.ShouldBe(2);
-        extensions[0]!["url"]!.GetValue<string>().ShouldBe("http://ignixa.io/testscript/assertionGroupMember");
-        var firstChildren = extensions[0]!["extension"]!.AsArray();
+        extensions.Count.ShouldBe(3);
+        extensions[0]!["url"]!.GetValue<string>().ShouldBe("http://ignixa.io/testscript/assertionAnyOfGroup");
+        extensions[0]!["valueString"]!.GetValue<string>().ShouldBe("grp");
+        extensions[1]!["url"]!.GetValue<string>().ShouldBe("http://ignixa.io/testscript/assertionGroupMember");
+        var firstChildren = extensions[1]!["extension"]!.AsArray();
         firstChildren.Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == false)
             .ShouldBeTrue();
-        extensions[1]!["extension"]!.AsArray()
+        extensions[2]!["extension"]!.AsArray()
             .Any(c => c!["url"]!.GetValue<string>() == "passed" && c["valueBoolean"]!.GetValue<bool>() == true)
             .ShouldBeTrue();
     }

--- a/test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestScriptResultRecorderTests.cs
@@ -196,4 +196,81 @@ public class TestScriptResultRecorderTests
         action.Exchange!.Request.ShouldBe(request);
         action.Exchange.Response.ShouldBe(response);
     }
+
+    [Fact]
+    public void GivenInapplicableAssertion_WhenRecording_ThenOutcomeIsSkip()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+        recorder.RecordAssertionResult("a", "desc",
+            new AssertionOutcome(false, WarningOnly: false, Applicable: false));
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Skip);
+    }
+
+    [Fact]
+    public void GivenPassingGroupResult_WhenRecording_ThenActionCarriesGroupIdAndMembers()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Preferred: 410 Gone", true, false, "Expected response 'gone' but got status 404"),
+            new("Alternative: 404 Not Found", true, true, null)
+        };
+        recorder.RecordAssertionGroupResult("deleted-resource-readback", "grp", "Deleted resource readback",
+            new AssertionOutcome(true, WarningOnly: false), members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        var action = report.TestResults[0].Actions[0];
+        action.Outcome.ShouldBe(TestScriptOutcome.Pass);
+        action.GroupId.ShouldBe("deleted-resource-readback");
+        action.Members.ShouldNotBeNull();
+        action.Members!.Count.ShouldBe(2);
+        action.Members[1].Passed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenErroredGroupResult_WhenRecording_ThenOutcomeIsError()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Member A", false, false, null),
+            new("Member B", false, false, null)
+        };
+        recorder.RecordAssertionGroupResult("group-x", null, "Group X",
+            new AssertionOutcome(false, WarningOnly: false, Message: "no member was applicable", IsError: true),
+            members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Error);
+    }
+
+    [Fact]
+    public void GivenFailedGroupResult_WhenRecording_ThenOutcomeIsFail()
+    {
+        var recorder = new TestScriptResultRecorder();
+        recorder.BeginPhase(TestPhaseType.Test, "Test");
+
+        var members = new List<AssertionGroupMemberResult>
+        {
+            new("Member A", true, false, "expected X"),
+            new("Member B", true, false, "expected Y")
+        };
+        recorder.RecordAssertionGroupResult("group-y", null, "Group Y",
+            new AssertionOutcome(false, WarningOnly: false, Message: "no alternative matched"),
+            members);
+        recorder.EndPhase();
+
+        var report = recorder.Build("name", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        report.TestResults[0].Actions[0].Outcome.ShouldBe(TestScriptOutcome.Fail);
+    }
 }


### PR DESCRIPTION
## Summary

PR #330 added parsing/validation for `assertionAnyOfGroup` and `assertionWhenResponseStatus` but left the evaluator inert — a suite authored against these extensions parsed cleanly and silently did nothing beyond plain adjacent `warningOnly` asserts. This closes out the remaining evaluation/reporting checklist items on #324:

- `TestScriptEvaluator` now aggregates assertions sharing an `AnyOfGroupId` within one test into a single strict-OR result: at least one applicable member must pass or the whole group hard-fails/errors, regardless of individual members' own `warningOnly` flags.
- `assertionWhenResponseStatus` is evaluated generically for any assertion (grouped or standalone) — a condition that doesn't match makes the assertion **not applicable** (a new `Skip` outcome), not silently passed or failed. This is slightly broader than #324's motivating example (always paired with a group), since the parser doesn't enforce that pairing and a standalone conditional assertion is a reasonable primitive on its own.
- An evaluation error on any group member (e.g. an unresolvable `WhenResponseStatus.sourceId`) takes priority over the aggregate outcome, even over an otherwise-passing sibling — surfaces authoring bugs instead of silently absorbing them into "no member passed."
- The FHIR `TestReport` generator renders group members as child `extension`s on the aggregate action, so diagnostics survive without inventing non-conformant top-level report shape.

## Known limitation (explicitly out of scope, documented in the design doc)

`TestScriptContext.ResponseHistory` isn't scoped per-test — a `WhenResponseStatus` condition referencing a different test's `responseId` will resolve instead of erroring, contrary to #324's "cross-test references are invalid" criterion. This is a pre-existing property of `TestScriptContext` unrelated to this feature; scoping it is a larger, separately-motivated change.

## Process

Brainstormed → design spec ([docs/superpowers/specs/2026-07-11-testscript-assertion-alternatives-evaluator-design.md](docs/superpowers/specs/2026-07-11-testscript-assertion-alternatives-evaluator-design.md)) → implementation plan ([docs/superpowers/plans/2026-07-11-testscript-assertion-alternatives-evaluator.md](docs/superpowers/plans/2026-07-11-testscript-assertion-alternatives-evaluator.md)) → 4 tasks, each implemented and reviewed independently (spec compliance + code quality gates, all approved, zero Critical/Important findings across all four).

## Test plan

- [x] `dotnet test test/Ignixa.TestScript.Tests` — 278/278 passing on net9.0 + net10.0 (264 baseline + 14 new)
- [x] Task-level spec-compliance + code-quality reviews — all four approved, no Critical/Important findings
- [ ] Final whole-branch review (pr-review-toolkit)
- [ ] Independent Fable-model review for ignixa-lab migration fitness

Closes remaining evaluation/reporting checklist items on #324.

🤖 Generated with subagent-driven development (Claude Code)