### PR TITLE
docs(architecture): Application layer modernization review and roadmap

### DIFF
--- a/docs/features/application-layer-modernization/investigations/api-http-layer-review.md
+++ b/docs/features/application-layer-modernization/investigations/api-http-layer-review.md
@@ -1,0 +1,264 @@
+# Investigation: API/HTTP Layer Architecture & Technical Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Ignixa.Api, Ignixa.Api.OpenIddict, Ignixa.Web
+
+## Summary
+
+The layer respects ADR 2509's macro structure — Minimal API only, no MVC controllers, no `Hl7.Fhir.*` dependencies, mediator-based dispatch, `Ignixa.Web` as a thin host. Below that, the layer has one systemic security defect and heavy copy-paste debt. Authorization is enforced *only* by per-file endpoint-filter registration (`RequireAuthorization` appears nowhere), and roughly a third of endpoint files forgot the filters — `$export`, `$import`, admin package management, system `/_history`, and all agnostic operation routes run with no authorization or audit. Separately, `FhirAuthorizationFilter` wraps the entire downstream pipeline in a `catch (Exception)` that converts every intentional FHIR error (400/404/412) into a generic 500 whenever authorization is enabled. Error response shapes are inconsistent across five different patterns, and the tenant/agnostic route duplication roughly doubles the endpoint code.
+
+## Strengths
+
+- **Layering discipline holds**: zero `Hl7.Fhir.*` usings, zero MVC controllers, zero `[ApiController]` in all three projects; endpoints dispatch via `IMediator.SendAsync` to Application-layer handlers.
+- **Streaming-first response design**: search/history/$everything stream bundles directly to `Response.Body` via `StreamingBundleSerializer` (`Endpoints/FhirEndpoints.cs:627`, `Endpoints/HistoryEndpoints.cs:158`), and `FhirResult` does zero-copy byte writes (`Results/FhirResult.cs:112`). `RecyclableMemoryStreamManager` is used consistently for body buffering.
+- **`Infrastructure/ProvenanceHeaderHelper.cs`** is a model helper: 16KB size cap (`:29-74`), specific exception types, actionable error messages, correct CT propagation.
+- **`Ignixa.Api.OpenIddict/Services/SmartScopeGenerator.cs`** is clean, `sealed`/static, source-generated regexes, correct SMART v2 CRUDS-order validation (`:217-237`).
+- **TenantResolutionMiddleware partition-0 block** works as specified in CLAUDE.md: `/tenant/0/` rejected with 400 + OperationOutcome (`Middleware/TenantResolutionMiddleware.cs:59-80`).
+- Experimental endpoints are properly config-gated per feature (`Endpoints/Experimental/ExperimentalEndpointExtensions.cs:38-68`) and the tenant group receives the standard filter stack via callback (`Extensions/EndpointRouteBuilderExtensions.cs:76-83`).
+
+## Findings
+
+### P0 — FhirAuthorizationFilter converts all downstream FHIR errors into generic 500s
+**Location**: `src/Application/Ignixa.Api/Filters/FhirAuthorizationFilter.cs:68-121`
+**Issue**: `return await next(context)` (line 101) sits *inside* the filter's `try` block, and the trailing `catch (Exception ex)` (line 108) returns `CreateErrorResponse("An error occurred during authorization")` — a 500. Endpoint handlers deliberately throw `BadRequestException`, `NotAcceptableException`, etc. (all `FhirException` subclasses, e.g. `Endpoints/FhirEndpoints.cs:437,448,457`) expecting `FhirExceptionMiddleware` to map them to 400/404/406/412. With `Authorization:Enabled=true` the filter intercepts every one of these first and returns a misleading 500 "authorization error". Because tests and the dev profile run with authorization disabled (the disabled path at line 61-64 returns *outside* the `try`), this bug is invisible until auth is turned on.
+**Recommendation**: Move `return await next(context)` out of the `try`, or narrow the `catch` to exceptions thrown by `BuildAuthorizationContextAsync`/`AuthorizeAsync` only. Add an E2E test suite that runs with authorization enabled.
+**Effort**: S (fix), M (test coverage)
+
+### P0 — Systemic authorization/audit bypass: many endpoints never receive the filter stack
+**Location**:
+- `src/Application/Ignixa.Api/Endpoints/ExportEndpoints.cs:28-45` — system `$export`, tenant `$export`, `Group/{id}/$export`, status, cancel: no filters
+- `src/Application/Ignixa.Api/Endpoints/ImportEndpoints.cs:33-42` — `$import`, status, cancel: no filters
+- `src/Application/Ignixa.Api/Endpoints/AdminPackageEndpoints.cs:19-36` — admin package load/list/unload: no filters
+- `src/Application/Ignixa.Api/Endpoints/HistoryEndpoints.cs:70,112` — system-level `/_history` (both tenant and agnostic) registered directly on `endpoints`, not the filtered group; the comment "no filter needed" confuses resource-type validation with authorization
+- `src/Application/Ignixa.Api/Endpoints/OperationEndpoints.cs:118-166` — *all* agnostic operation routes (`/$validate`, `/{resourceType}/$validate`, `/Patient/{id}/$everything`, `/Patient/$member-match`, `/{resourceType}/$includes`) registered with no filters, while their tenant-prefixed twins (`:66-71`) get all four
+- `src/Application/Ignixa.Api/Endpoints/DeIdOperationEndpoints.cs:55` — agnostic `/$de-identify` registered outside the filtered group
+
+**Issue**: `RequireAuthorization()` is used nowhere in the codebase and `UseAuthorization()` has no fallback policy, so `FhirAuthorizationFilter` is the *only* authorization enforcement — and it must be re-attached by hand in every endpoint file. The files above forgot it. Concretely: with authorization enabled, an unauthenticated caller can still run `GET /Patient/123/$everything` (full patient record), `POST /$export` (bulk export of everything), `POST /$import` (bulk write), and admin package mutation — and none of these produce audit events either, because `FhirAuditFilter` is missing too.
+**Recommendation**: Stop copy-pasting the filter stack: create one shared `MapFhirGroup(...)` helper that every endpoint file must use, and add a conformance test that walks `EndpointDataSource` asserting every non-allow-listed endpoint has the authorization filter. A global `FallbackPolicy` is *not* a sufficient alternative: `AspNetCorePipelineExecutor` invokes endpoint `RequestDelegate`s directly for bundle entries (`Infrastructure/AspNetCorePipelineExecutor.cs:108`), bypassing `AuthorizationMiddleware`, so policy-based enforcement would silently not apply inside bundles (see Architectural Observation 2).
+**Effort**: M
+
+### P0 — OpenIddict authorize endpoint auto-approves every request; dev certificates unconditional
+**Location**: `src/Application/Ignixa.Api.OpenIddict/Endpoints/AuthorizationEndpoints.cs:39-57`; `Extensions/OpenIddictServiceExtensions.cs:97-98`
+**Issue**: `/connect/authorize` signs in a hardcoded `"dev-user"` with *whatever scopes were requested* — no login, no consent, no credential check. The only gate is the `OpenIddict:Enabled` config flag; there is no `IHostEnvironment.IsDevelopment()` check anywhere in the project. `AddDevelopmentEncryptionCertificate()/AddDevelopmentSigningCertificate()` are always used — there is no code path for production certificates, so any deployment that flips `Enabled: true` (e.g. copying `appsettings.Development.json` patterns, or the checked-in `appsettings.openiddict.json` which has `"Enabled": true` plus `admin/admin123`-style users) becomes an open token mint for the FHIR API. Password comparison is also plaintext, non-constant-time (`Services/DevelopmentUserService.cs:26`).
+**Recommendation**: Hard-gate the whole `AddIgnixaOpenIddict` registration (or at minimum the auto-approve authorize handler, password flow, and dev certificates) on `IHostEnvironment.IsDevelopment()`, or fail startup in Production unless an explicit `AllowInsecureDevelopmentIdentityProvider=true` flag is set. Log a prominent warning when active.
+**Effort**: S
+
+### P1 — Server ships default-open: authentication and authorization disabled in production config
+**Location**: `src/Application/Ignixa.Web/appsettings.json` (`Authorization: { "Enabled": false, "RequireAuthentication": false }`); `src/Application/Ignixa.Api/Registrations/MiddlewareRegistration.cs:41`
+**Issue**: The checked-in production `appsettings.json` disables both authentication middleware and FHIR authorization. The code default in `MiddlewareRegistration.cs:41` is `true`, but the shipped config overrides it to `false`, so a default deployment of a healthcare data server accepts anonymous, unaudited access to everything. `MiddlewareRegistration` also conflates authentication and authorization behind the single `Authorization:Enabled` flag (`:41-46`) — you cannot have authenticated-but-unrestricted access.
+**Recommendation**: The F5-experience goal (ADR 2509) justifies open *Development* defaults, not open production defaults. Fail or loudly warn at startup when `Authorization:Enabled=false` outside Development; split the authentication toggle from the RBAC toggle.
+**Effort**: S
+
+### P1 — Internal exception messages leaked to clients in 500 responses
+**Location**: `src/Application/Ignixa.Api/Middleware/FhirExceptionMiddleware.cs:89`; `src/Application/Ignixa.Api/Endpoints/ImportEndpoints.cs:68-71`
+**Issue**: For any unhandled exception, `Diagnostics = exception.Message` puts raw internal detail (SQL errors, file paths, connection info) into the client-facing OperationOutcome. `ImportEndpoints.cs:70-71` does the same in a `catch (Exception)` that additionally misclassifies all failures as 400. Also, `FhirExceptionMiddleware.cs:78-82` maps every `InvalidOperationException` to 400 — that exception type is overwhelmingly a *server* bug and this masks 500s as client errors.
+**Recommendation**: Return a generic diagnostic plus the correlation ID for non-`FhirException` errors; log full detail server-side only. Drop the `InvalidOperationException`→400 mapping. In ImportEndpoints, narrow the catch to parse-specific exceptions.
+**Effort**: S
+
+### P1 — Authorization interaction parser defaults to `Read` (default-permit semantics)
+**Location**: `src/Application/Ignixa.Api/Filters/FhirAuthorizationFilter.cs:292-321`
+**Issue**: `ParseRoute`'s pattern match falls through to `_ => FhirInteraction.Read` (line 320). Concrete miss: `POST /tenant/1` (no trailing slash) matches the bundle route (`MapPost("/")` on the group tolerates the missing trailing slash) but the tuple arm at line 314 requires `path.EndsWith("/")`, so a *transaction* is authorized as a *read*. Any future route this parser doesn't recognize is likewise authorized under read semantics. Entry-level re-filtering does **not** mitigate this: bundle entries run the authorization filter against a synthetic HttpContext carrying an anonymous principal (verified — see Architectural Observation 2), so the transaction-level check is the only one that ever sees the real caller.
+**Recommendation**: Default-deny (throw or return 405/403) on unrecognized method/route combinations; derive the bundle case from the endpoint metadata (`WithName("Bundle")`) rather than string-matching the path.
+**Effort**: S
+
+### P1 — Denied and unauthenticated requests are never audited
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs:83-86` (filter order), `src/Application/Ignixa.Api/Filters/FhirAuditFilter.cs:14`
+**Issue**: `FhirAuthorizationFilter` runs before `FhirAuditFilter` and returns 403 by short-circuiting, so authorization denials — the events a healthcare audit trail most needs (ATNA) — produce no `AuditEvent`. The audit filter's own doc comment ("only audit authorized requests") codifies the gap.
+**Recommendation**: Swap the order (audit outermost) or have the authorization filter emit an audit event on denial.
+**Effort**: S
+
+### P1 — "Fire-and-forget" audit/metrics is fake async and races with the request lifetime
+**Location**: `src/Application/Ignixa.Api/Filters/FhirAuditFilter.cs:52-54,108`; `src/Application/Ignixa.Api/Filters/FhirMetricsFilter.cs:54-56,92`
+**Issue**: `CreateAuditEventAsync` contains no real await (`await Task.CompletedTask` at line 108; `auditLogger.LogHttpRequest` is synchronous), so the `#pragma warning disable CS4014` fire-and-forget ceremony currently runs fully synchronously — cargo cult that becomes a genuine bug the moment `IAuditLogger` gains a real async implementation, because the unobserved task captures `HttpContext` and would touch it after the request completes (undefined behavior; contexts are pooled). `FhirMetricsFilter` already has a real await (`RecordMetricAsync`, line 92) and its `catch` block reads `httpContext.Request` after that await (`:97-98`). Additionally `ResponseSizeBytes = httpContext.Response.ContentLength ?? 0` (line 88) is always 0 for streamed (chunked) responses — i.e., for every search result.
+**Recommendation**: Snapshot all needed HttpContext data into a DTO synchronously, then hand the DTO to a background channel/queue. Delete the pragmas.
+**Effort**: M
+
+### P1 — Single-tenant auto-detect cache never invalidates
+**Location**: `src/Application/Ignixa.Api/Middleware/TenantResolutionMiddleware.cs:213-254`
+**Issue**: `GetSingleTenantIdAsync` caches either the single tenant ID or the `-1` "multiple tenants" sentinel *forever* in middleware instance state. Adding a second tenant at runtime leaves agnostic routes silently pinned to the original tenant (requests that should now be ambiguous/400 keep writing to tenant 1); deactivating down to one tenant leaves agnostic routes permanently blocked. Also line 216's `_cachedSingleTenantId.HasValue || _cachedSingleTenantId == -1` is redundant — `== -1` implies `HasValue` — evidence the sentinel logic wasn't reasoned through.
+**Recommendation**: TTL the cache (seconds-scale) or invalidate via an `ITenantConfigurationStore` change event. Simplify the sentinel to a dedicated enum/record.
+**Effort**: S
+
+### P1 — Conditional delete corrupts search criteria when `_count` is present
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs:1406-1415`
+**Issue**: To strip `_count`, the code rebuilds the query string with `$"{kvp.Key}={kvp.Value}"` over `QueryHelpers.ParseQuery` output. `kvp.Value` is `StringValues`, so repeated parameters collapse to a comma-joined string (`name=a&name=b` → `name=a,b`), and values decoded by `ParseQuery` are not re-encoded (a value containing `&`/`=`/`+` corrupts the criteria passed to `ConditionalDeleteCommand`). A conditional delete can therefore target the wrong resource set.
+**Recommendation**: Filter the already-parsed parameter list instead of round-tripping through a string, or re-encode with `QueryString.Create(...)`.
+**Effort**: S
+
+### P1 — Unknown or unseen bundle types silently executed as batch
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs:1097-1103`
+**Issue**: `bundleType switch { "TRANSACTION" => ..., "BATCH" => ..., _ => BundleType.Batch }` means a POSTed `collection`, `searchset`, `document`, or garbage/absent `type` is processed as a batch instead of being rejected. Worse (per the CRUD-slices review, `crud-vertical-slices-review.md`): `BundleContext.BundleType` is also null when the streaming parser hasn't encountered `type` before the `entry` array — legal JSON property ordering — so a well-formed *transaction* bundle whose `type` follows `entry` is silently downgraded to batch semantics (no atomicity). FHIR requires servers to process only batch/transaction at the base endpoint.
+**Recommendation**: Reject anything not affirmatively identified as `batch`/`transaction` with 400/422 + OperationOutcome; if the streaming parser cannot guarantee `type` is known before entries stream, buffer until it is.
+**Effort**: S (API guard), M (parser ordering)
+
+### P1 — If-Match parsed with the If-None-Match parser; result feeds a dead command parameter
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs:478-490,504`
+**Issue**: `parsedIfMatch = ConditionalHeaderParser.ParseIfNoneMatch(ifMatchHeader)` (line 482) parses the `If-Match` header with the method written for `If-None-Match` — wrong semantic owner even where weak-ETag syntax overlaps (`*` semantics differ between the two headers). The value flows into `CreateOrUpdateResourceCommand`'s `IfMatch` parameter (line 504), which — per the CRUD-slices review (`crud-vertical-slices-review.md`, filed there as P0) — no Application handler ever reads: optimistic concurrency on PUT is entirely unenforced, so this parse bug is currently masked by the dead parameter. Fix both together.
+**Recommendation**: Add a dedicated `ParseIfMatch` (with `*` handling) on the API side; the missing 412 version-check enforcement is tracked in the CRUD review.
+**Effort**: S (API side)
+
+### P1 — Five inconsistent error-response shapes; several produce wrong content-type or wrong JSON
+**Location** (representative):
+- FHIR-correct: `Results/FhirResults.cs:150` and `Filters/FhirAuthorizationFilter.cs:137-140` (serialized OperationOutcome, `application/fhir+json`)
+- RFC 7807 problem+json: `Endpoints/FhirEndpoints.cs:392-395` (410 Gone)
+- Anonymous objects: `Endpoints/FhirEndpoints.cs:1087` (`new { error = ... }`), `Endpoints/PatchEndpoints.cs:153`, `Endpoints/ExportEndpoints.cs:399`, `Endpoints/ImportEndpoints.cs:285`
+- STJ-serialized wrapper types with `application/json`: `Filters/ResourceTypeValidationFilter.cs:94` (`Results.Json(outcome, ...)` serializes the `OperationOutcomeJsonNode` wrapper's CLR properties, likely emitting non-FHIR JSON), `Endpoints/OperationEndpoints.cs:390` (`Results.Ok(result.OperationOutcome)`), `Endpoints/CompartmentEndpoints.cs:140,226,316`, `Endpoints/FhirEndpoints.cs:1726` (`Results.BadRequest(operationOutcome.MutableNode)` — right JSON, wrong content-type, while `FhirResults.BadRequest` exists for exactly this)
+- Bodyless: `Endpoints/FhirEndpoints.cs:588,1132,1189` (`Results.StatusCode(500)` with no OperationOutcome)
+
+**Issue**: Clients cannot rely on a single error contract; several of these are FHIR-conformance failures outright.
+**Recommendation**: One `FhirResults.Error(status, issueType, diagnostics)` helper; ban `Results.BadRequest`/`Results.Json`/anonymous error objects in this layer via a Roslyn banned-API list.
+**Effort**: M
+
+### P1 — Duplicated Prefer-header parsing has already drifted (`mode=` vs `validation=`)
+**Location**: `src/Application/Ignixa.Api/Endpoints/OperationEndpoints.cs:398-425` vs `src/Application/Ignixa.Api/Infrastructure/PreferHeaderParser.cs:68-94`
+**Issue**: `$validate` parses `Prefer: mode=minimal|spec|full` via its own private `ParseValidationDepthFromPreferHeader`, while every other endpoint uses `PreferHeaderParser.TryParseValidationLevel` which parses `Prefer: validation=...`. Two vocabularies for the same preference, one of them invisible to the shared parser — classic copy-paste drift. `PreferHeaderParser` itself triplicates its split/trim/prefix-match loop across `TryParseValidationLevel`/`TryParseReturnPreference`/`ParseReturnPreferenceStrict`/`IsStrictHandling`.
+**Recommendation**: Single tokenizing parser for the Prefer header; pick one preference key for validation depth and document it.
+**Effort**: S
+
+### P1 — `/metadata` unreachable in multi-tenant mode; code comments contradict middleware behavior
+**Location**: `src/Application/Ignixa.Api/Middleware/TenantResolutionMiddleware.cs:184-206`; `src/Application/Ignixa.Api/Endpoints/MetadataEndpoints.cs:60-90`
+**Issue**: `IsResourceEndpoint` only exempts `/health` and `/.well-known`, so `/metadata` is treated as a resource route; in multi-tenant mode the middleware answers it with 400 "Tenant ID is required". The handler's doc comment ("In multi-tenant scenarios, returns system-wide capabilities", line 63) describes unreachable behavior, and its inline comment ("TenantResolutionMiddleware doesn't auto-detect because it's not classified as a resource endpoint", lines 79-81) is factually wrong. `FhirRequestContextMiddleware.cs:20-24` similarly documents a pipeline order (routing *after* the middleware) that contradicts the actual implicit `UseRouting`-first pipeline.
+**Recommendation**: Add `/metadata` to the middleware's exemption list and return system-wide capabilities; fix or delete the stale ordering comments.
+**Effort**: S
+
+### P1 — Sync-over-async in DI registration
+**Location**: `src/Application/Ignixa.Api/Registrations/DataLayerRegistration.cs:242,256`
+**Issue**: `factory.CreateClientAsync().GetAwaiter().GetResult()` and `tenantStore.GetTenantConfigurationAsync(1, default).AsTask().GetAwaiter().GetResult()` inside DI factory lambdas block threads and can deadlock; the second also hardcodes tenant 1 and passes `default` cancellation.
+**Recommendation**: Restructure to async initialization (hosted service or `IOptions` factory that resolves lazily on first async use).
+**Effort**: M
+
+### P1 — Client-application `Roles` config is silently dead
+**Location**: `src/Application/Ignixa.Api.OpenIddict/Configuration/ClientApplicationOptions.cs` (`Roles` property); `Endpoints/TokenEndpoints.cs:56-91`
+**Issue**: `appsettings.Development.json` assigns `"Roles": ["Admin"]` etc. to client-credentials clients, and `OpenIddictDataSeeder` accepts the config, but `HandleClientCredentialsGrantAsync` never adds role claims to the token — only subject, name, and scopes. Any RBAC rule keyed on roles silently fails for machine clients; the config knob is a no-op.
+**Recommendation**: Emit configured roles as role claims in the client-credentials grant, or delete the property.
+**Effort**: S
+
+### P1 — Insecure defaults and `EnsureCreated` in OpenIddict setup
+**Location**: `src/Application/Ignixa.Api.OpenIddict/Configuration/OpenIddictServerOptions.cs` (`DisableAccessTokenEncryption { get; set; } = true;`); `Extensions/OpenIddictServiceExtensions.cs:149`
+**Issue**: Token encryption is off *by default* in the options class (config must opt back in). Database initialization uses `EnsureCreatedAsync`, which is incompatible with EF migrations — fine for the in-memory dev store, wrong for the SQL Server path the same method supports.
+**Recommendation**: Default `DisableAccessTokenEncryption` to `false`; use migrations (or restrict SQL support explicitly).
+**Effort**: S
+
+### P1 — Log-injection sanitization applied inconsistently
+**Location**: sanitized: `Endpoints/FhirEndpoints.cs` (throughout), `Middleware/TenantResolutionMiddleware.cs`; unsanitized route/user values logged: `Endpoints/CompartmentEndpoints.cs:124-128,147`, `Endpoints/PatchEndpoints.cs:147,152`, `Endpoints/OperationEndpoints.cs:649`
+**Issue**: Route values can carry percent-encoded CR/LF that ASP.NET decodes, so the unsanitized files are injectable while others aren't. Three files also hand-roll `.Replace('\r',' ').Replace('\n',' ')` (`Filters/FhirAuthorizationFilter.cs:111-113`, `Filters/FhirAuditFilter.cs:85-87,114-115`, `Filters/FhirMetricsFilter.cs:97-98`) instead of using the existing `LogSanitizationExtensions.SanitizeForLog`.
+**Recommendation**: Use `SanitizeForLog` everywhere user-influenced values are logged; better, rely on structured-logging placeholders plus a log sink that encodes newlines, and delete the per-call ceremony.
+**Effort**: S
+
+### P1 — `FhirEndpoints.cs` is a 1,744-line God-file with ~2x duplicated registration and 250-line handlers
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs` (whole file; duplication `:77-178` vs `:186-310`; `HandlePostResource` `:748-1025`)
+**Issue**: The tenant and agnostic registration blocks are near-identical ~120-line copies differing only in how tenantId is sourced. `HandlePostResource` is ~280 lines mixing conditional-create protocol, ID generation (`Guid.NewGuid` at line 925 — a business decision living in the API layer), body validation, provenance/TTL/Prefer parsing, and three-way response shaping — far past CLAUDE.md's <25-line guideline. `HandleSearchResource`/`HandlePostSearchResource`/`HandleBaseSearchResource`/`HandlePostBaseSearchResource` are four copies of the same pipeline.
+**Recommendation**: One registration routine parameterized by tenant-id source; extract a `ResourceRequestReader` (body + headers → command inputs) and a `WritePreferenceResponder` (result + preference → IResult); move server-ID generation into the Application handler.
+**Effort**: L
+
+### P2 — `CancellationToken ct` naming violates the project's own convention
+**Location**: `Endpoints/FhirEndpoints.cs` (~22 occurrences, e.g. `:98,323`), `Endpoints/HistoryEndpoints.cs:96-133`, `Endpoints/PatchEndpoints.cs:70-121` registration lambdas
+**Issue**: CLAUDE.md mandates `cancellationToken`; `OperationEndpoints.cs`/`CompartmentEndpoints.cs` comply, these files don't — drift between files written at different times.
+**Recommendation**: Rename; add an analyzer/naming rule.
+**Effort**: S
+
+### P2 — Warnings-as-errors is diluted by a 35-entry NoWarn list
+**Location**: `Directory.Build.props` (`<NoWarn>` includes CA1031 catch-general, CA1062 null-validate, CA2201 reserved exceptions, CA1852 seal-types, CA1508 dead-condition, …)
+**Issue**: The suppressions disable exactly the analyzers that would have caught several findings above (broad catches, unsealed types, dead conditions).
+**Recommendation**: Re-enable at least CA1031, CA1852, CA1508 and fix or locally suppress with justification.
+**Effort**: M
+
+### P2 — Sealed-by-default not followed
+**Location**: 20+ classes: `Middleware/*.cs` (all three), `Filters/*.cs` (all four), `Services/*.cs`, `Infrastructure/AspNetCorePipelineExecutor.cs:23`, `Infrastructure/DurableTaskHostedService.cs:14`, `Api.OpenIddict/Data/OpenIddictDbContext.cs:8`
+**Issue**: None are designed for inheritance; `TenantResolutionMiddleware` even implements the full `protected virtual Dispose(bool)` pattern (`:265-287`) on a conventional middleware ASP.NET Core never disposes.
+**Recommendation**: `sealed` everywhere; replace the Dispose ceremony with a plain `Dispose`.
+**Effort**: S
+
+### P2 — Dead code and vestigial artifacts
+**Location / items**:
+- `Endpoints/FhirEndpoints.cs:1732-1742` — `ToAsyncEnumerable<T>` defined, never called
+- `Endpoints/FhirEndpoints.cs:8` — `using Azure;` with no apparent Azure SDK usage in the file
+- `Registrations/MiddlewareRegistration.cs:92-104` — `UseIgnixaDevelopmentFeatures` never called (duplicates `ApplicationBuilderExtensions:35-38`)
+- `Registrations/MiddlewareRegistration.cs:66-87` — dev "ordering validation" middleware whose condition (`RequestContext?.TenantId == 0`) can only fire false positives on non-tenant endpoints; validates nothing
+- `Results/FhirResult.cs:21,30` — `_httpContext` stored, threaded through every `With*` copy, never read
+- `Endpoints/PatchEndpoints.cs:388-393` — `IsValidResourceType` always returns `true`, with a `TODO` (CLAUDE.md bans leftover TODOs); its 404 path at `:150-154` is unreachable
+- `Endpoints/SmartEndpoints.cs:123-126` — `BuildSmartConfigurationResponse` parameters `context` and `tenantId` unused
+- `Middleware/FhirRequestContextMiddleware.cs:83` — `ExecutingBatchOrTransaction = fhirContext.DeferredWriteCoordinator != null` on a freshly constructed context is always `false`; the comment admits it
+- `Endpoints/FhirEndpoints.cs:508-509,980-981` — manual `Headers.Append("ETag"/"Last-Modified")` immediately overwritten by `FhirResult.ExecuteAsync`'s indexer writes (`Results/FhirResult.cs:94,100`); works only by accident of set-vs-append semantics
+
+**Recommendation**: Delete all of the above.
+**Effort**: S
+
+### P2 — One-type-per-file violations
+**Location**: `Middleware/FhirExceptionMiddleware.cs:18,102` (middleware + extensions class); `Infrastructure/PreferHeaderParser.cs:18,51` (enum `ReturnPreference` + parser); `Endpoints/SmartEndpoints.cs:20,151` (endpoints + `SmartConfiguration` record); `Services/SqlReferenceDataPreloadService.cs:22` (file named `...Service`, type named `SqlReferenceDataPreloadHandler`)
+**Recommendation**: Split per repo rule; rename the mismatched file.
+**Effort**: S
+
+### P2 — `CreateOperationOutcome` helper copy-pasted into six endpoint files
+**Location**: `Endpoints/OperationEndpoints.cs:171-186`, `Endpoints/ImportEndpoints.cs`, `Endpoints/DeIdOperationEndpoints.cs`, `Endpoints/Experimental/SummaryEndpoints.cs`, `Endpoints/Experimental/TerminologyEndpoints.cs`, `Endpoints/Experimental/TransformEndpoints.cs`
+**Issue**: Six private near-duplicates (signatures already drifting — ImportEndpoints' takes only a string). The "TenantId not found…" agnostic-route boilerplate is likewise repeated 4x in OperationEndpoints alone (`:214-220,237-243,277-283,621-627`).
+**Recommendation**: One shared factory next to `FhirResults`.
+**Effort**: S
+
+### P2 — Copyright headers are wrong or inconsistent
+**Location**: most `Ignixa.Api` files claim `Copyright (c) Microsoft Corporation` (e.g. `Endpoints/FhirEndpoints.cs:2`, `Middleware/TenantResolutionMiddleware.cs:2`, `Ignixa.Web/Program.cs:2` — some with missing spaces, "Corporation.All rights reserved"); `Middleware/FhirRequestContextMiddleware.cs:2` says "Ignixa Contributors"; the entire OpenIddict project has no headers. `Directory.Build.props` says the product copyright is "Ignixa Contributors".
+**Recommendation**: Pick one header (or none) and apply repo-wide; the Microsoft attribution looks like template residue and is a licensing-hygiene problem.
+**Effort**: S
+
+### P2 — Miscellaneous correctness/polish
+- `Endpoints/FhirEndpoints.cs:516` — created-vs-updated decided by `result.Key.VersionId == "1"` string compare; brittle (delete/recreate) and a semantic the Application layer already knows.
+- `Endpoints/FhirEndpoints.cs:529` — PUT `Location` header ignores the agnostic-route case and omits the `_history/{version}` suffix, unlike POST (`:1001-1005`) and conditional create (`:829-833`); three different Location formats for writes.
+- `Endpoints/FhirEndpoints.cs:829,874,1001` — `context.Items.ContainsKey("IsAgnosticRoute") && (bool)context.Items["IsAgnosticRoute"]!` double-lookup + forgiven cast, three copies.
+- `Endpoints/FhirEndpoints.cs:1107-1112` — `MaxParallelism = 10, ChannelCapacity = 100` hardcoded in the endpoint; belongs in options.
+- `Endpoints/MetadataEndpoints.cs:158-159` — error message literally contains the text "KnownContentTypes.ApplicationFhirJson, KnownContentTypes.ApplicationJson" — constant *names* interpolated as prose instead of values; telltale generated-code artifact.
+- `Endpoints/MetadataEndpoints.cs:128-161` — Accept-header validation exists only on metadata endpoints; ignores q-values; resource endpoints do no content negotiation at all.
+- `Endpoints/HistoryEndpoints.cs:164` — instance-level history hardcodes `pretty: false` while type/system levels honor `_pretty`.
+- `Endpoints/PatchEndpoints.cs:175,316` — `(char)reader.Peek()` on an empty body yields `(char)65535`; also the JSON-Patch detection block is duplicated verbatim across both handlers.
+- `Endpoints/PatchEndpoints.cs:339` — `context.RequestServices.GetRequiredService<ILoggerFactory>()` service-location inside a handler; every other handler injects it.
+- `Endpoints/CompartmentEndpoints.cs:216` — `validCompartmentTypes` array allocated per request; compartment membership is a spec/business rule hardcoded in the API layer.
+- `Filters/FhirAuthorizationFilter.cs:6,103` — `Grpc.Core`/`RpcException` transport concern leaking into an API filter; the Application-layer authorization service should translate sidecar transport failures.
+- `Filters/FhirAuthorizationFilter.cs:184-260` — `BuildAuthorizationContextAsync` is sync work wrapped in `Task.FromResult`.
+- `Registrations/MiddlewareRegistration.cs:34-37` — when `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true`, ASP.NET Core already inserts ForwardedHeaders middleware automatically; this adds it a second time.
+- `Ignixa.Web/Program.cs:83,150-151` — startup service calls (`GetAllTenantsAsync`, `GetTenantConfigurationAsync`) without cancellation tokens; `:170` assigns `repository` and never uses it.
+- `Extensions/ApplicationBuilderExtensions.cs:37` — `((IEndpointRouteBuilder)app).MapOpenApi()` cast hack; take `WebApplication` instead.
+- `Api.OpenIddict/Services/SmartScopeGenerator.cs:65-98` — full generation is 4 contexts x ~200 union resource types x 31 permission combos ≈ 25k registered scopes; check the size this imposes on discovery metadata and OpenIddict scope validation.
+- `Infrastructure/ProvenanceHeaderHelper.cs:134` — `coordinator` parameter typed `object?`; type it as the coordinator interface.
+
+## Architectural Observations
+
+1. **ADR 2509 macro-compliance, micro-erosion.** Dependency direction is correct (API → Application → Domain; no reverse references; no `Hl7.Fhir.*`; no controllers). But "thin endpoints" has eroded: handlers own protocol parsing *and* orchestration decisions (bundle-type routing, server ID generation, created-vs-updated detection, conditional-create response semantics). The Application layer should receive one command and return one result that already answers those questions.
+
+2. **Authorization architecture is convention-without-enforcement.** The decision to use endpoint filters instead of middleware (documented in `FhirAuthorizationFilter.cs:24-28`) is defensible for bundle-entry re-entry, but it makes security opt-in per endpoint file with no compile-time or startup-time check. The six files that forgot the filters (P0 above) are the predictable outcome. This needs a single choke point: shared group factory + startup assertion over `EndpointDataSource`. **Verified constraint on the fix**: an ASP.NET fallback authorization *policy* is NOT sufficient on its own — `AspNetCorePipelineExecutor.ExecuteAsync` (`Infrastructure/AspNetCorePipelineExecutor.cs:47-114`) hand-matches routes and invokes the selected endpoint's `RequestDelegate` directly (line 108), so `AuthorizationMiddleware` (which enforces authorization metadata for Minimal APIs) never runs for bundle entries; only filters compiled into the RequestDelegate execute. Compounding it, `BundleEntryExecutor` (Application layer, see `crud-vertical-slices-review.md`, verified P1 there) builds the per-entry `DefaultHttpContext` without copying the parent `HttpContext.User`, so even the endpoint filters that do run evaluate an anonymous principal. Net: bundle entries are effectively unauthorized regardless of which enforcement mechanism is chosen, and a caller can reach endpoints through a bundle under weaker checks than a direct request. The fix must therefore be filter-based (or the executor must run the real pipeline) *and* propagate `User` into entry contexts.
+
+3. **Two competing tenancy-flow mechanisms.** Some commands carry `TenantId` explicitly (`ConditionalCreateCommand`, `ConditionalUpdateCommand`, `ConditionalDeleteCommand`, `PatchResourceCommand`), others rely on ambient `IFhirRequestContext` (`GetResourceQuery`, `SearchResourcesQuery`, `DeleteResourceCommand` — see `FhirEndpoints.cs:371,614,1043`). Handlers reading tenant from two places is how cross-tenant bugs are born; pick one (ambient context, given it already exists) and strip tenantId from command signatures.
+
+4. **The tenant/agnostic dual-registration pattern doubles every endpoint file.** Five files (Fhir, Operation, Patch, Compartment, History) each contain two near-identical registration methods plus per-route "TenantId not found" fallbacks. Since `TenantResolutionMiddleware` already normalizes tenant into `HttpContext.Items`/`IFhirRequestContext` for both route shapes, a single registration helper that maps both prefixes onto one handler set would delete ~600 lines and remove the class of "agnostic twin forgot X" bugs (which is exactly how the P0 filter gaps and the PUT-Location inconsistency happened).
+
+5. **Error contract needs an owner.** `FhirExceptionMiddleware` + thrown `FhirException`s is the right backbone, but half the layer bypasses it with ad-hoc try/catch and five different response shapes, and the authorization filter actively breaks it (P0). Rule of thumb this layer should adopt: endpoints throw or return via `FhirResults`; nothing else constructs error bodies.
+
+6. **Generated-code fingerprints are pervasive**: identical XML-doc boilerplate, per-file re-derived helpers, comments that describe intent the code contradicts (`FhirRequestContextMiddleware` ordering, `MetadataEndpoints` auto-detect claim, `HistoryEndpoints` "no filter needed"), constant names pasted into user-facing strings, and pragma-suppressed patterns copied without their rationale. Treat comments in this layer as untrustworthy until re-verified.
+
+7. **Ignixa.Web is appropriately thin** (composition + startup validation only), and the startup fail-fast strategy-validation in `Program.cs:112-135` is good. The OpenIddict project, however, is a development tool packaged like a production feature — it needs either environment gating (P0) or an explicit "dev-only" module boundary.
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Move `next(context)` out of FhirAuthorizationFilter's catch-all; add auth-enabled E2E suite | S | Filters/FhirAuthorizationFilter.cs |
+| P0 | Centralize filter attachment (shared group factory) + startup assertion that every endpoint is authorized or explicitly anonymous | M | Export/Import/AdminPackage/History/Operation/DeId endpoints, Extensions/EndpointRouteBuilderExtensions.cs |
+| P0 | Environment-gate OpenIddict dev IdP (auto-approve authorize, password flow, dev certs) | S | Ignixa.Api.OpenIddict (Extensions, Endpoints) |
+| P1 | Secure-by-default posture: warn/fail in Production when authorization disabled; split authn/authz toggles | S | appsettings.json, MiddlewareRegistration.cs |
+| P1 | Stop leaking `exception.Message` in 500s; drop IOE→400 mapping | S | Middleware/FhirExceptionMiddleware.cs, Endpoints/ImportEndpoints.cs |
+| P1 | Default-deny in interaction parser; audit denials (reorder filters) | S | Filters/FhirAuthorizationFilter.cs, group registrations |
+| P1 | Replace fake fire-and-forget audit/metrics with snapshot + background channel | M | Filters/FhirAuditFilter.cs, Filters/FhirMetricsFilter.cs |
+| P1 | Add invalidation/TTL to single-tenant cache | S | Middleware/TenantResolutionMiddleware.cs |
+| P1 | Fix `_count` query-string reconstruction; reject unknown/unseen bundle types | S | Endpoints/FhirEndpoints.cs |
+| P1 | Dedicated If-Match parser (pairs with dead-IfMatch P0 in crud-vertical-slices-review.md) | S | Endpoints/FhirEndpoints.cs |
+| P1 | Unify error responses behind FhirResults; ban Results.Json/BadRequest for errors | M | ~10 endpoint/filter files |
+| P1 | Deduplicate Prefer parsing; single validation-preference key | S | Infrastructure/PreferHeaderParser.cs, Endpoints/OperationEndpoints.cs |
+| P1 | Fix `/metadata` in multi-tenant; correct stale pipeline comments | S | Middleware/TenantResolutionMiddleware.cs, Endpoints/MetadataEndpoints.cs |
+| P1 | Remove sync-over-async from DI factories | M | Registrations/DataLayerRegistration.cs |
+| P1 | Emit client Roles claims or delete the config property; fix insecure OpenIddict defaults; migrations over EnsureCreated | S | Ignixa.Api.OpenIddict |
+| P1 | Apply SanitizeForLog uniformly | S | Compartment/Patch/Operation endpoints, Filters |
+| P1 | Decompose FhirEndpoints.cs (single registration routine, request-reader + preference-responder helpers, move ID generation to Application) | L | Endpoints/FhirEndpoints.cs |
+| P2 | Rename `ct` → `cancellationToken`; seal classes; one type per file; delete dead code/TODOs; shared CreateOperationOutcome; fix copyright headers; re-enable CA1031/CA1852/CA1508 | M | layer-wide |
+
+---
+*Reviewed 2026-07-11. Direct file reads covered all of Ignixa.Api (Endpoints, Middleware, Filters, Results, Infrastructure header helpers, Extensions, Registrations/MiddlewareRegistration + DataLayerRegistration excerpts), all of Ignixa.Api.OpenIddict, and Ignixa.Web. Registrations/Services/BackgroundServices internals and Experimental endpoint bodies received a lighter pass (pattern sweeps + targeted reads); findings there are limited to what was verified.*

--- a/docs/features/application-layer-modernization/investigations/application-core-infra-review.md
+++ b/docs/features/application-layer-modernization/investigations/application-core-infra-review.md
@@ -1,0 +1,315 @@
+# Investigation: Application Core Infrastructure & Administrative Features Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Ignixa.Application/Events, Infrastructure, Utilities, Features/{Authorization,Admin,Conformance,Metadata,Specification,Packages}
+
+## Summary
+
+The subsystem is functional but carries four P0-class defects: a fail-open authorization pipeline, an unsynchronized shared-state race in `ConformanceState`, a missing-R6 switch that crashes `/metadata` for R6 tenants, and an OIDC discovery deserializer that cannot bind standard snake_case fields. Beyond those, the dominant pattern is **machinery that no longer (or never) does what its API claims**: a capability version-hash mechanism whose mismatch branch is unreachable, a schema eager-load path with zero callers guarded by an elaborate event/debounce invalidation chain, a `ClearAsync` that is a silent no-op behind an "all caches cleared" log, and a "multi-tenant" package API that ignores the tenant. Layering is also compromised: `HttpContext` and web packages live in the Application project, non-Application namespaces are compiled into the Application assembly, and DataLayer references Application in violation of ADR-2509.
+
+## Strengths
+
+- **SMART scope parsing** (`Features/Authorization/Smart/SmartScopeParser.cs`) is genuinely good: generated regexes, CRUDS order validation, v1→v2 conversion, search-constraint parsing, and a clean `SmartScope` model. The POST `_search` + constrained-scope denial in `SmartScopeAuthorizationHandler.cs:101-115` shows real security thinking.
+- **Structured logging discipline**: `AuditLogger.cs` and `LocalMetricsService.cs` use `[LoggerMessage]` source generators correctly.
+- **PackageActivationPipeline / event-sourced conformance** (`Features/Conformance/PackageActivationPipeline.cs`) follows ADR-2512 faithfully on the write side: validate → build events → append atomically → apply, with idempotency and a proper activation lock.
+- **Dependency-closure package loading** (`Features/Packages/ImplementationGuideProvider.cs:143-297`) handles diamond dependencies, version conflicts, core-package pre-seeding, and partial-failure reporting well; the `LoadedPackages`/`SkippedPackages` result surface is caller-friendly.
+- **SidecarLoggerProvider** uses a bounded channel with drop-oldest backpressure and batched flushes — the right shape for fire-and-forget log shipping.
+- No `Hl7.Fhir.*` NuGet references anywhere in the project — the `Ignixa.*` rule is respected.
+
+## Findings
+
+### P0 — Authorization pipeline fails open for authenticated principals with no roles and no SMART scopes
+**Location**: `src/Application/Ignixa.Application/Features/Authorization/Handlers/RbacAuthorizationHandler.cs:44-49`, `Handlers/SmartScopeAuthorizationHandler.cs:34-39`, `Services/FhirAuthorizationService.cs:47-86`
+**Issue**: The pipeline is a chain of handlers where each returns `Success()` when its concern doesn't apply. RBAC skips when `!context.HasRoles` ("let next handler decide"); SMART skips when `SmartContext == null`. No handler is the "decider of last resort" — `FhirAuthorizationService` grants access when every handler passes. A valid JWT carrying zero roles and zero scopes therefore gets full CRUD within its tenant. The registered handlers (`Ignixa.Api/Registrations/ApplicationServicesRegistration.cs:479-510`) are exactly Authentication(10), TenantIsolation(20), Rbac-or-Sidecar(30), SmartScope(40) — nothing denies. ADR-2501's "5. Data Filtering" layer and the documented priority-50 capability handler (`Handlers/IAuthorizationHandler.cs:23`) do not exist in this pipeline.
+**Recommendation**: Add a terminal default-deny: if the request reached the end of the pipeline and neither an RBAC grant nor a SMART scope match affirmatively authorized it, deny. Concretely, make RBAC's "no roles" path return `Denied` unless SMART context exists, or add a priority-100 `DefaultDenyHandler` that checks an "affirmatively granted" flag on the context.
+**Effort**: S
+
+### P0 — ConformanceState: unsynchronized reads of mutable dictionaries concurrent with locked writes
+**Location**: `src/Application/Ignixa.Application/Features/Conformance/ConformanceState.cs:11-16, 71-92, 158-342`; `Features/Conformance/ActiveSearchParameter.cs:22-23`
+**Issue**: Writers (`Apply` via `InitializeFromEventsAsync`/`ApplyAndTrack`/`CatchUpAsync`) mutate plain `Dictionary<,>` instances under `_activationLock`, but readers (`GetSearchParameter`, `GetEnabledSearchParameter`, `EnabledSearchParameters`, `AllSearchParameters`, `FindByCanonical`) take no lock at all. ADR-2512 explicitly makes this the query-time hot path ("query-time resolution becomes a single O(1) dictionary lookup"), so request threads read these dictionaries while package activation writes them. `Dictionary<TKey,TValue>` is not safe for read-during-write — this can throw or return corrupt state. `ActiveSearchParameter.Status`/`ReindexJobId` are also mutable setters flipped by writers while readers filter on `Status`, so even key-stable updates race. Secondary smells confirm the confusion: `Interlocked.Increment(ref _nextSearchParamId) - 1` at line 52 mixed with plain `_nextSearchParamId = sp.SearchParamId + 1` at line 237, and `Interlocked.Read(_lastProcessedEventId)` paired with plain writes.
+**Recommendation**: Either switch the three maps to `ConcurrentDictionary` and make `ActiveSearchParameter` immutable (replace-on-change), or adopt an immutable-snapshot pattern: build a new projection under the lock and swap a single `volatile` reference readers dereference. The snapshot swap is cleaner and matches the event-sourced replay model.
+**Effort**: M
+
+### P0 — /metadata throws for R6 tenants: OperationsSegment version switch omits R6
+**Location**: `src/Application/Ignixa.Application/Features/Metadata/Segments/OperationsSegment.cs:204-214`
+**Issue**: `GetFhirVersionString` handles R4, R4B, R5, Stu3 and throws `ArgumentOutOfRangeException` for everything else. `FhirVersion.R6` exists and is wired (`Features/Search/FhirVersionContext.cs:73` creates `R6CoreSchemaProvider`; `CompositeStructureDefinitionSummaryProvider.cs:282` maps R6). Any capability-statement build for an R6 tenant crashes in `ApplyAsync` line 47 — this also breaks `CapabilityEnforcementBehavior`, which builds the capability statement for every guarded request, so R6 tenants likely fail far beyond `/metadata`.
+**Recommendation**: Add the R6 case. Better: delete this private switch and use the existing shared `FhirVersion`→string conversion (`ToVersionString()` used in `FhirVersionContext.cs:114`) so new versions can't silently miss one of N hand-rolled switches. Audit the sibling switches (`SidecarMetricsService.ParseFhirOperation` style maps are fine; version maps are not).
+**Effort**: S
+
+### P0 — OIDC discovery deserialization cannot bind snake_case fields; SMART configuration endpoint is dead on arrival
+**Location**: `src/Application/Ignixa.Application/Features/Authorization/Services/OidcDiscoverySmartConfigurationProvider.cs:25-28, 70-71, 128-129, 143-155`
+**Issue**: `OidcDiscoveryDocument` has PascalCase properties (`AuthorizationEndpoint`, `JwksUri`, …) with no `[JsonPropertyName]` attributes, and the serializer options set only `PropertyNameCaseInsensitive = true`. The OIDC discovery document uses snake_case (`authorization_endpoint`, `jwks_uri`) per RFC 8414 — case-insensitivity does not bridge underscores, so every field except `Issuer` binds to null and line 128 throws `InvalidOperationException("authorization_endpoint missing from discovery")` on every fetch. There is no test covering this class. Additionally, `GetConfigurationAsync` caches per-`tenantId` keys while `FetchConfigurationAsync` ignores the tenant entirely — N identical cache entries.
+**Recommendation**: Set `PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower` (or add `[JsonPropertyName]` attributes), and add a deserialization test against a real discovery document. Drop the per-tenant cache key or actually make the fetch tenant-aware.
+**Effort**: S
+
+### P1 — Composite schema provider eager-load is dead code guarded by a live invalidation pipeline
+**Location**: `src/Application/Ignixa.Application/Features/Specification/CompositeStructureDefinitionSummaryProvider.cs:75-193, 112-116, 252-264`; `Features/Specification/CompositeSchemaProviderRegistry.cs`; `Events/Package/PackageLoadedNotificationHandler.cs`; `Utilities/DebounceInvalidationStrategy.cs`
+**Issue**: `InitializeAsync` — the only thing that populates `_packageStructureDefinitions` — has **zero callers** in the entire solution. On top of that, the code itself admits the conversion is unimplemented (`// TODO: ... For now, this returns null until ToTypeDefinition() is fully implemented`, line 112). So package-profile type resolution never happens, `GetTypeDefinition` always falls through to base spec, and `ClearCache()` (line 252: "Requires re-initialization via InitializeAsync() after clearing") resets `_isInitialized` for an initialization that never occurs. Meanwhile a four-stage pipeline exists solely to invalidate this empty cache: package events → `PackageLoaded/UnloadedNotificationHandler` → `CompositeSchemaProviderRegistry` (whose `packageId` parameter is ignored and whose two interface methods are identical) → `DebounceInvalidationStrategy` (243 lines of timer/CTS management). This is the definitive early-agent artifact in the subsystem: elaborate, plausible-looking infrastructure around a feature that does nothing.
+**Recommendation**: Decide the feature's fate. If package profiles must feed schema resolution, implement `ToTypeDefinition`, call `InitializeAsync` during tenant preload and after debounced invalidation, and add a test asserting a loaded profile resolves. If ADR-2512's `ConformanceState.StructureDefinitions` is the intended source of truth instead, delete the composite provider's eager-load path, the registry, the debounce strategy, and both notification handlers.
+**Effort**: L
+
+### P1 — DataLayer references Application: layering inversion around package events
+**Location**: `src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Ignixa.DataLayer.SqlEntityFramework.csproj:32`; `src/Application/Ignixa.Application/Events/Package/*.cs`; `src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Events/PackageLoadedSearchParameterSyncHandler.cs:146`
+**Issue**: ADR-2509 mandates `DataLayer → Domain` only, yet `Ignixa.DataLayer.SqlEntityFramework` has a `ProjectReference` to `Ignixa.Application` so its event handlers can consume `IPackageLoaded`/`ICapabilityCacheInvalidator` and publish `TerminologyImportTriggeredEvent`. Consequences beyond the dependency arrow: capability-cache invalidation on package **load** happens only in the DataLayer's `PackageLoadedSearchParameterSyncHandler` (a class ADR-2512 lists as part of the legacy flow to be removed), while the Application-layer `PackageLoadedNotificationHandler` does not invalidate the capability cache at all — unload and load invalidation live in different layers, and removing the legacy sync handler per ADR-2512 would silently leave `/metadata` stale for up to the 1-hour TTL after package loads.
+**Recommendation**: Move the package/terminology event contracts to `Ignixa.Domain` (they are already POCO records with a Medino marker), or into a small shared contracts project, and remove the DataLayer→Application reference. Add capability invalidation to the Application-layer load handler so behavior survives the planned removal of the legacy sync handler.
+**Effort**: M
+
+### P1 — Capability version-hash validation is unreachable; cache freshness rests solely on TTL and explicit invalidation
+**Location**: `src/Application/Ignixa.Application/Features/Metadata/CapabilityStatementService.cs:30-32, 69-101, 110-122, 231-245`
+**Issue**: The "smart caching with version hash validation" compares the cached entry's hash to a "current" hash — but the current hash is read from `_versionHashCache`, which is populated at the same moment as the entry and removed only in `InvalidateCacheAsync` (which also removes the entry itself). Both caches live and die together, so the mismatch branch at line 96 can never execute; every `GetVersionHashAsync` implementation across six segments (including SHA256 computations over all search parameters and reference targets) feeds a mechanism that cannot fire. Worse, step 4 (line 112) can attach a **stale** pre-rebuild hash to a freshly built statement. The entire `ICapabilitySegment.GetVersionHashAsync` surface is currently ballast.
+**Recommendation**: Either make it real — recompute the composite hash on each validation (or on a short interval) instead of caching it beside the entry — or delete `GetVersionHashAsync` from the segment interface and rely on TTL + event-driven invalidation, which is what actually protects freshness today. Deleting is the honest option; the segments' hash code is nontrivial and all dead.
+**Effort**: M
+
+### P1 — MemoryCapabilityCache.ClearAsync is a silent no-op behind "All capability caches cleared" logs; three of four invalidator methods have no callers
+**Location**: `src/Application/Ignixa.Application/Infrastructure/Caching/MemoryCapabilityCache.cs:58-69`; `Infrastructure/Caching/CapabilityCacheInvalidator.cs:36-63`; `Infrastructure/Caching/ICapabilityCacheInvalidator.cs`
+**Issue**: `ClearAsync` intentionally does nothing (comment: "this is a no-op") yet `CapabilityCacheInvalidator.InvalidateAllAsync` logs "All capability caches cleared" after calling it, and `CapabilityStatementService.ClearCacheAsync` logs "Cleared all capability caches". Nothing was cleared — and `CapabilityStatementService._versionHashCache` isn't touched either. Mitigating factor that is itself a finding: `InvalidateAllAsync`, `InvalidateForProfileChangesAsync`, and `InvalidateForSearchParameterChangesAsync` have zero call sites; only `InvalidateForTenantAsync` is used. The interface is 75% speculative API.
+**Recommendation**: Delete the three unused methods. If an "invalidate all" is ever needed, implement it properly (track keys, or wrap `MemoryCache` with a generation token via `CancellationChangeToken`). Never log success for a no-op.
+**Effort**: S
+
+### P1 — PackageResourceMapper silently drops malformed conformance resources
+**Location**: `src/Application/Ignixa.Application/Features/Conformance/PackageResourceMapper.cs:141-144, 175-178`
+**Issue**: Both `MapSearchParameter` and `MapStructureDefinition` end in a bare `catch { return null; }` — no logging, no issue collection. A SearchParameter with malformed JSON, or one missing `code`/`expression`/`type`, simply vanishes from activation. This directly contradicts ADR-2512, whose stated motivation includes eliminating "silent failures when sync handlers catch and log exceptions" and whose design point is that "package activation validates the entire configuration atomically." A package can "activate successfully" while indexing definitions were dropped on the floor.
+**Recommendation**: Return mapping failures as `ValidationIssue`s (e.g., `SP_PARSE_ERROR` with the resource id) so `PackageActivationPipeline.ValidateActivation` surfaces them in `ActivationResult.Issues`. At minimum, log at Warning with the exception and resource identity.
+**Effort**: S
+
+### P1 — LoadPackageHandler reports success when activation failed; unvalidated `int.Parse(TenantId)` after the import already committed
+**Location**: `src/Application/Ignixa.Application/Features/Admin/LoadPackageHandler.cs:93-113, 116-122`; `Features/Admin/LoadPackageCommand.cs`
+**Issue**: Two problems. (1) When `ActivateAsync` fails, the handler logs a Warning and returns a normal `LoadPackageResult` — the API caller has no way to know the package's search parameters were never activated. `LoadPackageResult` has no activation status field. (2) `int.Parse(request.TenantId)` at line 120 runs after the import and activation succeeded; a non-numeric tenant id throws `FormatException` at the very end, producing a 500 for an operation that actually completed — and skipping the cache-invalidation event. Root cause: Admin commands model `TenantId` as `string` while every other layer (events, config store, partition strategy) uses `int`. `ImplementationGuideProvider.LoadPackageInternalAsync:85` even re-parses it back to int with proper validation, so the string round-trips twice.
+**Recommendation**: Change `LoadPackageCommand`/`UnloadPackageCommand`/`ListPackagesQuery` to `int TenantId` and parse/validate once at the API boundary. Add `ActivationSucceeded`/`ActivationIssues` to `LoadPackageResult` (or fail the request when activation fails — a loaded-but-unactivated package is not a success under ADR-2512's explicit-activation model).
+**Effort**: M
+
+### P1 — Package management tenant scoping is cosmetic: list and unload operate globally
+**Location**: `src/Application/Ignixa.Application/Features/Packages/ImplementationGuideProvider.cs:305-329, 339-377`
+**Issue**: `ListLoadedPackagesAsync(tenantId, …)` validates and logs the tenant id, then calls `_packageRepository.ListLoadedPackagesAsync(cancellationToken)` — the comment admits "Phase 1 limitation - returns packages from global repository for all tenants." `UnloadPackageAsync` likewise deactivates globally: tenant A's admin can deactivate a package tenant B depends on. `LoadPackageInternalAsync` (line 85-88) *does* scope its existence check by tenant, so the same class is half tenant-aware. Under CLAUDE.md's multi-tenancy rules this is an isolation gap on an admin surface, and the signatures actively mislead callers (`ProfileCapabilitySegment` passes a tenant id believing it means something).
+**Recommendation**: Thread the tenant id into `IPackageResourceRepository.ListLoadedPackagesAsync`/`DeactivatePackageAsync` (the load path proves the repository already partitions by tenant), or — if package state is intentionally global for now — remove the tenantId parameters and say so in the interface docs instead of a buried NOTE.
+**Effort**: M
+
+### P1 — Audit logging: fire-and-forget with silent loss, documentation claims the opposite, and fabricated audit values
+**Location**: `src/Application/Ignixa.Application/Infrastructure/SidecarAuditLogger.cs:14-17, 30-51, 65-72, 141-144`
+**Issue**: The class doc says "Fail-fast: Throws RpcException if sidecar is unavailable (returns 503 to client)" but every method is `_ = SomethingAsync(...)` fire-and-forget with all exceptions caught and logged — audit events are droppable by design, contradicting the doc and the usual compliance expectation for healthcare audit trails (contrast `SidecarRbacAuthorizationHandler`, which really does fail fast). The unawaited tasks also outlive the request with no queue/backpressure (unlike `SidecarLoggerProvider`, which got a bounded channel). Fabricated data compounds it: `LogTenantAccessAsync` invents `HttpStatusCode = authorized ? 200 : 403`, and `LogTtlDeletionAsync` hardcodes `IpAddress = "127.0.0.1"`.
+**Recommendation**: Pick a guarantee and implement it: either fail-fast (await, propagate `Unavailable`) or reliable-async (bounded channel + background flusher like `SidecarLoggerProvider`, with a dropped-event counter). Fix the doc either way; stop synthesizing status codes and IPs — omit unknown fields.
+**Effort**: M
+
+### P1 — HttpContext and web-stack types embedded in the Application layer
+**Location**: `src/Application/Ignixa.Application/Ignixa.Application.csproj:21-23` (`Microsoft.AspNetCore.Http`, `Microsoft.AspNetCore.OpenApi`); `Infrastructure/IPipelineExecutor.cs:21`; `Infrastructure/FhirVersionExtractor.cs:31`; `Features/Authorization/Models/FhirAuthorizationContext.cs:81` (`required HttpContext`); `Features/Authorization/Handlers/SmartScopeAuthorizationHandler.cs:104`; `Handlers/SidecarRbacAuthorizationHandler.cs:51`
+**Issue**: The Application layer takes a hard dependency on ASP.NET Core's `HttpContext`. `FhirAuthorizationContext` — the core authorization model — *requires* an `HttpContext`, which authorization handlers then reach into (`Request.Method`, `TraceIdentifier`). `IPipelineExecutor` is an Application-defined interface whose contract is "execute an HttpContext". This makes the authorization pipeline untestable without faking a web server and violates the ADR-2509 layer diagram, where HTTP is the API layer's concern. The pattern of `IFhirRequestContext` shows the team already knows the right shape — HTTP facts get projected into a neutral context; the authorization slice just never got that treatment.
+**Recommendation**: Replace `FhirAuthorizationContext.HttpContext` with the specific facts consumed (`HttpMethod` string, `CorrelationId`) — two properties cover all current uses. Move `FhirVersionExtractor` to the API layer (it is only meaningful there). `IPipelineExecutor` is harder (bundle re-entrancy is designed around synthetic HttpContexts) — at minimum document it as a sanctioned exception in an ADR rather than leaving it implicit.
+**Effort**: M
+
+### P1 — Foreign namespaces compiled into the Application assembly
+**Location**: `src/Application/Ignixa.Application/Features/Packages/ImplementationGuideProvider.cs:8` and `PackageResourceImporter.cs:8` (`namespace Ignixa.PackageManagement.Infrastructure`); `IImplementationGuideProvider.cs:3`, `IPackageResourceImporter.cs:4` (`Ignixa.PackageManagement.Abstractions`); `PackageImportResult.cs:1` (`Ignixa.PackageManagement.Models`); `Infrastructure/ResourceReferenceHelper.cs:13` (`namespace Ignixa.Serialization.Helpers`)
+**Issue**: Six files in the Application project declare namespaces belonging to the Core `Ignixa.PackageManagement` and `Ignixa.Serialization` packages. Anyone reading a stack trace or a `using Ignixa.PackageManagement.Abstractions;` line will look for these types in the wrong project, and since `Ignixa.Application` also *references* `Ignixa.PackageManagement`, the same namespace is now split across two assemblies — a collision waiting to happen if Core ever adds a type of the same name. This is classic copy-migration residue.
+**Recommendation**: Either move these files into the actual `Ignixa.PackageManagement` project (they have no Application dependencies — check `KnownPackages` usage) or rename the namespaces to `Ignixa.Application.Features.Packages` / `Ignixa.Application.Infrastructure` and fix usings.
+**Effort**: S
+
+### P1 — ResourceReferenceHelper.UpdateReference destroys sibling reference fields
+**Location**: `src/Application/Ignixa.Application/Infrastructure/ResourceReferenceHelper.cs:103, 110, 272-279`
+**Issue**: Updating a reference replaces the whole node with `CreateReferenceJsonObject`, i.e. `{ "reference": "Patient/456" }` — any existing `display`, `type`, `identifier`, or extensions on the original Reference are silently deleted. For bundle reference rewriting (its apparent use), losing `display` mutates clinical data beyond the intended id swap. Additionally, `elementPath` lookups are top-level only (`jsonObject.TryGetPropertyValue(elementPath, …)`), so nested references (e.g., `Patient.contact.organization`) can never be found or updated — whether that's a real gap depends on what `IReferenceMetadataProvider` emits, but the helper can't handle what the metadata type's name implies. `ResourceReferenceExtensions.cs` is a one-method pass-through wrapper adding nothing.
+**Recommendation**: Mutate only the `reference` property of the existing JsonObject (`node["reference"] = newValue`). Verify metadata never emits nested paths, or implement path traversal. Delete the extensions wrapper or the helper's duplicate entry point — one API is enough.
+**Effort**: S
+
+### P1 — `EnableV1ScopeCompatibility` is dead configuration: v1 scopes are always accepted
+**Location**: `src/Application/Ignixa.Application/Features/Authorization/SmartOptions.cs:30`; `Features/Authorization/Smart/SmartScopeParser.cs:80-87`
+**Issue**: `SmartOptions.EnableV1ScopeCompatibility` (default false, present in `appsettings.json`) is read by nothing. `SmartScopeParser.ParseScope` unconditionally falls back to the v1 regex, so v1 scopes (`patient/Observation.read`) are always honored regardless of configuration. An operator who believes they've disabled legacy scope acceptance has not. The parser is static, so wiring the option requires a design decision, not just a null check.
+**Recommendation**: Either plumb the flag (make the parser instance-based or pass an options struct into `ParseScope`) or delete the option and document that v1 compatibility is always on. A config knob that does nothing is worse than no knob.
+**Effort**: S
+
+### P1 — CapabilityEnforcementBehavior: generic exception for authz denial, per-request statement materialization, arbitrary version fallback
+**Location**: `src/Application/Ignixa.Application/Infrastructure/Behaviors/CapabilityEnforcementBehavior.cs:93-121, 130-152`
+**Issue**: (1) Denial throws bare `InvalidOperationException` relying on middleware to translate it to 403 — but `InvalidOperationException` is thrown for dozens of unrelated failures across the codebase (including inside this very behavior's dependencies, e.g. "Tenant X not found"), so genuine server bugs can masquerade as 403 capability denials and vice versa. A dedicated exception type exists as prior art (`ValidationException` in `ValidationBehavior`). (2) Every guarded request calls `capabilityStatement.ToElement(provider)` and compiles/evaluates a FHIRPath expression against the full capability statement — the statement is cached but the element projection is rebuilt per request; ADR-2501 budgets <0.5ms for this layer, which per-request `ToElement` of a document with hundreds of resources will not meet. (3) When no request context exists, `GetFhirVersionForTenantAsync` silently uses "first tenant's version" — cross-tenant behavior leakage identical to the pattern in `GetCapabilityStatementHandler.cs:62-68`. (4) The XML doc example references `IRequiresCapability`; the interface is `IRequireCapability`.
+**Recommendation**: Introduce `CapabilityNotSupportedException` mapped to 403+OperationOutcome. Cache the `ToElement` projection alongside the statement in `CapabilityCacheEntry` (it's invalidated at the same time). Make the no-context fallback explicit: default R4 or throw, but never "whichever tenant is listed first".
+**Effort**: M
+
+### P1 — DebounceInvalidationStrategy: `AddOrUpdate` factories with side effects leak live timers
+**Location**: `src/Application/Ignixa.Application/Utilities/DebounceInvalidationStrategy.cs:70-73, 96-100, 110-151`
+**Issue**: `ConcurrentDictionary.AddOrUpdate` may invoke its factories multiple times under contention and discard all but one result. Both factories here have side effects: `CreateNewDebounceState` starts a live `Timer`; `ResetDebounceTimer` *disposes the existing state's timer* and starts a new one. Under concurrent `RequestInvalidation` calls for the same tenant, a discarded factory result leaves an orphaned armed timer (double invalidation — benign here, but the callback also races `_debounceStates.TryRemove` cleanup), and the update factory's disposal of `existing` executes even when its result loses the race. The class works in the common single-threaded case, which is why it's survived.
+**Recommendation**: Replace the AddOrUpdate dance with a per-tenant lock or `lock`-guarded plain dictionary — this is a low-frequency admin path; `ConcurrentDictionary` cleverness buys nothing. Given the P1 dead-feature finding above, this class may simply be deleted along with its only consumer.
+**Effort**: S
+
+### P1 — FhirRequestContextAccessor: static AsyncLocal contradicts scoped registration; two types per file
+**Location**: `src/Application/Ignixa.Application/Infrastructure/FhirRequestContextAccessor.cs:18-33, 39-101`
+**Issue**: The accessor's comment says "Registered as SCOPED service in DI container" but the backing store is a `private static readonly AsyncLocal<>` — all instances share one store, so scoped lifetime is meaningless (harmless today, but a maintainer adding per-instance state will introduce a cross-request leak that the "scoped" label hides). The file also contains both `FhirRequestContextAccessor` and `FhirRequestContext` (one-type-per-file violation), and `IFhirRequestContext.cs` likewise bundles `OperationOutcomeIssue`.
+**Recommendation**: Register singleton and fix the comment (matching how ASP.NET Core's own `HttpContextAccessor` works), split the files.
+**Effort**: S
+
+### P1 — RBAC ReadOnly/read grants don't cover search, vread, or history
+**Location**: `src/Application/Ignixa.Application/Features/Authorization/Handlers/InMemoryRolePermissionStore.cs:55-56, 60-63`; `Features/Authorization/Models/ResourceGrant.cs:30-39`; `Models/FhirAuthorizationContext.cs:116-117`
+**Issue**: `RequiredPermission` uses FHIR interaction codes (`read`, `vread`, `search-type`, `history-instance`, …) and `ResourceGrant.Matches` does exact string comparison. The built-in `ReadOnly` role grants `("*", "read")` — which matches only the `read` interaction. A ReadOnly user cannot search, vread, or view history; the `Clinician` role's `("Practitioner", "read")` has the same problem. Unlike SMART scopes (where `MapInteractionToPermission` folds vread/history into Read), RBAC has no interaction-family mapping. The role is unusable as intended and nobody noticed, which suggests RBAC-only deployments are untested.
+**Recommendation**: Add an interaction-family mapping to `ResourceGrant.Matches` (read ⊇ {read, vread, history-instance, history-type, search-type}), mirroring `SmartScope.MapInteractionToPermission`, or define grants in terms of the CRUDS permission flags shared with SMART.
+**Effort**: S
+
+### P1 — ProfileCapabilitySegment: cache-type abuse, serialize/deserialize round-trip per build, hardcoded tenant "1", parallel source of truth
+**Location**: `src/Application/Ignixa.Application/Features/Metadata/Segments/ProfileCapabilitySegment.cs:71, 161, 204-317`
+**Issue**: (1) The segment smuggles a `List<PackageResource>` (full StructureDefinition JSON blobs) through `ICapabilityCache` by stuffing serialized JSON into `CapabilityCacheEntry.Statement.MutableNode["_profileData"]` — "repurposed for segment-level caching" per its own comment. Every cache *hit* pays `ToJsonString()` + `JsonSerializer.Deserialize<List<PackageResource>>` over all loaded profiles, and `ApplyAsync` + `GetVersionHashAsync` each do it (twice per capability build). (2) `context.TenantId?.ToString() ?? "1"` hardcodes tenant 1 as the system-wide default in two places — system `/metadata` shows tenant 1's profiles, and the fallback disagrees with `CapabilityContext.ToCacheKey()`'s `"default"`. (3) The segment queries `IImplementationGuideProvider`/`IPackageResourceRepository` directly while ADR-2512's `ConformanceState._structureDefinitions` holds the same data as an event-sourced projection — two competing sources of truth for "active profiles".
+**Recommendation**: Give segment-level caching its own typed `IMemoryCache` entry (a `record ProfileData` is already defined — cache it directly instead of via JSON). Remove the tenant-"1" default; system-wide should aggregate or omit profiles explicitly. Longer term, read profiles from `ConformanceState`.
+**Effort**: M
+
+### P1 — CompositeStructureDefinitionSummaryProvider: sync-over-async in property getter; invalidation leaves the provider permanently uninitialized
+**Location**: `src/Application/Ignixa.Application/Features/Specification/CompositeStructureDefinitionSummaryProvider.cs:36-39, 219-221, 252-264, 352-390`; `Features/Search/FhirVersionContext.cs:338`
+**Issue**: (1) `ResourceTypeNames` → `ComputeResourceTypeNames` → `GetCustomResourceTypesFromPackages` blocks on `Task.Run(...).GetAwaiter().GetResult()` inside a `Lazy` — a database query behind a synchronous property getter, called from capability-statement builds on request threads. The same pattern appears at `FhirVersionContext.cs:338`. CLAUDE.md forbids `.Result`/`.Wait()`; `Task.Run` avoids classic deadlock but burns a threadpool thread and hides latency in a property. (2) `GetTypeDefinition` negative-caches base-provider misses forever (`_cache[typeName] = baseType` even when null); `ClearCache()` resets `_isInitialized = false` and expects re-initialization that (per the P1 dead-feature finding) never comes, so post-invalidation the provider silently degrades to base-spec-only. `_isInitialized` is also a plain bool read/written across threads.
+**Recommendation**: If the provider survives the dead-feature decision: make `ResourceTypeNames` computation async-initialized during tenant preload (it already has an `InitializeAsync` lifecycle — use it), make `_isInitialized` `volatile`, and have the debounced invalidation call `InitializeAsync` after `ClearCache`.
+**Effort**: M
+
+### P2 — One-type-per-file violations across the subsystem
+**Location**: `Features/Admin/ListPackagesQuery.cs` (3 types), `Features/Admin/LoadPackageCommand.cs` (2), `Features/Admin/UnloadPackageCommand.cs` (2), `Features/Authorization/AuthorizationOptions.cs` (3), `Features/Authorization/Smart/SmartScope.cs` (3), `Smart/SmartAuthorizationContext.cs` (2), `Smart/SpecialScope.cs` (2), `Features/Authorization/Services/ISmartConfigurationProvider.cs` (2), `Services/OidcDiscoverySmartConfigurationProvider.cs` (2), `Features/Conformance/ActivationResult.cs` (2), `Features/Conformance/PackageResources.cs` (2), `Features/Conformance/SearchParameterInfo.cs` (2), `Infrastructure/FhirRequestContextAccessor.cs` (2), `Infrastructure/IFhirRequestContext.cs` (2), `Infrastructure/SidecarLogger.cs` (3 public types)
+**Issue**: CLAUDE.md's ONE TYPE PER FILE rule is violated in at least 15 files in scope. Enum-plus-record pairs are defensible; three public types in `SidecarLogger.cs` and query+result+DTO bundles in Admin are not.
+**Recommendation**: Split mechanically; prioritize files with 3+ types or public non-nested types.
+**Effort**: M
+
+### P2 — Log-and-rethrow catch blocks add noise without value
+**Location**: `Features/Admin/ListPackagesHandler.cs:61-65`, `LoadPackageHandler.cs:128-135`, `UnloadPackageHandler.cs:83-90`; `Features/Packages/ImplementationGuideProvider.cs:127-134, 324-328, 369-376`; `Features/Packages/PackageResourceImporter.cs:132-140`
+**Issue**: Seven `catch (Exception ex) { _logger.LogError(...); throw; }` blocks whose only content is context already present in the exception path and the preceding Information logs. CLAUDE.md: "Log once at the boundary where you handle it. Don't log-and-rethrow."
+**Recommendation**: Delete the try/catch wrappers; the exception middleware is the logging boundary.
+**Effort**: S
+
+### P2 — Argument validation via InvalidOperationException; `ct` parameter names
+**Location**: `Features/Admin/LoadPackageHandler.cs:31-36`, `UnloadPackageHandler.cs:42-47`, `ListPackagesHandler.cs:37-38` (should be `ArgumentException`); `Infrastructure/AppSettingsTenantConfigurationStore.cs:97,114`, `CompositeRepositoryFactory.cs:38`, `CompositeSearchServiceFactory.cs:38`, `PassthroughExecutionStrategy.cs:40,76` (parameter named `ct`, CLAUDE.md mandates `cancellationToken`)
+**Issue**: Wrong exception type for bad arguments; `ct` naming contradicts the project's own critical-violations table. The `ct` names originate in Domain interfaces — fix them there and ripple.
+**Recommendation**: Mechanical rename + exception-type swap.
+**Effort**: S
+
+### P2 — Copyright header chaos: "Microsoft Corporation" on Ignixa code, three header styles, and headerless files
+**Location**: Pervasive — e.g. `Infrastructure/ApplicationVersionInfo.cs:1-4` (Microsoft), `Infrastructure/Behaviors/ValidationBehavior.cs:1-4` (Ignixa Contributors), `Infrastructure/ResourceReferenceExtensions.cs:1-4` (XML-style Microsoft), `Features/Admin/*.cs`, `Features/Conformance/ConformanceState.cs` (no header)
+**Issue**: Most files claim "Copyright (c) Microsoft Corporation" — presumably template residue from the Microsoft FHIR Server. For a project publishing NuGet packages this is a legal-hygiene problem, not just style.
+**Recommendation**: Pick one header (or none), enforce via `.editorconfig` `file_header_template`, and sweep.
+**Effort**: S
+
+### P2 — ValidationBehavior: vacuous depth condition and misleading skip branch
+**Location**: `src/Application/Ignixa.Application/Infrastructure/Behaviors/ValidationBehavior.cs:79, 145-151`
+**Issue**: `if (validationDepth != ValidationDepth.Minimal || validationDepth == ValidationDepth.Spec || validationDepth == ValidationDepth.Full)` — the two `||` arms are unreachable given the first (a value equal to Spec or Full already satisfies `!= Minimal`). The `else` branch then logs "Validation running with minimal depth" while actually skipping validation entirely. Also, `ValidationBehavior` is a non-generic `IPipelineBehavior<CreateOrUpdateResourceCommand, ResourceKey>` living in Infrastructure/Behaviors while coupled to a specific Resource-feature command — it's feature logic, not infrastructure.
+**Recommendation**: Simplify to `if (validationDepth != ValidationDepth.Minimal)`, fix the log message, and consider relocating next to the Resource feature.
+**Effort**: S
+
+### P2 — Capability statement advertises unimplemented-verified capabilities and omits supported ones
+**Location**: `src/Application/Ignixa.Application/Features/Metadata/Segments/ResourceInteractionCapabilitySegment.cs:83-101, 134-151`; `Features/Metadata/CapabilityStatementService.cs:165`
+**Issue**: Every resource type unconditionally advertises `ConditionalCreate`, `ConditionalUpdate`, `ConditionalDelete=Single`, `UpdateCreate`, `ReadHistory` — while the interaction list omits `vread`, `history-instance`, `history-type`, and `patch` even though the server implements them (`FhirInteraction` enumerates them; History/Patch features exist). Under ADR-2501 the CapabilityStatement is an enforced contract: interactions not advertised may be denied by capability enforcement, and flags advertised but unimplemented break conformance. Also `CapabilityStatementService.cs:165` hardcodes `statement.Url = "http://Ignixa.example.com/fhir/CapabilityStatement"` — an example.com URL served in production metadata.
+**Recommendation**: Advertise the full implemented interaction set (vread/history/patch) and derive conditional flags from actual feature registration. Make the canonical URL configurable from server base URL.
+**Effort**: M
+
+### P2 — IncludeRevInclude segment ignores tenant; two segments share priority 40
+**Location**: `src/Application/Ignixa.Application/Features/Metadata/Segments/IncludeRevIncludeCapabilitySegment.cs:38, 48, 123`; `Segments/ProfileCapabilitySegment.cs:49`
+**Issue**: `GetSearchParameterDefinitionManager(context.FhirVersion)` omits `context.TenantId` (contrast `SearchParameterCapabilitySegment.cs:48` which passes it), so tenant-package reference parameters never appear in `searchInclude`/`searchRevInclude`. Both this segment and ProfileCapabilitySegment declare `Priority => 40`, making their relative order registration-order-dependent.
+**Recommendation**: Pass the tenant id; renumber priorities uniquely.
+**Effort**: S
+
+### P2 — `IsBaseFhirPackage` logic triplicated
+**Location**: `Features/Conformance/PackageActivationPipeline.cs:278-280`, `Features/Conformance/ConformanceState.cs:340-342`, plus `KnownPackages.IsCorePackage` (Ignixa.PackageManagement) used in `LoadPackageHandler.cs:39`
+**Issue**: The "is this a core FHIR package" predicate exists in at least three places with two different implementations (`hl7.fhir.r*.core` prefix/suffix vs `KnownPackages.CorePackages` list). Divergence here changes which SearchParameters skip the reindex lifecycle — a behavioral fork waiting to happen.
+**Recommendation**: Single predicate on `KnownPackages`; delete the private copies.
+**Effort**: S
+
+### P2 — Azure resource-provider string in Ignixa RBAC sidecar contract
+**Location**: `src/Application/Ignixa.Application/Features/Authorization/Handlers/SidecarRbacAuthorizationHandler.cs:88-92`
+**Issue**: `BuildDataAction` emits `Microsoft.HealthcareApis/fhir/{INTERACTION}` — the Azure Healthcare APIs RBAC action namespace, copied verbatim into a non-Azure product's authorization protocol. Any sidecar implementation must now match Azure's action-string format forever.
+**Recommendation**: Define an Ignixa-native data-action format in the sidecar proto contract.
+**Effort**: S
+
+### P2 — Event abstraction inconsistency: interface events vs concrete-record events
+**Location**: `Events/Package/IPackageLoaded.cs`/`IPackageUnloaded.cs`/`Events/Terminology/ITerminologyImportTriggered.cs` vs their records; `Ignixa.Application.BackgroundOperations/Terminology/EventHandlers/TerminologyImportTriggeredHandler.cs:19`; `Ignixa.Api/Services/SqlReferenceDataPreloadService.cs:24`
+**Issue**: Package events define interface + record pairs and handlers subscribe to the interfaces; terminology and startup events are handled by their concrete records (`INotificationHandler<TerminologyImportTriggeredEvent>`), making `ITerminologyImportTriggered` decorative. One event (`TenantPackagePreloadCompletedEvent`) has no interface at all. Three patterns for one mechanism; the interface layer buys nothing since the records are already immutable contracts.
+**Recommendation**: Drop the event interfaces; publish and subscribe to the records.
+**Effort**: S
+
+### P2 — PackageLoaded/Unloaded handler asymmetry within the Application layer
+**Location**: `Events/Package/PackageLoadedNotificationHandler.cs` vs `PackageUnloadedNotificationHandler.cs:52-58`
+**Issue**: The unload handler invalidates both schema registry and capability cache; the load handler invalidates only the schema registry — load-side capability invalidation lives in the DataLayer legacy handler (see the P1 layering finding). Also inconsistent ctor null-checking within the pair (unload null-checks one of three params, load none).
+**Recommendation**: Mirror the invalidation set in both handlers.
+**Effort**: S
+
+### P2 — ConditionalHeaderParser: no `*`, no ETag lists, no strict HTTP-date parsing
+**Location**: `src/Application/Ignixa.Application/Utilities/ConditionalHeaderParser.cs:16-56`
+**Issue**: `If-None-Match: *` (a meaningful conditional-create guard per RFC 7232 §3.2) parses to the literal `"*"` rather than being recognized; multi-value headers (`"5", "7"`) parse to garbage (`5", "7`); `ParseIfModifiedSince` uses culture-sensitive `DateTimeOffset.TryParse` instead of the `"R"` format it emits. Also redundant `using System;` under ImplicitUsings, and HTTP-header parsing arguably belongs in the API layer.
+**Recommendation**: Handle `*` explicitly, split on commas, parse with `DateTimeOffset.TryParseExact(..., "R", CultureInfo.InvariantCulture, ...)` with lenient fallback.
+**Effort**: S
+
+### P2 — Misleading comments: partition-0 example, PE-header claim, phase-number archaeology
+**Location**: `Infrastructure/IsolatedModePartitionStrategy.cs:18` ("Tenant 0 = Mayo Clinic" — partition 0 is the reserved system partition per CLAUDE.md/ADR-2510; the example teaches the forbidden pattern); `Infrastructure/ApplicationVersionInfo.cs:149-150` (comment says "build timestamp from linker timestamp in PE header", code reads `File.GetLastWriteTimeUtc`); pervasive "Phase 1.2/7/11/12/20.2" comments (`ICapabilityCache.cs:12`, `MemoryCapabilityCache.cs:13-14`, `ProfileCapabilitySegment.cs` etc.) that reference a roadmap no reader can consult
+**Recommendation**: Fix the partition-0 example immediately (it's a security-relevant doc bug); delete or correct the rest.
+**Effort**: S
+
+### P2 — SidecarMetricsService passes the request token into a fire-and-forget task
+**Location**: `src/Application/Ignixa.Application/Infrastructure/SidecarMetricsService.cs:27`
+**Issue**: `_ = RecordMetricInternalAsync(metrics, cancellationToken)` — the request-scoped token can cancel the unawaited gRPC send when the request aborts, dropping the metric for exactly the requests you most want measured. `SidecarLoggerProvider.ProcessLogEntriesAsync` also has a dead `lastFlush` variable (lines 72, 112) and its `Dispose()` uses sync `.Wait(...)` alongside a proper `DisposeAsync`.
+**Recommendation**: Use `CancellationToken.None` (or a service-lifetime token) for the detached send; delete `lastFlush`.
+**Effort**: S
+
+### P2 — Redundant `#nullable enable` directives and leftover TODO
+**Location**: `Infrastructure/ResourceReferenceHelper.cs:6`, `Utilities/DebounceInvalidationStrategy.cs:6`, `Features/Specification/CompositeSchemaProviderRegistry.cs:6`, `CompositeStructureDefinitionSummaryProvider.cs:6`, `ICompositeSchemaProviderRegistry.cs:6` (project already has `<Nullable>enable</Nullable>`); `CompositeStructureDefinitionSummaryProvider.cs:112` (TODO in committed code, banned by CLAUDE.md checklist)
+**Recommendation**: Delete the directives; resolve the TODO as part of the dead-feature decision.
+**Effort**: S
+
+### P2 — CompositeRepositoryFactory / CompositeSearchServiceFactory: duplicated routing with magic strings and ambiguous DI
+**Location**: `Infrastructure/CompositeRepositoryFactory.cs:48-53`, `Infrastructure/CompositeSearchServiceFactory.cs:48-53`
+**Issue**: Two near-identical classes switch on `"FileSystem"` / `"SqlEntityFramework" or "SqlServer"` string literals (defined nowhere central), and each takes two parameters of the *same interface type* distinguished only by parameter name — correct resolution depends entirely on Autofac positional/named registration, which a refactor can silently break.
+**Recommendation**: Extract storage-type constants (or an enum on `TenantConfiguration.Storage`), and use keyed services so the container enforces which factory is which.
+**Effort**: S
+
+## Addendum: Cross-scope handoffs from background-operations review (verified)
+
+The background-operations review found that `Ignixa.Application.Operations/Features/Transform` and `.../Terminology/{Expand,Subsumes,Translate}` are dead namespace-only duplicates of `Ignixa.Application/Features/Experimental/Transform` and `.../Experimental/Terminology` (its report recommends deleting the duplicates). Three behavioral issues in the **live** copies were handed off to this review and have been verified against the source:
+
+### P1 — FhirPathEvaluatorWithTimeout: "timeout" abandons the thread, never cancels the work
+**Location**: `src/Application/Ignixa.Application/Features/Experimental/Transform/FhirPathEvaluatorWithTimeout.cs:64, 102-108`; `Features/Experimental/Infrastructure/ExperimentalAutofacRegistration.cs:154-160`
+**Issue**: `Task.Run(() => _evaluator.Evaluate(element, compiled), cts.Token)` — the token gates only the *start* of the task; `FhirPathEvaluator.Evaluate` receives no cancellation and runs to completion regardless. On timeout the caller gets `TimeoutException` while the runaway expression keeps burning a threadpool thread; repeated timeouts (the exact scenario this class exists for — pathological expressions) leak threads until pool starvation. The sync `Evaluate` wrapper blocks via `.GetAwaiter().GetResult()` (CLAUDE.md-banned pattern; here it means every FML transform step blocks a second thread waiting on the first). The 5-second timeout is hardcoded in the registration rather than configuration.
+**Recommendation**: Thread a `CancellationToken` into `FhirPathEvaluator.Evaluate` (cooperative checks in the evaluation loop) so timeout actually stops work. If the evaluator can't be made cancellable, at minimum document the abandonment and add a runaway-expression counter so pool exhaustion is diagnosable. Move the timeout to options.
+**Effort**: M
+
+### P1 — ConceptMapResolverService sync wrapper converts infrastructure failure into "no translation"
+**Location**: `src/Application/Ignixa.Application/Features/Experimental/Transform/ConceptMapResolverService.cs:122-148` vs `:96-110`
+**Issue**: `TranslateAsync` deliberately wraps and rethrows failures ("Rethrow to let caller handle"); the sync `Translate` wrapper — the one the FML `translate()` transform actually calls — catches **all** exceptions and returns null. Null means "no translation found", so a terminology-service outage or a missing ConceptMap silently produces transformed resources with absent coded fields instead of a failed transform. That is data-quality corruption in output resources, and it directly contradicts the async method's documented contract two screens up in the same file.
+**Recommendation**: Remove the catch-all in the sync wrapper — let the `InvalidOperationException` from `TranslateAsync` propagate so the transform fails loudly. If FML semantics require lenient translate, make leniency an explicit parameter, not an accident of which overload was called.
+**Effort**: S
+
+### P1 — MapRegistryCache: per-request lifetime nullifies both the cache and its invalidation handler
+**Location**: `src/Application/Ignixa.Application/Features/Experimental/Transform/MapRegistryCache.cs`; `Events/PackageLoadedMapCacheInvalidationHandler.cs`; `ExperimentalAutofacRegistration.cs:142-146, 168-170`
+**Issue**: `MapRegistryCache` is registered `InstancePerLifetimeScope` — every request gets a fresh, empty cache, so the class's documented performance profile ("Cache hit: ~1-5ms … Throughput: 200-500 transforms/sec (cached)") only holds within a single request. `PackageLoadedMapCacheInvalidationHandler` (`InstancePerDependency`) resolves the cache from the publishing request's scope, so it "invalidates" an instance that dies with that admin request — the handler, its statistics logging, and `InvalidatePackage` are all dead weight under this lifetime. Caution for the obvious fix: naively promoting the cache to `SingleInstance` would (a) share `Register()`-ed inline maps and repository-loaded maps **across tenants** — `GetOrLoadAsync`/`GetStructureMapByUrlAsync` key by canonical URL with no tenant discriminator — and (b) the singleton would need tenant-keying before the invalidation handler becomes safe to keep.
+**Recommendation**: Decide the intended lifetime. If transforms are hot enough to justify caching, make the cache singleton keyed by `(tenantId, canonicalUrl)` and keep the invalidation handler; otherwise delete the handler, the statistics machinery, and the misleading performance claims, leaving a simple per-request registry.
+**Effort**: M
+
+## Architectural Observations
+
+1. **Layer boundaries are the systemic weakness.** Three independent violations converge: `HttpContext`/ASP.NET packages inside `Ignixa.Application` (authorization models, `IPipelineExecutor`, `FhirVersionExtractor`), DataLayer referencing Application (package events), and Core-package namespaces compiled into the Application assembly. Each is individually explainable; together they mean ADR-2509's dependency diagram no longer describes the build graph. An ADR amendment or a cleanup epic should pick one story and enforce it (an architecture test asserting reference direction would prevent regression).
+
+2. **ADR-2512 is half-executed and the halves disagree.** The event-sourced `ConformanceState` write path exists and is good, but: the legacy `PackageLoadedSearchParameterSyncHandler` flow ADR-2512 promised to remove still carries load-side cache invalidation; `ProfileCapabilitySegment` reads profiles from the package repository instead of the projection; and the composite schema provider builds a third profile source that is dead. Until reads converge on `ConformanceState`, every consumer must be audited against three sources of truth.
+
+3. **"Belt-and-braces that doesn't buckle" is the signature early-agent pattern here.** The capability version-hash system, the schema-invalidation debounce chain, the four-method cache invalidator, and the event interface layer are all sophisticated-looking infrastructure whose critical path is unreachable, uncalled, or no-op. The subsystem would be *smaller and more correct* after deletion: roughly 800-1,000 lines (segments' hash methods, debounce strategy, registry, three invalidator methods, event interfaces, dead eager-load) can go once the two "make it real or delete it" decisions (version-hash, composite provider) are made.
+
+4. **Authorization is centralized (good) but its contract is implicit (bad).** The handler-pipeline design avoids the duplicated-authorization-in-handlers antipattern — there is exactly one pipeline. But its semantics ("skip means pass") produce the P0 fail-open, ADR-2501's five layers don't match the four registered handlers, and the RBAC/SMART interaction vocabularies don't align (`read` vs CRUDS vs FHIR interaction codes — three permission languages in one folder). Worth a short ADR refresh defining: default-deny, the canonical interaction→permission mapping, and where capability enforcement actually lives (Medino behavior, not authz handler).
+
+5. **Tenant handling has three type systems.** Route/config use `int`, Admin commands and package management use `string`, authorization compares `context.TenantId` (string from claims) with `fhirContext.TenantId.ToString()`. Every seam is a parse or ToString with its own failure mode (`LoadPackageHandler`'s post-hoc `int.Parse` being the worst). Standardize on `int` at the Application boundary.
+
+6. **Conventions adherence is otherwise decent.** Medino Query/Handler separation is followed where CQRS applies; constructor injection is universal (no service locators found); primary constructors and file-scoped namespaces are used in newer files; `CancellationToken` is threaded through I/O correctly in nearly all paths (the exceptions are the deliberate fire-and-forget spots and the sync-over-async property getters flagged above).
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Add default-deny terminal to authorization pipeline | S | RbacAuthorizationHandler, FhirAuthorizationService (+1 new handler) |
+| P0 | Make ConformanceState reads thread-safe (immutable snapshot swap) | M | ConformanceState, ActiveSearchParameter |
+| P0 | Fix R6 in OperationsSegment; consolidate version-string switches | S | OperationsSegment |
+| P0 | Fix OIDC snake_case deserialization + add test | S | OidcDiscoverySmartConfigurationProvider |
+| P1 | Decide fate of composite-provider eager load; delete or complete invalidation chain | L | CompositeStructureDefinitionSummaryProvider, registry, debounce, 2 event handlers |
+| P1 | Move package events to Domain; remove DataLayer→Application reference; fix load/unload invalidation asymmetry | M | Events/*, DataLayer csproj, 2 notification handlers |
+| P1 | Delete or fix capability version-hash mechanism | M | CapabilityStatementService, ICapabilitySegment + 6 segments |
+| P1 | Delete 3 unused invalidator methods; fix no-op ClearAsync logging | S | ICapabilityCacheInvalidator, CapabilityCacheInvalidator, MemoryCapabilityCache |
+| P1 | Surface PackageResourceMapper parse failures as ValidationIssues | S | PackageResourceMapper, PackageActivationPipeline |
+| P1 | int TenantId in Admin commands; report activation failure in LoadPackageResult | M | 6 Admin files |
+| P1 | Make package list/unload actually tenant-scoped (or drop the parameter) | M | ImplementationGuideProvider, IPackageResourceRepository |
+| P1 | Fix SidecarAuditLogger guarantee (channel or fail-fast); stop fabricating audit fields | M | SidecarAuditLogger |
+| P1 | Remove HttpContext from FhirAuthorizationContext; move FhirVersionExtractor to API | M | FhirAuthorizationContext, 2 handlers, FhirVersionExtractor |
+| P1 | Fix foreign namespaces in Application assembly | S | 6 files (Packages/, ResourceReferenceHelper) |
+| P1 | UpdateReference must preserve sibling Reference fields | S | ResourceReferenceHelper |
+| P1 | Wire or delete EnableV1ScopeCompatibility | S | SmartOptions, SmartScopeParser |
+| P1 | Dedicated 403 exception + cached element in CapabilityEnforcementBehavior | M | CapabilityEnforcementBehavior, CapabilityCacheEntry |
+| P1 | RBAC interaction-family mapping (read covers vread/history/search) | S | ResourceGrant |
+| P1 | ProfileCapabilitySegment: typed cache, no tenant-"1" default | M | ProfileCapabilitySegment |
+| P2 | One-type-per-file split | M | ~15 files |
+| P2 | Remove log-and-rethrow wrappers; ArgumentException for args; rename `ct` | S | ~10 files |
+| P2 | Header sweep (drop Microsoft Corporation headers) | S | pervasive |
+| P2 | Advertise vread/history/patch; configurable canonical URL; fix vacuous ValidationBehavior condition | M | ResourceInteractionCapabilitySegment, CapabilityStatementService, ValidationBehavior |
+| P2 | Tenant-aware includes; unique segment priorities; single IsBaseFhirPackage; Ignixa-native RBAC action strings; concrete-record events; ConditionalHeaderParser RFC gaps; comment fixes | S | ~12 files |
+| P1 (addendum) | Make FHIRPath timeout actually cancel evaluation; configurable timeout | M | FhirPathEvaluatorWithTimeout, FhirPathEvaluator, ExperimentalAutofacRegistration |
+| P1 (addendum) | Remove catch-all-return-null in ConceptMapResolverService sync Translate | S | ConceptMapResolverService |
+| P1 (addendum) | Fix MapRegistryCache lifetime (tenant-keyed singleton) or delete invalidation handler + stats | M | MapRegistryCache, PackageLoadedMapCacheInvalidationHandler, ExperimentalAutofacRegistration |

--- a/docs/features/application-layer-modernization/investigations/background-operations-review.md
+++ b/docs/features/application-layer-modernization/investigations/background-operations-review.md
@@ -1,0 +1,248 @@
+# Investigation: Background Operations & Sidecar Contracts Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Ignixa.Application.BackgroundOperations, Ignixa.Application.Operations, Ignixa.Sidecar.Contracts
+
+## Summary
+
+The DurableTask orchestration/activity decomposition matches ADR 2510's intended shape, and the streaming pipelines (bounded channels, line-by-line NDJSON, no whole-file buffering) are genuinely good. But the failure/observability story is broken end-to-end: orchestrations swallow failures into "Completed" orchestration states, the status handler then reports failed jobs as successful, no retry policy exists anywhere despite being the ADR's core justification, and two orchestrations perform non-deterministic I/O inside orchestration code. Ignixa.Application.Operations carries ~13 files of dead, namespace-only duplicates of the Experimental Transform/Terminology features. Ignixa.Sidecar.Contracts is healthy.
+
+## Strengths
+
+- **Streaming done right**: `StreamingImportFileActivity` reads NDJSON line-by-line from a blob stream through a bounded channel with backpressure (`Import/Activities/StreamingImportFileActivity.cs:122-129, 322-368`); `ExportWorkerActivity` streams DB→writer with a bounded 500-slot channel and periodic flush (`Export/Activities/ExportWorkerActivity.cs:223-292`). No whole-dataset buffering anywhere.
+- **Partition-based export design**: surrogate-ID range partitioning (`GetExportRangesActivity`) eliminates continuation-token pagination and parallelizes cleanly — a sound architecture.
+- **Eternal orchestration singletons**: `EternalOrchestrationStarter` uses `CreateOrchestrationInstanceAsync` with `dedupeStatuses` for atomic dedup (`Ignixa.Api/BackgroundServices/EternalOrchestrationStarter.cs:63-95`), and `ContinueAsNew` correctly truncates history.
+- **TtlCleanup cannot run away**: bounded batch (default 100/tenant/cycle), per-tenant repository scoping, partition 0 explicitly excluded (`TtlCleanup/Orchestrations/TtlCleanupOrchestration.cs:57-58`), per-resource audit logging on success and failure (`TtlCleanup/Activities/TtlCleanupActivity.cs:93-118`). This is exactly the defensive posture a hard-delete job needs.
+- **TransactionWatcher matches the app-level transaction model**: commits stalled transactions via `IFhirRepositoryFactory`/`CommitTransactionAsync` (roll-forward visibility, not SQL ACID rollback), per-tenant, skips partition 0, isolates per-transaction failures (`TransactionWatcher/Activities/TransactionWatcherActivity.cs:65-93`).
+- **No `Hl7.Fhir.*` anywhere** — both csproj files use only `Ignixa.*`, DurableTask, and Grpc packages. Nullable enabled; repo-wide `TreatWarningsAsErrors`.
+- **DurableTaskHostedService init**: thoughtful transient-error classification for SQL Server and RBAC-propagation retry for Azure Storage (`Ignixa.Api/Infrastructure/DurableTaskHostedService.cs:82-210`).
+- **Sidecar.Contracts** is clean: four well-documented protos (audit, logging, metrics, rbac), fail-fast semantics documented in the contract itself, dual-targeted net9.0/net10.0, packable. No issues.
+
+## Findings
+
+### P0 — Failed jobs are reported as Completed
+**Location**: `src/Application/Ignixa.Application.BackgroundOperations/Jobs/GetJobStatusHandler.cs:204-223`, `Import/Orchestrations/ImportOrchestration.cs:149-160`, `Export/Orchestrations/ExportOrchestration.cs:216-248`
+**Issue**: Every orchestration catches all exceptions and returns a failure *payload* (`Status = "Failed"` / `Success = false`) — so the DurableTask orchestration itself ends in `OrchestrationStatus.Completed`. `GetJobStatusHandler.UpdateJobStatusFromOrchestrationAsync` maps `OrchestrationStatus.Completed` unconditionally to `job.Status = "Completed"` and never inspects the output's `Status`/`Success`/`ErrorMessage` fields. Consequences: (a) a failed import is reported to the client as Completed, with counts extracted from the failure output; (b) for export, `CompleteJobActivity` correctly writes `Status = "Failed"` to the job record, and the next status poll *overwrites it back to "Completed"*. `OrchestrationStatus.Failed` can effectively never occur because the orchestrations never rethrow.
+**Recommendation**: Pick one failure channel. Either let orchestrations throw (DurableTask marks the instance Failed and the handler mapping works), or make the status handler deserialize the output and honor its success flag. Also stop overwriting `EndDate` with poll time on every read.
+**Effort**: M
+
+### P0 — Export job result records file paths that don't exist
+**Location**: `src/Application/Ignixa.Application.BackgroundOperations/Export/Orchestrations/ExportOrchestration.cs:85` vs `:190`
+**Issue**: Workers write to `partition/{tenantId}/export/{jobId}/...` (line 85) but Phase 4 builds the `exportedFiles` dictionary — persisted into the job result and returned by `$export` status — with `tenant/{tenantId}/export/{jobId}/...` (line 190). `partition/` appears nowhere else in the codebase; every other path (including `ExportJobDefinition.OutputPath` in `CreateExportJobHandler.cs:108` and the documented format in `ExportWorkerInput.cs`) uses `tenant/`. Clients following the reported output URLs will find nothing.
+**Recommendation**: Build the path once, pass it through `ExportWorkerOutput`, and use the worker-reported path in the result. Add an E2E test that downloads a reported output file.
+**Effort**: S
+
+### P0 — Non-deterministic I/O inside orchestration code
+**Location**: `src/Application/Ignixa.Application.BackgroundOperations/TransactionWatcher/Orchestrations/TransactionWatcherOrchestration.cs:31, 53`; `TtlCleanup/Orchestrations/TtlCleanupOrchestration.cs:31, 54`
+**Issue**: Both eternal orchestrations constructor-inject `ITenantConfigurationStore` and call `GetAllTenantsAsync` inside `RunTask`. DurableTask orchestrations must be deterministic: on replay (worker failover, mid-cycle recovery while tenant activities are in flight) the live tenant list can differ from the history, producing divergent task scheduling or non-determinism failures. The registration helper's name — `AddTaskOrchestrationsFromInterface` "orchestrations with DI dependencies" (`Ignixa.Api/Infrastructure/DurableTaskConfiguration.cs:58-60`) — institutionalizes the mistake.
+**Recommendation**: Move tenant enumeration into a `GetActiveTenantsActivity` and schedule it like any other activity. Orchestrations should have zero I/O dependencies.
+**Effort**: M
+
+### P0 — Default export silently exports only 6 hardcoded resource types
+**Location**: `src/Application/Ignixa.Application.BackgroundOperations/Export/Orchestrations/ExportOrchestration.cs:251-262`
+**Issue**: When `_type` is not specified, `GetDefaultResourceTypes()` returns exactly `{Patient, Observation, Condition, MedicationRequest, Encounter, Procedure}`. The command doc (`CreateExportJobCommand.cs:23-25`) and `ExportCoordinatorInput` both promise "if empty, exports all types," and the FHIR bulk-export spec requires all types by default. A system-level `$export` silently omits every other resource type — undetectable data loss for the consumer.
+**Recommendation**: Resolve the full supported resource-type list from the tenant's schema/capability provider (via an activity), or reject type-less exports until that exists. Do not ship a silent subset.
+**Effort**: S/M
+
+### P0 — No retry policy anywhere; ADR 2510's fault-tolerance claim is unimplemented
+**Location**: all orchestrations — zero usages of `ScheduleWithRetry`/`RetryOptions` across `Ignixa.Application.BackgroundOperations`
+**Issue**: ADR 2510 selects DurableTask for "built-in retry policies and fault tolerance," but every activity is scheduled with plain `ScheduleTask`. One transient SQL timeout in one export worker fails the whole job (and per the first P0, may then be reported as Completed). Long-running import files that crash mid-way are never retried.
+**Recommendation**: Wrap activity scheduling in `ScheduleWithRetry` with a shared `RetryOptions` policy (short backoff, handle-transient predicate). This also forces the idempotency review below.
+**Effort**: M
+
+## P1 — Significant tech debt
+
+### P1 — Fake concurrency limiting in Import and Terminology orchestrations
+**Location**: `Import/Orchestrations/ImportOrchestration.cs:54-90`; `Terminology/Orchestrations/TerminologyImportOrchestration.cs:26-47`
+**Issue**: `input.InputFiles.Select(f => context.ScheduleTask(...)).ToList()` schedules *every* activity immediately; the subsequent batched `Task.WhenAll` in groups of 2 (or 5) limits nothing — all activities run as concurrently as the worker allows. The 10-line comment explaining the thread-pool math ("2 concurrent files × 9 = 18 threads vs 45") describes behavior the code does not have. Classic generated-code artifact: elaborate justification, no-op mechanism.
+**Recommendation**: Schedule lazily — only create the next `ScheduleTask` after a slot frees (sliding-window pattern), or rely on the worker's `MaxConcurrentTaskActivityWorkItems` and delete the fake batching + comment.
+**Effort**: S
+
+### P1 — Import job completion never persisted; error log written to local disk
+**Location**: `Import/Activities/CompleteJobActivity.cs:27-142`
+**Issue**: Import's `CompleteJobActivity` never touches `IBackgroundJobRepository` — the job record is only moved to a terminal state lazily when a client polls (`GetJobStatusHandler`), and per P0 #1 that flattening is wrong. Worse, the "error log upload" writes NDJSON to `Path.Combine("import-errors")` — a CWD-relative path on the local filesystem of whichever worker node ran the activity — and returns a URL (`/import-errors/...`) that nothing serves. The file is not tenant-scoped and contains failure details for PHI-bearing resources. The `Future: Upload to blob storage` comment has shipped.
+**Recommendation**: Write the error NDJSON to blob storage under `tenant/{tenantId}/import/{jobId}/errors.ndjson` via the existing `IBlobStorageClient`, and update the job record (status, result, EndDate) here, mirroring export's activity.
+**Effort**: M
+
+### P1 — Unbounded error accumulation flows through orchestration state (memory + PHI)
+**Location**: `Import/Activities/StreamingImportFileActivity.cs:230-238, 391-442`; `Import/Models/ImportErrorLogEntry.cs`; `Import/Orchestrations/ImportOrchestration.cs:99-101`
+**Issue**: Every failed line stores the *full resource JSON* in `ImportErrorLogEntry.ResourceJson`, accumulated in memory per file, serialized into `StreamingImportFileOutput`, through DurableTask history, aggregated across files, and passed into `CompleteJobInput`. A malformed 1M-line file produces a multi-GB activity output — OOM and/or orchestration-message-size failure. It also persists raw PHI into the DurableTask state store.
+**Recommendation**: Cap in-memory errors (e.g., first N), stream error entries directly to a blob from within the activity, and pass only counts + the blob path through orchestration state. Drop `ResourceJson` from entries that transit DurableTask.
+**Effort**: M
+
+### P1 — Cancellation is not implemented anywhere
+**Location**: every activity — `CancellationToken.None` at all I/O sites (e.g., `Export/Activities/ExportWorkerActivity.cs:83-292`, `Import/Activities/StreamingImportFileActivity.cs:91-281`, `TtlCleanup/Activities/TtlCleanupActivity.cs:43-83`)
+**Issue**: ADR 2510 lists cancellation support as a requirement. DurableTask.Core activities don't hand you a token, but the code doesn't build one either: there is no `TerminateAsync` path, no job-cancel command/endpoint, and no cooperative check of job status inside long loops. A multi-hour export cannot be stopped except by killing the worker. `GetJobStatusHandler` even maps `Terminated → Cancelled` (`Jobs/GetJobStatusHandler.cs:231-234`) for a transition nothing can trigger.
+**Recommendation**: Add a `CancelJobCommand` that calls `TaskHubClient.TerminateAsync`, plus a periodic job-status check (every N batches) inside worker/import loops to stop cooperatively.
+**Effort**: M
+
+### P1 — Orphaned producer task on consumer failure in ExportWorkerActivity
+**Location**: `Export/Activities/ExportWorkerActivity.cs:229-289`
+**Issue**: The producer is a `Task.Run` writing to a bounded channel; the consumer loop runs inline. If the consumer throws (line 255-286 rethrows), the method unwinds without awaiting `producerTask` (line 289 is never reached) and without completing the channel reader. The producer remains blocked on `WriteAsync` against a full channel forever, holding an open DB streaming query — a leaked task, connection, and unobserved exception per failed worker.
+**Recommendation**: In a `finally`, drain/complete: `channel.Reader.Complete()` isn't available — instead cancel the producer via a linked CTS and `await producerTask` inside try/catch before rethrowing. Same pattern in `StreamingImportFileActivity` is safer (it awaits producer then consumers, line 277-278) but still deadlock-prone if a consumer dies while the channel is full and other consumers exit.
+**Effort**: S
+
+### P1 — Group export is wrong for non-Patient types and unbounded for large groups
+**Location**: `Export/Activities/ExportWorkerActivity.cs:163-197`
+**Issue**: Group-scoped export (`GroupId`) only constrains the `Patient` type; every other requested type exports the *entire tenant's* resources, not the group compartment — a data-overexposure bug against bulk-export semantics. Additionally, group membership is re-resolved by every worker (once per range — 6+ redundant resolutions), and all member IDs are joined into a single `_id=a,b,c,...` parameter, which breaks for large groups (query/parameter limits).
+**Recommendation**: Resolve membership once in the orchestration (activity), constrain non-Patient types by patient compartment, and chunk the ID filter. If compartment-scoped export isn't ready, reject `GroupId` + non-Patient type combinations instead of silently over-exporting.
+**Effort**: L
+
+### P1 — Import retry non-idempotency: server-assigned IDs regenerate on re-run
+**Location**: `Import/Activities/StreamingImportFileActivity.cs:404-409`
+**Issue**: Resources missing an `id` get `Guid.NewGuid()` assigned per execution. When the file activity is re-executed (worker crash today; retry policy once P0 #5 is fixed), previously-written resources with generated IDs are written *again* under new IDs — silent duplication. Resources with client IDs are safe (PUT upsert).
+**Recommendation**: Derive deterministic IDs for ID-less rows (e.g., UUIDv5 of jobId + fileUrl + lineNumber), making file replay idempotent.
+**Effort**: S
+
+### P1 — Zombie jobs: no reconciliation for crash between job-create and orchestration-start
+**Location**: `Export/CreateExportJobHandler.cs:115-137`; `Import/CreateImportJobHandler.cs:85-106`
+**Issue**: Job row is created (`Status="Queued"`), then the orchestration is started, then the row is updated with the instance ID. A crash between steps leaves a Queued job with no orchestration, forever. `GetJobStatusHandler` fetches orchestration state by JobId and silently does nothing when it's null (`Jobs/GetJobStatusHandler.cs:189-246`) — the job shows Queued indefinitely. Nothing sweeps for these (TransactionWatcher watches transactions, not jobs; `HeartbeatDate` is written once and never updated by anything).
+**Recommendation**: Either start the orchestration first with the job payload (orchestration creates the record), or have the status handler mark instance-less jobs older than a threshold as Failed. Delete `HeartbeatDate` if nothing maintains it.
+**Effort**: M
+
+### P1 — Eternal orchestrations can silently never start; background subsystem silently disabled
+**Location**: `Ignixa.Api/BackgroundServices/EternalOrchestrationStarter.cs:31, 110-113`; `Ignixa.Api/Infrastructure/DurableTaskHostedService.cs:38-43`
+**Issue**: The starter "waits for DurableTask infrastructure" with a blind `Task.Delay(5s)`, then swallows any startup failure with a catch-all log. If SQL schema init is still in its retry loop (it retries up to 10× with growing delays), the create fails and TtlCleanup + TransactionWatcher never run until a process restart — with the only evidence one log line. Similarly, `DurableTaskHostedService` returns on init failure, "disabling" all background jobs while the server reports healthy. TransactionWatcher not running means stalled import transactions stay invisible — a data-visibility outage with no signal.
+**Recommendation**: Sequence properly (expose an initialization signal from the hosted service, or start the starter from within it after `StartAsync`), and surface both failure modes in a health check.
+**Effort**: M
+
+### P1 — Application layer constructs concrete SQL DataLayer types (Terminology)
+**Location**: `Terminology/Activities/ImportTerminologyResourceActivity.cs:9-10, 42-51, 197-237`
+**Issue**: The activity service-locates `SqlEntityFrameworkRepositoryFactory` from `IServiceProvider`, `new`s `SqlSystemRepository` and `SqlCodeSystemImporter`, uses `FhirDbContext` and EF Core directly, and hand-builds an `UPDATE dbo.PackageResource` SQL string (parameterized — not injectable, but still raw SQL in Application). This violates the layer rule (Application → Domain interfaces → DataLayer implements) and is untestable without a real SQL provider. It also hard-locks terminology import to the SQL provider even when the tenant runs the FileSystem datalayer.
+**Recommendation**: Define `ITerminologyImportStore` (load package resource, update import status) in Domain, implement in the SQL DataLayer, inject it.
+**Effort**: M
+
+### P1 — ~13 files of dead duplicated Transform/Terminology code in Ignixa.Application.Operations
+**Location**: `Ignixa.Application.Operations/Features/Transform/*` (7 files), `Ignixa.Application.Operations/Features/Terminology/{Expand,Subsumes,Translate}/*` (6 files)
+**Issue**: These are byte-for-byte copies of `Ignixa.Application/Features/Experimental/Transform` and `.../Experimental/Terminology` differing only in namespace (verified by diff). Nothing outside the Operations project references the Operations namespaces for these features; DI registration (`ExperimentalAutofacRegistration.cs:121-171`) and endpoints use the Experimental copies. Two diverging copies of a $transform engine is how a security fix lands in only one of them. (Behavioral issues in the *live* Experimental copies — 5s FHIRPath "timeout" that abandons the evaluating thread since the token is never observed by the evaluator, sync-over-async `GetAwaiter().GetResult()` in `ConceptMapResolverService.Translate` which also swallows all exceptions into `null`, and a per-request-scoped `MapRegistryCache` that a package-loaded invalidation handler can never meaningfully invalidate — belong to the Application-core review, but apply verbatim to these copies.)
+**Recommendation**: Delete the Operations copies of Transform and Terminology outright. Keep DeIdentify, MemberMatch, PatientEverything, Validate (those are the live, registered ones).
+**Effort**: S
+
+### P1 — MemberMatch ignores identifier.system: wrong-patient match risk
+**Location**: `Ignixa.Application.Operations/Features/MemberMatch/DefaultMemberMatchStrategy.cs:198-203`
+**Issue**: `BuildIdentifierExpression` matches on `FieldName.TokenCode` only — the identifier *system* is extracted (`ExtractIdentifiers`) and then discarded. Two patients with the same identifier value under different systems (MRN "12345" at hospital A vs plan-member "12345") can produce a single confident "match" of the wrong person. `$member-match` returning the wrong patient is a PHI disclosure, and HRex matching is exactly where this matters.
+**Recommendation**: Include system in the token expression when present (`system|value` semantics); only fall back to bare-value matching when the input identifier has no system, and consider requiring more than one corroborating identifier for a match.
+**Effort**: S
+
+### P1 — Patient $everything silently truncates with no paging
+**Location**: `Ignixa.Application.Operations/Features/PatientEverything/PatientEverythingHandler.cs:71, 117-122`
+**Issue**: `MaxItemCount = request.Count ?? 50`, `ContinuationToken: null`, `HasMore: false`. A patient with 500 resources returns 50 with no `next` link and no signal that the bundle is incomplete. Consumers of $everything (payer/member access flows) will treat the bundle as the complete record.
+**Recommendation**: Implement continuation for the PatientEverything expression, or until then set a high explicit cap and return `HasMore`/an OperationOutcome warning when truncated — silent truncation is the worst option.
+**Effort**: M/L
+
+### P1 — ListJobsTool loads all tenants' jobs and filters in memory
+**Location**: `JobManagement/ListJobsTool.cs:76-101`
+**Issue**: `ListAsync(jobType)` fetches every job across all tenants, then filters `j.Definition.TenantId == resolvedTenantId` in process. Tenant isolation enforced post-query in application code is one refactor away from a cross-tenant leak, and it's O(all-jobs) per call.
+**Recommendation**: Add a tenant-scoped `ListAsync(tenantId, jobType, ...)` to `IBackgroundJobRepository` and push the predicate to the store.
+**Effort**: S
+
+### P1 — SAS tokens persisted into DurableTask orchestration state
+**Location**: `Import/Models/ImportOrchestrationInput.cs` (`StorageDetail` — "SAS tokens, etc."), flows into `CompleteJobInput.StorageDetail`
+**Issue**: `StorageDetail` is documented to carry SAS tokens and is serialized as orchestration input — persisted, unredacted, into the DurableTask store (SQL/Azure Storage) and replayed through history. It is currently unused by any activity (`CompleteJobActivity` ignores it), so today it's pure secret-at-rest liability.
+**Recommendation**: Remove it from orchestration inputs until needed; when needed, store a reference/secret handle, not the token.
+**Effort**: S
+
+## P2 — Polish / style / dead code
+
+### P2 — Counterfeit Microsoft copyright headers
+**Location**: ~40 files across all three projects (e.g., `Export/Orchestrations/ExportOrchestration.cs` has none, but `ExportWorkerActivity.cs:1-4`, `ImportOrchestration.cs`, all model files, MCP tools, and even `Ignixa.Api/BackgroundServices/EternalOrchestrationStarter.cs` carry `Copyright (c) Microsoft Corporation`)
+**Issue**: This repo is not microsoft/fhir-server; the header misattributes copyright and points at a LICENSE that isn't Microsoft's. Newer files use the correct `Ignixa Contributors` header (e.g., `DeIdentifyHandler.cs:2`), so both exist inconsistently.
+**Recommendation**: Repo-wide header sweep to the Ignixa header (or none).
+**Effort**: S
+
+### P2 — Dead code inventory
+**Location / items**:
+- `Export/Activities/SearchAndWriteChunkInput.cs`, `SearchAndWriteChunkOutput.cs` — models for an activity that no longer exists (pre-partitioning pagination design).
+- `Import/Activities/ImportBatchActivity.cs` + `ImportBatchInput/Output` — not registered in `DurableTaskConfiguration`, not scheduled by any orchestration; also duplicates `PrepareResource` logic from `StreamingImportFileActivity` (copy-paste divergence risk).
+- `Import/Activities/ValidateFileActivity.cs:83-113` — `ExtractBlobName` never called, contains a bare `catch { return string.Empty; }`.
+- `Ignixa.Application.Operations/Features/Validate/ValidateResourceHandler.cs:87-129, 224-373` — ~200 lines of commented-out pseudo-code for CREATE/UPDATE/DELETE modes, and `:475-614` a ~140-line dead method tree (`ValidateTerminologyBindingsAsync`, `GetKnownBindings`, `ExtractCodedValue`) "kept for reference" — which also uses `MutableNode` JSON navigation, banned by CLAUDE.md.
+**Recommendation**: Delete all of it. Pseudo-code plans belong in docs/investigations, not shipped handlers.
+**Effort**: S
+
+### P2 — Job status magic strings
+**Location**: throughout — `"Queued"/"Running"/"Completed"/"Failed"/"Cancelled"` string literals in handlers, activities, tools (`CreateExportJobHandler.cs:100`, `GetJobStatusHandler.cs:197-233`, `UpdateProgressActivity.cs:65-67`, etc.), plus mode strings `"InitialLoad"/"IncrementalLoad"` validated by string comparison in three places.
+**Recommendation**: A `JobStatus` enum (or constants class) in Domain; same for import mode. Note `Mode` is validated but never actually changes behavior — either implement InitialLoad semantics or collapse the parameter.
+**Effort**: S
+
+### P2 — Invalid XML doc placement on positional record parameters
+**Location**: all Export models, e.g. `Export/Models/ExportCoordinatorInput.cs:15-22` — `/// <summary>` blocks *inside* the parameter list. These are not valid doc comments (compiler treats them as trivia); TtlCleanup/TransactionWatcher models show the correct `<param>` style.
+**Recommendation**: Convert to `<param>` on the record.
+**Effort**: S
+
+### P2 — Empty catch blocks in ExportOrchestration
+**Location**: `Export/Orchestrations/ExportOrchestration.cs:125-128, 163-166, 235-239`
+**Issue**: Three `catch { }` blocks around failure-path `CompleteJobActivity` scheduling. Comments acknowledge it ("just continue"). Project rule: empty catch blocks are bugs. Also `ScheduleTask<bool>` return values (job-not-found → false) are ignored everywhere.
+**Recommendation**: At minimum, orchestrations can't log — surface via the output's `FailurePhase`; better, let the orchestration fail and reconcile in the status handler (see P0 #1).
+**Effort**: S
+
+### P2 — Export progress never reported
+**Location**: `GetJobStatusHandler.cs:137-145` parses `ExportJobProgress`; nothing ever writes export progress (no export UpdateProgressActivity, no `SetCustomStatus` anywhere despite ADR 2510 citing it).
+**Recommendation**: Emit worker-completion progress from the orchestration (a small activity after each `WhenAll` slice once real windowing exists).
+**Effort**: S
+
+### P2 — Import progress reporting is post-hoc and off-by-one
+**Location**: `Import/Orchestrations/ImportOrchestration.cs:92-122`
+**Issue**: Because all file tasks complete before the aggregation loop (see fake-batching P1), progress updates fire only after everything is done; `CurrentFile = input.InputFiles[processedFiles].Url` also points at the *next* file, not the one processed. Cosmetic once real windowing lands.
+**Effort**: S (fold into the fake-concurrency fix)
+
+### P2 — Optional constructor dependencies
+**Location**: `Export/CreateExportJobHandler.cs:32` (`ViewDefinitionLoader? = null`), all four MCP tools (`IMcpAuthorizationService? = null`)
+**Issue**: Optional ctor params hide wiring failures — a mis-registered `ViewDefinitionLoader` silently disables ViewDefinition validation instead of failing at startup. For the authz service, "null = authorization service not configured" is a risky default for a tool that starts import jobs.
+**Recommendation**: Require them; use a no-op registration where a feature is genuinely optional.
+**Effort**: S
+
+### P2 — TtlCleanup throughput ceiling and log volume
+**Location**: `TtlCleanup/Activities/TtlCleanupActivity.cs:69-120`; `TtlCleanup/Models/TtlCleanupOrchestrationInput.cs`
+**Issue**: 100 resources/tenant/15-min cycle = ~9,600/day/tenant maximum; expiry rates above that accumulate a permanent backlog with no signal. Each deletion is an individual round-trip with two Information-level log lines plus an audit entry (log spam at scale). The bounded batch is the right safety default — but there's no drain-until-empty loop and no backlog metric.
+**Recommendation**: Loop batches within the activity up to a time budget; drop per-resource success logs to Debug; emit a "remaining expired" gauge.
+**Effort**: S
+
+### P2 — Watcher stall threshold vs long imports (needs verification)
+**Location**: `TransactionWatcher/Models/TransactionWatcherOrchestrationInput.cs` (default 5-min stall threshold); `Import/Activities/StreamingImportFileActivity.cs:100-106, 281`
+**Issue**: A large import file can hold its transaction open well past 5 minutes. Whether the watcher prematurely commits it depends on `GetStalledTransactionsAsync` heartbeat semantics in the DataLayer — the import activity itself never explicitly heartbeats. If `BatchWriteAsync` does not refresh the transaction heartbeat, a slow import gets its transaction committed mid-flight by the watcher (partial visibility — arguably acceptable roll-forward, per CLAUDE.md's degraded-state philosophy, and the final `CommitTransactionAsync` must then be idempotent). Not verified in this review's scope; flagging for the DataLayer review.
+**Effort**: S (verify + document)
+
+### P2 — Multiple types per file in Api DurableTask wiring
+**Location**: `Ignixa.Api/Infrastructure/DurableTaskConfiguration.cs` (3 types), `MapRegistryCache.cs` (3 types, in the dead Operations copy and the live Experimental one)
+**Recommendation**: Split per repo rule.
+**Effort**: S
+
+## Architectural Observations
+
+- **The failure channel is architecturally inverted.** Orchestrations are written to "never fail" (catch-all → failure payload → Completed status), which defeats DurableTask's own failure model, breaks the status handler, makes `OrchestrationStatus.Failed`/`Terminated` unreachable, and forced the empty-catch compensation blocks. One decision — "orchestrations throw; the job record is reconciled from real orchestration status" — collapses P0 #1, the empty catches, and half the status-handler complexity.
+- **Idempotency story is thin.** Activities are re-runnable-ish by accident (PUT upserts, re-queried expired lists) rather than by design: generated import IDs break replay, `CompleteJobActivity` timestamps drift on re-execution, and there are no retries to exercise any of it. ADR 2510's "activities are stateless, retriable, idempotent units" is aspiration, not implementation.
+- **Observability is logs-only.** No metrics for job success/failure, TTL backlog, watcher commits/failures; eternal-orchestration outputs are computed then discarded on `ContinueAsNew`; failures in TtlCleanup/TransactionWatcher activities are folded into output records that nothing reads. A failed background subsystem (init failure, starter race) is indistinguishable from a healthy idle one.
+- **Layering is respected everywhere except Terminology import** (direct EF/SQL types in Application) **and the MCP tools**, which couple BackgroundOperations to `Features.Experimental.Mcp` infrastructure — background-job MCP surface living in the jobs assembly but depending on an experimental feature's authz/DTO types is a dependency direction worth revisiting when MCP graduates.
+- **Duplication as a change-risk multiplier**: the Operations project's dead Transform/Terminology twins, plus `PrepareResource` duplicated between the live and dead import activities, are exactly where a future fix lands once and silently misses the copy.
+- **Positive**: the transaction model usage is correct per CLAUDE.md — no SQL transactions wrapped around merges, watcher commits (rolls forward) rather than rolls back, extension/index-extraction failures degrade gracefully (import proceeds with a warning when search-index extraction fails — consistent with the PostMergeExtensionUpdater philosophy).
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Unify failure channel: orchestrations throw; status handler honors real orchestration outcome; stop overwriting Failed→Completed | M | GetJobStatusHandler.cs, 3 orchestrations |
+| P0 | Fix `partition/` vs `tenant/` export path mismatch | S | ExportOrchestration.cs |
+| P0 | Move tenant enumeration out of orchestrations into an activity | M | TransactionWatcherOrchestration.cs, TtlCleanupOrchestration.cs, DurableTaskConfiguration.cs |
+| P0 | Export all resource types by default (or reject type-less export) | S/M | ExportOrchestration.cs |
+| P0 | Adopt `ScheduleWithRetry` + shared RetryOptions | M | all orchestrations |
+| P1 | Replace fake concurrency batching with real sliding-window scheduling | S | ImportOrchestration.cs, TerminologyImportOrchestration.cs |
+| P1 | Import completion: persist job record; error log to blob, tenant-scoped | M | Import CompleteJobActivity.cs |
+| P1 | Cap/stream import errors; strip ResourceJson from orchestration state | M | StreamingImportFileActivity.cs, models |
+| P1 | Implement job cancellation (TerminateAsync + cooperative checks) | M | new command/handler, activities |
+| P1 | Fix orphaned producer task on consumer failure | S | ExportWorkerActivity.cs |
+| P1 | Fix group export scope (non-Patient types) + membership resolution | L | ExportWorkerActivity.cs, ExportOrchestration.cs |
+| P1 | Deterministic IDs for ID-less import rows | S | StreamingImportFileActivity.cs |
+| P1 | Zombie-job reconciliation; remove dead HeartbeatDate | M | Create*JobHandler.cs, GetJobStatusHandler.cs |
+| P1 | Startup sequencing + health checks for DurableTask/eternal orchestrations | M | DurableTaskHostedService.cs, EternalOrchestrationStarter.cs |
+| P1 | Extract ITerminologyImportStore; remove EF/SQL from Application | M | ImportTerminologyResourceActivity.cs, Domain, DataLayer |
+| P1 | Delete dead Operations Transform/Terminology duplicate trees | S | 13 files in Ignixa.Application.Operations |
+| P1 | MemberMatch: match on system|value | S | DefaultMemberMatchStrategy.cs |
+| P1 | $everything paging or explicit truncation signal | M/L | PatientEverythingHandler.cs |
+| P1 | Tenant-scoped job listing in repository | S | ListJobsTool.cs, IBackgroundJobRepository |
+| P1 | Remove StorageDetail (SAS) from orchestration state | S | Import models |
+| P2 | Header sweep (remove Microsoft copyright) | S | ~40 files |
+| P2 | Delete dead code (SearchAndWriteChunk, ImportBatchActivity, pseudo-code blocks, dead validate methods) | S | 6+ files |
+| P2 | JobStatus enum; implement or remove import Mode | S | cross-cutting |
+| P2 | Fix record doc comments; empty catches; export progress; optional ctor deps; TTL drain loop; per-file type split | S | various |

--- a/docs/features/application-layer-modernization/investigations/crud-vertical-slices-review.md
+++ b/docs/features/application-layer-modernization/investigations/crud-vertical-slices-review.md
@@ -1,0 +1,293 @@
+# Investigation: FHIR CRUD/RESTful Vertical Slices Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Features/{Resource,Bundle,Patch,ConditionalOperations,History,Search,Compartment,Export}
+
+## Summary
+
+The CRUD slices follow the ADR-2509 vertical-slice shape (Query/Command records + handlers) and the read path (Get/Search/History) is in reasonable shape. The write path is not: resource validation on create/update is structurally dead (DI generic mismatch), optimistic concurrency (`If-Match`) is parsed everywhere and enforced nowhere, PATCH silently drops search indices and rejects legal `identifier` patches, and the bundle pipeline neither rewrites intra-bundle `urn:uuid` references nor provides transaction atomicity — despite ADR-2509-bundle-processing advertising both. Several of these are silent data-integrity failures, not crashes, which is why they have survived: test coverage for exactly these paths (validation rejection, intra-bundle references, If-Match conflicts) is absent.
+
+## Strengths
+
+- **Read path design is sound**: `GetResourceHandler`, `SearchResourcesHandler`, and the History handlers consistently use `SearchEntryResult` raw-bytes zero-copy through to `FhirJsonWriter.WriteRawProperty` — resources are never deserialized on the read path (`Features/Resource/GetResourceHandler.cs`, `Features/Bundle/Serialization/StreamingBundleSerializer.cs:632`).
+- **Count-as-render pagination** (`SearchResourcesHandler.cs:92-107` + `StreamingBundleSerializer.SerializeWithPaginationAsync`) is a good pattern: pageSize+1 fetch, serializer detects `hasMore` without a COUNT query, `_total` only triggers COUNT when explicitly requested.
+- **Capability enforcement via `IRequireCapability`** on every query/command with a FHIRPath expression against the CapabilityStatement is clean and declarative (`GetResourceQuery.cs:25`, `DeleteResourceCommand.cs:23`).
+- **Patch executors** use the strategy pattern per ADR-2510 correctly, and the before/after `ImmutablePropertyValidator` backstop is the right defense-in-depth idea (`Features/Patch/Executors/*`).
+- **DeferredWriteCoordinator's** TCS-per-operation + bounded-channel batching design (`Features/Bundle/DeferredWriteCoordinator.cs`) is a solid pattern, including `RunContinuationsAsynchronously` and partition grouping.
+- **`FilterUnsupportedParams`** in the serializer correctly strips unsupported params (incl. per-field `_sort`) from self links (`StreamingBundleSerializer.cs:842-900`).
+- Bundle streaming serializer guarantees well-formed JSON on mid-stream failure by appending an error entry (`StreamingBundleSerializer.cs:404-439`).
+
+## Findings
+
+### P0 — Resource validation never runs: ValidationBehavior registered with wrong response type
+**Location**: `src/Application/Ignixa.Application/Infrastructure/Behaviors/ValidationBehavior.cs:24`, `src/Application/Ignixa.Api/Registrations/ApplicationServicesRegistration.cs:129-131`
+**Issue**: `ValidationBehavior` implements `IPipelineBehavior<CreateOrUpdateResourceCommand, ResourceKey>`, but the handler pipeline is `<CreateOrUpdateResourceCommand, UpdateResult>` (`CreateOrUpdateResourceHandler.cs:38`, registration line 140-142). The mediator resolves behaviors for `UpdateResult`, so this behavior is never in the pipeline. `CreateOrUpdateResourceHandler.cs:70` says "Validation now handled by ValidationBehavior in the pipeline" and performs no validation itself. Net effect: **PUT/POST resources are persisted without any schema validation** regardless of tenant `ValidationDepth` or `Prefer` header. No test in the repo references `ValidationBehavior`.
+**Recommendation**: Change the behavior to `IPipelineBehavior<CreateOrUpdateResourceCommand, UpdateResult>` (and the `RequestHandlerDelegate<T>`), fix the registration, and add an E2E test that an invalid resource returns 400. Consider a Roslyn/RepoGuard check that behavior registrations match a registered handler signature.
+**Effort**: S
+
+### P0 — If-Match / optimistic concurrency is parsed but never enforced
+**Location**: `src/Application/Ignixa.Application/Features/Resource/CreateOrUpdateResourceHandler.cs:63-204`, `Features/Patch/PatchResourceHandler.cs:44-181`, `Features/ConditionalOperations/ConditionalUpdate/ConditionalUpdateHandler.cs:276`, `Features/ConditionalOperations/ConditionalPatch/ConditionalPatchHandler.cs:125`
+**Issue**: `CreateOrUpdateResourceCommand.IfMatch` and `PatchResourceCommand.IfMatch` are documented ("update only succeeds if resource version matches") and populated by the API layer (`FhirEndpoints.cs:477-504`) and by the conditional handlers ("prevents lost updates" comments) — but **no handler reads the property**. It is never compared against the stored version and never passed to the repository (`ResourceRequest` has an `IfMatch` slot that is also never filled). PUT with a stale `If-Match` succeeds; conditional update/patch have a TOCTOU lost-update window they explicitly claim to close; ADR-2510-patch's documented 412 path cannot occur. Aside: the API layer parses the If-Match header with `ConditionalHeaderParser.ParseIfNoneMatch` (`FhirEndpoints.cs:482`) — flagged to the API review.
+**Recommendation**: Enforce in one place: fetch-or-pass-through the expected version to the repository write and translate mismatch into 412 (`ResourceVersionConflictException` already exists). Delete the parameter from the commands if the decision is to not support it — silent acceptance is the worst option.
+**Effort**: M
+
+### P0 — Intra-bundle urn:uuid reference rewriting is not implemented
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/ReferenceResolutionContext.cs:56` (`ResolveReference` — zero callers), `BundleReferencePreProcessor.cs:33-72`, `BundleEntryExecutor.cs:60-197`
+**Issue**: The preprocessor assigns IDs for `urn:uuid` fullUrls and builds the map, and the target POST gets its pre-assigned ID via `BundleAssignedResourceId`. But nothing ever rewrites `urn:uuid:` references *inside resource bodies*: `BundleEntryExecutor` receives `referenceContext` and only null-checks it; the request body is the original `RawJson`. A transaction of `POST Patient (urn:uuid:A)` + `POST Observation {subject: urn:uuid:A}` persists the Observation with the literal `urn:uuid:A` string — a permanently broken reference, violating the FHIR transaction spec. ADR-2509-bundle-processing lists "Reference resolution for urn:uuid" as a delivered positive; it is not. No E2E test covers intra-bundle references.
+**Recommendation**: After Phase-2 preprocessing, rewrite references in each entry's parsed resource (FHIRPath-driven or JSON scan for `"reference"` values) and regenerate `RawJson`, or resolve at serialization into the mini-request body. Add an E2E transaction test asserting the stored Observation references `Patient/{assignedId}`.
+**Effort**: L
+
+### P0 — Transaction bundles are not atomic; Phase-2 response plumbing is broken
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/BundleProcessor.cs:60-266`, `BundleChannelExecutor.cs:412-431`
+**Issue**: Three compounding defects in `ProcessAsync`:
+1. **Split commit**: a transaction whose entries are split across Phase 1 (plain) and Phase 2 (urn:uuid/conditional) gets **two coordinators with two transaction IDs and two commits** (lines 84-161 vs 191-229). Phase 1 is committed before Phase 2 runs; if Phase 2 fails, Phase 1 stays committed (`BundleProcessor.cs:359` even logs "Transaction rollback not implemented"). This is partial execution of a FHIR transaction. The application-level transaction model (CLAUDE.md) does not excuse this — the Application layer chooses to commit early.
+2. **Phase-2 ordered-yield deadlock/drop**: `ExecuteTransactionStreamingAsync`/`ExecuteBatchStreamingAsync` yield responses in consecutive index order starting at `nextIndex = 0` (`BundleChannelExecutor.cs:413-428`). Phase-2 buffered entries have original indices starting at k>0 (Phase 1 consumed 0..k-1), so **no response is ever yielded** — everything accumulates in `completedResponses` and is discarded when the channel completes; the positional mapping `responses[bufferedEntries[i].Index] = phase2ResponseList[i]` (`BundleProcessor.cs:219-222`) then throws IndexOutOfRange. Additionally, `bufferedEntries` is reordered by verb (line 186) while the executor yields in index order, so even with the offset fixed, positional mapping misassigns responses to entries.
+3. **Batch-write errors dropped before commit**: `StartBatchProcessor` collects errors from `ProcessBatchAsync` into `allErrors` and never surfaces them (`BundleProcessor.cs:494-500`); `CommitAsync` is then called unconditionally (line 160), committing the successful subset of a transaction whose other entries failed.
+**Recommendation**: For transactions, drop the two-phase split: buffer the whole transaction (transactions must be atomic anyway), use one coordinator/transaction ID, refuse to commit if any entry failed, and map responses by `entry.Index` (dictionary), never by position. Keep two-phase only for batch.
+**Effort**: L
+
+### P0 — Streaming batch path rejects legal batch entries containing query strings
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/BundleChannelExecutor.cs:437-462`, `BundleProcessor.cs:586-659`, routed from `Ignixa.Api/Endpoints/FhirEndpoints.cs:1143-1153`
+**Issue**: All batch bundles route to `ProcessBatchStreamingAsync`, which runs `ValidateStreamingEntry` on every entry and **throws for any `request.url` containing `?`**. `GET Patient?name=Smith`, `PUT Patient?identifier=...`, `DELETE Patient?identifier=...` are all legal, common batch entries; any one of them aborts the entire batch (the producer faults, and the serializer appends a single 500 error entry, dropping legitimate per-entry results). The endpoint comment "Batch bundle with no urn:uuid references" is aspirational — nothing routes batches with such entries to the buffered path.
+**Recommendation**: In the batch streaming producer, treat entries that fail streaming validation as individually-buffered work items (or fall back to `ProcessAsync` for the whole batch), never as fatal. FHIR batch semantics require per-entry independence.
+**Effort**: M
+
+### P0 — PATCH: legal patches on `identifier` rejected by substring immutability check
+**Location**: `src/Application/Ignixa.Application/Features/Patch/Validation/ImmutablePathChecker.cs:17-45`
+**Issue**: Immutability is checked with `upperPath.Contains(".ID")`. `"PATIENT.IDENTIFIER"` contains `".ID"`, so `delete Patient.identifier[0]` / `replace Patient.identifier...` — among the most common PATCH operations in the wild — throw "Cannot delete immutable property". Any path segment starting with "id" (`identifier`, element `.id` at nested levels which are legitimately mutable) is blocked.
+**Recommendation**: Tokenize the path and compare segments exactly: root-level `id`, `meta.versionId`, `meta.lastUpdated`. The post-patch `ImmutablePropertyValidator` already backstops the real invariants, so the pre-check can be strict-exact.
+**Effort**: S
+
+### P0 — PATCH persists without search indices and stamps every resource as FHIR 4.0
+**Location**: `src/Application/Ignixa.Application/Features/Patch/PatchResourceHandler.cs:136-171`
+**Issue**: The updated `ResourceWrapper` is built without `SearchIndices` (contrast `CreateOrUpdateResourceHandler.CreateResourceWrapper`, which treats index extraction as mandatory and fails the request if it errors). The data layer does not re-extract (`FileBasedFhirRepository.cs:163` stores `resource.SearchIndices?...` verbatim; SQL row generators consume the provided list). A patched resource's current version therefore has **no search index rows** — it disappears from or goes stale in search. Additionally `FhirVersion = "4.0", // Default to R4` is hard-coded on both wrappers (lines 147, 170) in a server that supports R4/R4B/R5/R6, silently rewriting the stored version of R5/R6 resources. The handler also bypasses `IPartitionStrategy` (uses `request.TenantId` raw) unlike every other write handler.
+**Recommendation**: Extract search indices exactly as the create/update handler does (share the helper — see Architectural Observations), take FHIR version from `IFhirRequestContextAccessor`, and route partitioning through `IPartitionStrategy`.
+**Effort**: M
+
+### P0 — Streaming bundle parser fails on any JSON string token larger than ~8KB, and leaks PHI in the error
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleParser.cs:21, 253-291, 608-687`
+**Issue**: `SharedStreamBuffer` uses a fixed 8KB buffer that can never grow. A single JSON token larger than the buffer (base64 `Binary.data`, `DocumentReference` attachments, large narratives — routine in FHIR) means `Utf8JsonReader` can never complete the token, `HasSpaceForMoreData()` goes false, and after 3 no-progress iterations the parser throws "Parser stuck in infinite loop" — **the whole bundle fails**. The exception message embeds the raw unconsumed buffer (`Content: '{remainingStr}'`, line 271-274) — patient data straight into exception messages and logs.
+**Recommendation**: Grow the buffer (double up to a cap) when a token spans it — the standard `Utf8JsonReader` streaming pattern — and remove payload content from the exception text. Also: the rented `ArrayPool` buffer is never returned (`Dispose()` exists but is never called by `ParseStreamAsync`).
+**Effort**: M
+
+### P0 — Streamed batch bundles: transaction is never committed
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/StreamingBundleContext.cs:43-55`, `BundleProcessor.cs:586-659`
+**Issue**: `ProcessBatchStreamingAsync` allocates a transaction ID via `DeferredWriteCoordinator.CreateAsync` and batch-writes under it, but `StreamingBundleContext.CompleteAsync` (the only cleanup the API layer calls, `FhirEndpoints.cs:1179`) only calls `CompleteWrites()` and awaits the batch processor — **`CommitAsync` is never invoked** on this path. Every non-streaming path commits (lock-file → committed rename / `dbo.Transactions` visibility per CLAUDE.md). Depending on the backend's treatment of uncommitted transactions, resources written via the streaming batch path are invisible or reaped as orphans.
+**Recommendation**: Call `coordinator.CommitAsync` inside `CompleteAsync` (it holds the coordinator already). Add an E2E test that a resource POSTed via a batch bundle is readable after server restart / against the SQL backend.
+**Effort**: S
+
+### P1 — Bundle response bodies carry wrong version metadata on the deferred path
+**Location**: `src/Application/Ignixa.Application/Features/Resource/CreateOrUpdateResourceHandler.cs:119-131, 259-260`
+**Issue**: On the coordinator path, `UpdateResult.ResourceBytes` is serialized from the pre-write `JsonNode`, whose `meta.versionId` was force-set to `"1"` and `meta.lastUpdated` to queue-time `UtcNow` (line 259-260). For an update that actually produced version 5, the bundle entry response body says `versionId: "1"` with a fabricated timestamp. The `ResourceKey` from the coordinator has the real version; the body does not.
+**Recommendation**: Patch the JSON's meta from the returned `ResourceKey`/write result before serializing, or return only key+location on the deferred path (Prefer: return=minimal semantics).
+**Effort**: S
+
+### P1 — Debug leftovers logged at Warning per bundle entry
+**Location**: `src/Application/Ignixa.Application/Features/Resource/CreateOrUpdateResourceHandler.cs:112-116` ("HANDLER: Retrieved entry index..."), `Features/Bundle/DeferredWriteCoordinator.cs:151-155` ("QUEUE: Entry ...")
+**Issue**: Two `LogWarning` calls with ALL-CAPS debug prefixes fire for every write in every bundle — pure development scaffolding polluting production logs and alerting.
+**Recommendation**: Delete or demote to `LogTrace`.
+**Effort**: S
+
+### P1 — Exception classification by message substring
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/BundleEntryExecutor.cs:261-265`
+**Issue**: `ex.Message.Contains("conflict")` / `"recently updated"` / `"constraint violation"` decides between 409 and 500. Any unrelated exception whose message contains "conflict" becomes a 409; a reworded exception message silently changes HTTP semantics.
+**Recommendation**: Match on exception types (`ResourceVersionConflictException` is already handled above — extend the typed catch set) and let everything else be 500.
+**Effort**: S
+
+### P1 — RecyclableMemoryStream instances never disposed in bundle entry execution
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/BundleEntryExecutor.cs:124, 345-355`
+**Issue**: `responseBodyStream` and the request-body stream from `SerializeResourceToStream` are rented from `RecyclableMemoryStreamManager` and never disposed, defeating the pooling the manager exists for (and its debug-mode leak detection will scream).
+**Recommendation**: `await using` both streams for the lifetime of the entry execution.
+**Effort**: S
+
+### P1 — Hand-rolled JSON re-assembly in the parser produces invalid JSON for edge inputs
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleParser.cs:363-367, 563-602`
+**Issue**: Entry resources are rebuilt token-by-token into a `StringBuilder`. `EscapeJsonString` handles only `\ " \n \r \t` — control characters U+0000–U+001F (legal in JSON strings via `\uXXXX`, e.g. `\b`, `\f`) are re-emitted raw, producing invalid `RawJson` that is then parsed/persisted. Property names are re-quoted **without any escaping** (line 365), so a crafted property name containing `"` breaks or injects into the reconstructed JSON. This is attacker-reachable input on the bundle endpoint.
+**Recommendation**: Replace the whole string-rebuild with `JsonDocument.ParseValue(ref reader)` + `WriteRawValue` per entry resource (correct by construction), or at minimum escape via `JsonEncodedText`. This also deletes ~200 lines of comma/flag state machinery in `BundleParserState`.
+**Effort**: M
+
+### P1 — `_elements` filtering: nested paths silently drop elements; decimals lose precision; numbers can vanish
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/Serialization/ResourceElementsSerializer.cs:34-59, 183-201, 254-263`
+**Issue**: (1) The doc claims "dot notation supported for nested", but filtering is root-level only: `_elements=name.family` puts `"name.family"` in the allowlist, the root property `name` doesn't match, and the entire `name` element is dropped — silently wrong results for a documented feature. (2) Numbers are round-tripped via `TryGetInt64`/`TryGetDouble`: FHIR decimals lose precision/trailing zeros (`1.50` → `1.5`), which the FHIR spec explicitly forbids. (3) In the array branch (line 254-263) there is no fallback: a number fitting neither long nor double is **silently omitted** from output. (4) No `SUBSETTED` meta tag is added (spec SHOULD). Also, `SkipValue`/`SkipObject`/`SkipArray` reimplement `Utf8JsonReader.Skip()`.
+**Recommendation**: Copy numbers via `reader.ValueSpan` raw always; either implement nested paths (include root when a dotted path is requested) or reject dotted `_elements` with 400; add `SUBSETTED`; use `reader.Skip()`.
+**Effort**: M
+
+### P1 — Serializer flush threshold is 50 MB; empty `entry` arrays violate FHIR JSON rules
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleSerializer.cs:97, 169, 219, 304, 399`
+**Issue**: (1) `FlushThresholdBytes = 50 * 1024 * 1024` — the "streaming" search serializer buffers up to 50 MB in the `Utf8JsonWriter` before first flush; most responses are fully buffered, killing TTFB and memory-bounding claims (comment says "prevents unbounded memory growth" — 50 MB per concurrent request is the growth). Meanwhile `SerializeAsync`/`SerializeHistoryAsync` flush per entry (a syscall each). (2) Every method writes `WriteStartArray("entry")` unconditionally: a zero-match search emits `"entry": []`, which the FHIR JSON representation forbids (arrays must not be empty) — validators flag every empty search result.
+**Recommendation**: Threshold ~64 KB; defer `entry` array start until the first entry.
+**Effort**: S
+
+### P1 — Transaction silently downgraded to batch when `type` follows `entry` in the JSON
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/Serialization/StreamingBundleParser.cs:80-131`, `Ignixa.Api/Endpoints/FhirEndpoints.cs:1096-1103`
+**Issue**: Header parsing stops at the `entry` array. JSON property order is not guaranteed; if a client emits `entry` before `type` (legal), `BundleType` is null and the endpoint defaults to **Batch** — a transaction executes with batch semantics (no atomicity, no verb ordering) with no error to the client.
+**Recommendation**: If `type` was not seen before `entry`, reject with 400 (cheap) or buffer until `type` is found. Silently guessing transaction-vs-batch is not acceptable.
+**Effort**: S
+
+### P1 — Conditional create in bundles ignores the pre-assigned resource ID
+**Location**: `src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs:215`, vs `Features/Bundle/BundleEntryExecutor.cs:100`
+**Issue**: `BundleEntryExecutor` sets the typed property `entryContext.BundleAssignedResourceId`; `ConditionalCreateHandler` looks for `context.Properties["BundleAssignedResourceId"]` (dictionary), which is never populated. A bundle conditional-create with a `urn:uuid` fullUrl gets a fresh GUID instead of the pre-assigned one, so the reference map entry points at an ID that doesn't exist. (Standalone `FhirEndpoints.cs:916` reads the typed property correctly.)
+**Recommendation**: Read `context.BundleAssignedResourceId` (the typed property). Delete the Properties-dictionary convention.
+**Effort**: S
+
+### P1 — Conditional create/update race: search-then-write with no uniqueness guard
+**Location**: `src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs:99-134, 150-171`, `ConditionalUpdate/ConditionalUpdateHandler.cs:84-119`
+**Issue**: Match counting and the subsequent write are not atomic. Two concurrent `If-None-Exist` creates both observe 0 matches and both create — duplicates, the exact thing conditional create exists to prevent. The "deleted between search and get → create new" branch (line 150-171) widens the window. Since If-Match is also unenforced (see P0), conditional update has the same lost-update exposure.
+**Recommendation**: At minimum document the level of guarantee in the CapabilityStatement; properly, push the match-check into the repository write (compare-and-swap style) or serialize conditional ops per (tenant, type, criteria-hash).
+**Effort**: L
+
+### P1 — `_total=accurate` for history enumerates the entire history stream
+**Location**: `src/Application/Ignixa.Application/Features/History/HistoryCountHelper.cs:23-96`
+**Issue**: Counting is done by `await foreach` over the full result set with `Count = int.MaxValue` — for system-level history that is every version of every resource in the tenant, per request. This is a COUNT query done in application memory.
+**Recommendation**: Add `Count*HistoryAsync` methods to `IFhirRepository` and push the count to the store. Also: all three methods name the token `ct`, violating the repo's explicit `cancellationToken` rule.
+**Effort**: M
+
+### P1 — $includes pagination re-executes the search and skip-scans per page
+**Location**: `src/Application/Ignixa.Application/Features/Resource/IncludesResourceHandler.cs:62-112`
+**Issue**: Each `$includes` page re-runs the original search with `MaxItemCount = min(pageSize*10, 10000)` and client-side skips `offset` include entries (`FilterIncludesWithPaginationAsync`). Page N costs O(N·pageSize) repository work — O(n²) across a full pagination walk — and any includes beyond the 10k fetch cap are silently unreachable. The decoded token's pageSize is discarded (`out _`, line 67) even though `Encode` stores it.
+**Recommendation**: Push include-offset pagination into the execution strategy, or persist the match-set keys in the continuation token instead of re-searching.
+**Effort**: M
+
+### P1 — SearchCompartmentHandler mutates the request and skips the pagination contract
+**Location**: `src/Application/Ignixa.Application/Features/Compartment/SearchCompartmentHandler.cs:83-146`
+**Issue**: (1) The handler mutates `request.SearchOptions.Expression` and `.ResourceType` in place — command records are supposed to be immutable, and a pipeline retry would AND the compartment expression twice. (2) It does not apply the pageSize+1 count-as-render pattern used by `SearchResourcesHandler`, so `hasMore`/next-link detection is inconsistent for compartment searches; `Total` and `ContinuationToken` are `TODO` (lines 131-144) in a production path. (3) `SearchCompartmentQuery.GetCapabilityRequirementExpression()` with `ResourceType == "*"` emits `type = '*'`, which no CapabilityStatement advertises — wildcard compartment search (`GET /Patient/123/*`) likely fails capability enforcement (mirror the `null → "true"` handling of `SearchResourcesQuery`).
+**Recommendation**: Build a new `SearchOptions` (see the clone problem below), reuse the +1 pattern, fix the wildcard capability expression.
+**Effort**: M
+
+### P1 — SearchOptions hand-copying: three divergent copies of a fragile clone
+**Location**: `src/Application/Ignixa.Application/Features/Resource/SearchResourcesHandler.cs:94-107`, `Features/Resource/IncludesResourceHandler.cs:73-86`, (contrast: `SearchCompartmentHandler` mutates instead)
+**Issue**: Because `SearchOptions` is a mutable class, handlers clone it by hand-listing every property. The two existing copies already diverge (Includes handler zeroes `Total` and `ContinuationToken`), and neither copies `Elements`, `IncludesMaxItemCount`, `IncludesContinuationToken`, or `BundleIssues` — properties the serializer reads. Any new `SearchOptions` property is silently dropped at these seams.
+**Recommendation**: Give `SearchOptions` a `Clone()`/`With(maxItemCount:)` method (or make it a record with `with`), and use it in all three handlers.
+**Effort**: S
+
+### P1 — Sync-over-async and poll-waiting in search parameter initialization
+**Location**: `src/Application/Ignixa.Application/Features/Search/FhirVersionContext.cs:338`, `Features/Search/CompositeSearchParameterDefinitionManager.cs:116-135`
+**Issue**: `Task.Run(async () => ...).GetAwaiter().GetResult()` inside a `ConcurrentDictionary.GetOrAdd` factory blocks a request thread; the awaited `InitializeAsync` itself poll-waits for `ConformanceState.IsInitialized` in a 100ms × 50 `Task.Delay` loop — so first-touch of a tenant's search parameters can block a thread for 5 seconds. `GetOrAdd` also offers no single-execution guarantee, so multiple threads can run this concurrently (and `GetSchemaProvider`'s factory registers with the provider registry — a side effect that can fire twice).
+**Recommendation**: Expose an `Initialization` Task on `ConformanceState` to await; make the manager acquisition path async (or use `Lazy<Task<T>>` per key).
+**Effort**: M
+
+### P1 — Dead code: two unused 90-line processing paths, duplicated batch processor, dead PaginationResult
+**Location**: `src/Application/Ignixa.Application/Features/Bundle/BundleProcessor.cs:282-458` (`ProcessBufferedAsync`, `ProcessStreamingAsync` — private, zero callers), `BundleProcessor.cs:610-642` (verbatim copy of `StartBatchProcessor`), `Serialization/StreamingBundleSerializer.cs:920` (`PaginationResult` — zero usages)
+**Issue**: ~220 lines of dead or copy-pasted orchestration logic that near-duplicates the live path. Anyone reading or modifying bundle processing must reverse-engineer which of four paths actually executes (answer: `ProcessAsync` for transactions, `ProcessBatchStreamingAsync` for batches).
+**Recommendation**: Delete the two private methods and `PaginationResult`; have `ProcessBatchStreamingAsync` call `StartBatchProcessor`.
+**Effort**: S
+
+### P1 — X-Provenance handling duplicates the write path with weaker guarantees
+**Location**: `src/Application/Ignixa.Application/Features/Resource/CreateOrUpdateResourceHandler.cs:295-427`
+**Issue**: `ProcessProvenanceAsync` re-implements wrapper construction + index extraction (a near-copy of `CreateResourceWrapper`) and its own validation (`ValidateProvenance`) instead of dispatching a `CreateOrUpdateResourceCommand`. If no Provenance schema is found it logs a warning and **skips validation entirely** (line 401-405). The Provenance write is also a second, non-atomic write: main resource committed, Provenance write fails → 500 returned for a request whose primary effect succeeded.
+**Recommendation**: Dispatch through the mediator (gets pipeline validation for free once the P0 is fixed), or extract a shared wrapper-builder; decide and document the failure semantics for the Provenance side-write.
+**Effort**: M
+
+### P1 — FHIR Patch wire format deviates from the spec for add/move
+**Location**: `src/Application/Ignixa.Application/Features/Patch/FhirPatchParametersParser.cs:91-108`, `Executors/MoveOperationExecutor.cs:23-68`
+**Issue**: Spec-conformant FHIRPath Patch `add` uses `path` (parent) + `name` + `value`; this parser has no `name` part at all — conformant clients (HAPI, firely) sending `name` will have it ignored and the operation misapplied or rejected. Spec `move` is `path` + `source` (integer index) + `destination` (integer index) within one collection; this implementation treats source/destination as string FHIRPaths and implements move as delete+append — destination *position* is not honored, so reordering (the entire point of move) doesn't work.
+**Recommendation**: Implement the spec shapes (`name` for add; integer indices for move) — this is a conformance-suite-visible deviation. Also note the same required-part validation is written three times (parser, `FhirPatchValidator`, each executor); keep one.
+**Effort**: M
+
+### P2 — ONE TYPE PER FILE violations
+**Location**: `Features/Bundle/BundleProcessingOptions.cs` (record + `BundleType` enum), `Features/Patch/FhirPatchOperation.cs` (record + enum), `Features/Patch/FhirPatchParametersParser.cs` (+`FhirPatchException`), `Features/Resource/IncludesResourceHandler.cs` (+`IncludesContinuationToken`), `Features/Bundle/Serialization/StreamingBundleSerializer.cs` (+`PaginationResult`)
+**Issue**: Explicit repo rule violated in five files. Additionally two distinct classes are both named `StreamingBundleContext` (`Features/Bundle/` vs `Features/Bundle/Serialization/`) — one is the parse-side context, the other the response-side; same name, different meaning, regular source of confusion.
+**Recommendation**: Split files; rename one context (e.g. `ParsedBundleStream` / `StreamingBundleResponseContext`).
+**Effort**: S
+
+### P2 — CancellationToken naming and constructor-parameter style violations
+**Location**: `Features/History/HistoryCountHelper.cs:27,54,80` (`ct`), `Features/Bundle/Serialization/StreamingBundleParser.cs:40,217,637` (`ct`), `Features/History/GetResourceHistoryHandler.cs:25` (constructor parameter named `_logger`)
+**Issue**: CLAUDE.md marks `ct` as a critical violation; `ILogger<...> _logger` as a parameter name with `this._logger = _logger` is plainly generated-and-unreviewed.
+**Recommendation**: Rename.
+**Effort**: S
+
+### P2 — Nonsense boolean in ValidationBehavior
+**Location**: `src/Application/Ignixa.Application/Infrastructure/Behaviors/ValidationBehavior.cs:79`
+**Issue**: `if (depth != Minimal || depth == Spec || depth == Full)` — the ORs are unreachable; it reduces to `depth != Minimal`. Harmless but a marker that the file was never reviewed (consistent with it never executing).
+**Recommendation**: `if (validationDepth != ValidationDepth.Minimal)`.
+**Effort**: S
+
+### P2 — Per-get dictionary allocation in package features
+**Location**: `Features/Resource/IncludesOperationFeature.cs:24-28`, `Features/Export/BulkDataExportFeature.cs:24-29`
+**Issue**: `ResourceOperations` allocates a fresh `Dictionary` on every property read.
+**Recommendation**: `static readonly FrozenDictionary`.
+**Effort**: S
+
+### P2 — Swallowed exceptions and poll patterns in Search infrastructure
+**Location**: `Features/Search/CompositeSearchParameterDefinitionManager.cs:311-323` (`catch { return false; }` over `TryGetSearchParameters`), `CompositeSearchParameterDefinitionManager.cs:149-154` (dead local `baseByResourceTypeAndCode` — built with a custom comparer and never used)
+**Issue**: The bare catch violates the no-silent-failures rule (a schema-provider bug would surface as "resource type has no search parameters"); the dead lookup is leftover from a removed merge strategy.
+**Recommendation**: Catch nothing (Try-pattern should only convert *not-found*, not all failures); delete the dead local and `ResourceTypeCodeComparer` if then unused.
+**Effort**: S
+
+### P2 — Style drift markers across the subsystem
+**Location**: throughout
+**Issue**: Three copyright-header styles (banner, XML `<copyright>`, none — Patch and ConditionalDelete/Read files have none); explicit `using System;` blocks only in Patch/ConditionalRead files; `Nullable<int>` instead of `int?` (`FhirVersionContext.cs:80,178,279`); primary constructors used in exactly two handlers (`IncludesResourceHandler`, patch executors) while a dozen others use full ctor + `ArgumentNullException` boilerplate; comment density far beyond the "no inline comments" rule (most handlers narrate every step). Each inconsistency maps to a different generation of agent authorship.
+**Recommendation**: One `.editorconfig`-enforced header, primary constructors as the standard, a comment-stripping pass when files are next touched. Not worth a dedicated PR per file.
+**Effort**: M (amortized)
+
+### P1 — Bundle entries bypass the HTTP middleware pipeline, including authorization, and run with an anonymous principal (verified)
+**Location**: `src/Application/Ignixa.Api/Infrastructure/AspNetCorePipelineExecutor.cs:47-114`, `Features/Bundle/BundleEntryExecutor.cs:123-134`
+**Issue**: Verified mechanism: `AspNetCorePipelineExecutor.ExecuteAsync` does route matching itself and then invokes the matched endpoint's `RequestDelegate` directly (line 108). It never runs the middleware pipeline — so `AuthorizationMiddleware` (which is what enforces `RequireAuthorization`/endpoint authorization metadata for Minimal APIs) does not execute for bundle entries. Compounding this, `BundleEntryExecutor` builds a bare `DefaultHttpContext` and never copies `parentHttpContext.User`, so `context.User` is an anonymous principal inside every entry. Net: any per-endpoint authorization enforced via endpoint metadata + middleware is silently skipped for operations executed through a bundle; only Medino pipeline behaviors (capability enforcement, and whatever the Authorization slice registers as behaviors) apply. Whether an Application-layer authorization behavior fully covers the gap is owned by the Authorization slice review — but at minimum `httpContext.User = parentHttpContext.User` must be copied, and the security model for bundle-entry execution needs to be stated explicitly rather than emergent.
+**Recommendation**: Copy `User` (and relevant auth-result features) onto the mini context; document that middleware does not run for bundle entries and enumerate which protections must therefore live in Medino behaviors; add a test that a bundle entry against a protected endpoint is rejected for an unauthorized caller.
+**Effort**: M
+
+### P2 — Created-vs-updated is inferred by string-comparing versionId at the API boundary
+**Location**: `src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs:516`, `src/Application/Ignixa.Domain` (`UpdateResult`)
+**Issue**: The API decides 201-vs-200 via `result.Key.VersionId == "1"`. Functionally correct today (creates are always v1), but it's a stringly-typed contract: the repository knows whether it created or updated and should say so. `ConditionalCreateResult.WasCreated` already sets the precedent. Any future versioning change (imports, version-preserving restores) silently breaks HTTP semantics. (Raised by the API/HTTP review; the fix belongs on the Application/Domain result type.)
+**Recommendation**: Add `WasCreated` (or an enum) to `UpdateResult`, populated by the repository write; drop the versionId comparison.
+**Effort**: S
+
+### P2 — Misc correctness nits
+- `DeferredWriteCoordinator.cs:339` uses `TrySetException` but line 355 uses `SetException` — the latter throws if the TCS was already completed (possible when a batch is split across partition groups after a prior failure). Use `TrySetException` consistently. Also `QueueWriteAsync`'s `await tcs.Task` ignores the cancellation token — a cancelled request hangs until the batch processor completes the TCS.
+- `BundleParserState.CompleteEntry` calls `_resourceJsonBuilder.ToString()` twice (lines 163, 184) — two full string materializations per entry; it also eagerly `ResourceJsonNode.Parse`s every entry resource even though `BundleEntryExecutor` only uses `RawJson`.
+- `BundleParserState.ExtractIdFromUrl` returns null for `Patient/123/_history/2` style URLs (versioned bundle requests lose their ID).
+- `ConditionalDeleteHandler.cs:138-143` deletes matches one-by-one through the mediator (N partition resolutions + N repository round trips) and ignores the per-delete `bool` result — a concurrent delete is still counted in `DeletedIds`.
+- `ConditionalReadHandler.cs:41-50` doesn't handle `If-None-Match: *` and compares raw versionId (correct only if API layer strips `W/"..."` — it does today, but the contract is implicit).
+- `GetResourceHandler`/`SearchResourcesHandler` pass empty `queryParams` to `DetermineReadPartition` with a `// TODO: Extract from SearchOptions` (`SearchResourcesHandler.cs:64`) — if partition selection ever depends on query params, this is a silent wrong-partition bug lying in wait.
+- `FhirJsonWriter.WriteString` throws on empty values, and `WriteBundleLinks` passes `link.Url ?? string.Empty` (`StreamingBundleSerializer.cs:545`) — a link with an empty URL crashes serialization mid-stream.
+- `SerializeWithPaginationAsync` sets the next-link continuation parameter as `after` (`StreamingBundleSerializer.cs:234`) — verify this matches the parameter the search endpoint actually parses; the token itself is offset-based, so pages skew under concurrent writes.
+
+## Architectural Observations
+
+1. **The write path has no shared spine.** `CreateOrUpdateResourceHandler`, `PatchResourceHandler`, `ProcessProvenanceAsync`, and the two conditional handlers each assemble `ResourceWrapper`s with their own rules for meta, FHIR version, search indices, and partitioning — and each gets a different subset right. PATCH loses indices and version; Provenance skips pipeline validation; conditional handlers convert `UpdateResult → SearchEntryResult → ResourceWrapper` through two copy-paste `ConvertSearchEntryToWrapper` helpers (`ConditionalCreateHandler.cs:263`, `ConditionalUpdateHandler.cs:302`). A single `ResourceWrapperFactory` (version from context, mandatory index extraction, partition via strategy) would eliminate the whole defect class. This is consistent with vertical-slice architecture — slices may share infrastructure.
+
+2. **Concurrency control is documentation-only.** `IfMatch` flows API → command → nowhere, in three separate features, each with comments asserting it works. This is the signature early-agent failure mode: the seam was built on both sides but the middle was never wired, and no test exercises it.
+
+3. **Bundle processing has four orchestration paths, two alive.** The live transaction path violates its own ADR (atomicity, reference resolution both advertised, both absent), and the live batch path can't process legal batch entries with query strings. The channel/verb-group machinery in `BundleChannelExecutor` (channel-recreation per verb group, consumer restarts) is sophisticated code solving the wrong problem first — correctness of the simple cases (references, atomicity, response mapping) was never established. Recommend: make transactions boring (fully buffered, one coordinator, one commit, dictionary-indexed responses) and keep streaming cleverness for batches only.
+
+4. **The Serialization subfolder is a hand-rolled JSON stack** (parser state machine, string re-assembly, custom escaper, custom Skip). Roughly 2,600 lines where `JsonDocument.ParseValue`/`WriteRawValue`/`reader.Skip()` would cover most of it. The bugs found (8KB token limit, control-char escaping, decimal precision, dropped numbers) are all consequences of reimplementing primitives the BCL provides. This directly contradicts the CLAUDE.md preference for robust, declarative data access.
+
+5. **Layering per ADR-2509 is mostly respected** — no `Hl7.Fhir.*` packages in Application (verified in `Ignixa.Application.csproj`), Minimal API only, dependency direction clean. Two soft violations: `HistoryQueryParametersParser` and `BundleEntryExecutor` take direct dependencies on `Microsoft.AspNetCore.Http` types inside Application (the latter is intrinsic to the pipeline-routing design; the former is avoidable). The FHIRPath-over-JSON-navigation rule is moot in most of this subsystem because the read path is deliberately zero-copy bytes, but the Patch mutators appropriately use the FHIRPath mutator.
+
+6. **Tenancy plumbing is inconsistent across verbs**: Get/Search/Delete/CreateOrUpdate resolve partitions via `IPartitionStrategy`; Patch and all three History handlers use raw `TenantId`; `DeleteResourceHandler` builds its `ResourceKey` with `context.TenantId` while writing to the strategy-resolved partition (`DeleteResourceHandler.cs:80-91`) — fine while they're equal in Isolated mode, wrong the day they aren't.
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Fix ValidationBehavior generic response type + registration; add validation E2E test | S | ValidationBehavior.cs, ApplicationServicesRegistration.cs |
+| P0 | Enforce If-Match end-to-end (412 on mismatch) or remove the parameter | M | CreateOrUpdateResourceHandler, PatchResourceHandler, repository interface |
+| P0 | Implement urn:uuid body-reference rewriting for transactions | L | BundleReferencePreProcessor, BundleEntryExecutor, BundleEntryContext |
+| P0 | Single-coordinator atomic transactions; fix Phase-2 index/response mapping; fail commit on batch-write errors | L | BundleProcessor, BundleChannelExecutor |
+| P0 | Batch streaming: buffer (not reject) entries with query strings | M | BundleProcessor, BundleChannelExecutor |
+| P0 | Exact-segment immutable path check (unblock `identifier` patches) | S | ImmutablePathChecker.cs |
+| P0 | PATCH: extract search indices, use context FHIR version, partition strategy | M | PatchResourceHandler.cs |
+| P0 | Growable parse buffer; strip PHI from parser exceptions; return pooled buffer | M | StreamingBundleParser.cs |
+| P0 | Commit transaction on streamed-batch completion | S | StreamingBundleContext.cs |
+| P1 | Correct meta in deferred-path response bodies | S | CreateOrUpdateResourceHandler.cs |
+| P1 | Remove HANDLER:/QUEUE: warning-level debug logs | S | CreateOrUpdateResourceHandler, DeferredWriteCoordinator |
+| P1 | Type-based (not message-substring) exception→status mapping | S | BundleEntryExecutor.cs |
+| P1 | Dispose RecyclableMemoryStreams per bundle entry | S | BundleEntryExecutor.cs |
+| P1 | Replace string-rebuild with JsonDocument.ParseValue raw copy | M | StreamingBundleParser, BundleParserState |
+| P1 | Fix `_elements` nested paths, decimal precision, SUBSETTED tag | M | ResourceElementsSerializer.cs |
+| P1 | 64KB flush threshold; omit empty `entry` arrays | S | StreamingBundleSerializer.cs |
+| P1 | 400 (or buffer) when bundle `type` not seen before `entry` | S | StreamingBundleParser, FhirEndpoints |
+| P1 | Read typed BundleAssignedResourceId in ConditionalCreate | S | ConditionalCreateHandler.cs |
+| P1 | Repository-level COUNT for history `_total=accurate` | M | HistoryCountHelper, IFhirRepository |
+| P1 | Store-side $includes pagination (kill re-search + skip-scan) | M | IncludesResourceHandler, execution strategy |
+| P1 | Compartment: stop mutating request, add +1 pagination, fix `*` capability expr | M | SearchCompartmentHandler, SearchCompartmentQuery |
+| P1 | SearchOptions.Clone(); use at all three copy sites | S | SearchOptions, 3 handlers |
+| P1 | Async init for search-param managers (no GetResult, no poll loop) | M | FhirVersionContext, CompositeSearchParameterDefinitionManager |
+| P1 | Delete dead bundle paths + PaginationResult; dedupe StartBatchProcessor | S | BundleProcessor, StreamingBundleSerializer |
+| P1 | Shared ResourceWrapperFactory for all writers (incl. Provenance) | M | Resource/Patch/ConditionalOperations handlers |
+| P1 | Spec-conformant Patch add (`name`) and move (integer indices) | M | FhirPatchParametersParser, Move/Add executors |
+| P1 | Copy `User` to bundle-entry contexts; define bundle-entry security model (middleware bypassed) | M | BundleEntryExecutor, AspNetCorePipelineExecutor |
+| P2 | `WasCreated` on UpdateResult; drop `VersionId == "1"` heuristic | S | UpdateResult, FhirEndpoints |
+| P2 | File splits, renames (`StreamingBundleContext` collision), `ct`→`cancellationToken`, header/style unification, frozen dictionaries, remove swallowed catches | M | ~15 files |

--- a/docs/features/application-layer-modernization/investigations/domain-conformance-events-review.md
+++ b/docs/features/application-layer-modernization/investigations/domain-conformance-events-review.md
@@ -1,0 +1,235 @@
+# Investigation: Domain Layer & Conformance Events Architecture & Technical Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Ignixa.Domain, Ignixa.Conformance.Events
+
+## Summary
+
+`Ignixa.Domain` is not the dependency-free models-and-abstractions project ADR-2509 describes. It carries two Core project references plus an implementation package (`Microsoft.Extensions.Caching.Memory`), contains a dead caching subsystem with latent correctness bugs, ~350 lines of dead terminology models duplicated by DataLayer entities, and a copy-pasted exception hierarchy in which two exceptions return the wrong HTTP status code (a live, spec-visible defect). `Ignixa.Conformance.Events` is by contrast small, clean, and close to its ADR — its main problems are a published README that documents event types that do not exist, and an event-type registry that lives in DataLayer instead of the package that owns the contract.
+
+## Strengths
+
+- **Zero-copy read models are well designed.** `Models/SearchEntryResult.cs` and `Models/UpdateResult.cs` (raw `ReadOnlyMemory<byte>` + metadata) are a deliberate, documented design that avoids re-serialization on the hot path, and the whole `IFhirRepository` read surface is built around it consistently.
+- **`Models/TransactionId.cs`** is a textbook `readonly record struct` value type — small, immutable, with `Parse`/`TryParse`.
+- **`Models/HistoryQueryParameters.cs`** is a sealed record with self-validating `WithValidatedCount()`/`Validate()` methods returning sanitized copies — good "invalid state hard to keep" design.
+- **`required`/`init` is used broadly** across models (`TenantConfiguration`, `ExportJobDefinition`, `HttpRequestAuditEvent`, `FhirOperationMetrics`), so construction completeness is enforced at compile time in most places.
+- **`Caching/ConformanceResourceResolver.cs`** uses source-generated `[LoggerMessage]` throughout instead of string-interpolated logging (the subsystem is dead, but the logging pattern is right).
+- **Ignixa.Conformance.Events events** (`Events/*.cs`) are small immutable positional records with no behavior — exactly what event payloads should be. `Abstractions/ISourceEventStore.cs` is a minimal 4-method contract, uses `IAsyncEnumerable` for replay, and every method takes a properly named `cancellationToken`.
+- **No `Hl7.Fhir.*` dependency anywhere** in either project — the layer rule that matters most is respected.
+- Nullable is enabled and warnings-as-errors is inherited from the root `Directory.Build.props` in both projects; no `#nullable disable` found.
+
+## Findings
+
+### P0 — ResourceNotFoundException returns HTTP 400 instead of 404
+**Location**: `src/Application/Ignixa.Domain/Exceptions/ResourceNotFoundException.cs` (whole file); base default at `src/Core/Ignixa.Serialization/Abstractions/FhirException.cs:50`
+**Issue**: `FhirException.StatusCode` defaults to 400 and `FhirExceptionMiddleware` (`src/Application/Ignixa.Api/Middleware/FhirExceptionMiddleware.cs:62`) writes it straight to the response. `ResourceNotFoundException` never overrides `StatusCode`, so every throw produces a 400 with a "not found" diagnostic. There is a live throw site: `src/Application/Ignixa.Application/Features/Experimental/Ips/Generator/IpsGeneratorService.cs:73` (`$summary` for a missing patient). This is a FHIR-spec-visible conformance defect (read of missing resource must be 404).
+**Recommendation**: Add `public override int StatusCode => 404;`. Audit the other subclasses that silently inherit 400: `MethodNotAllowedException` (should be 405 — it also mislabels the issue as `IssueType.Forbidden`), and confirm 400 is intentional for `BadRequestException`, `EverythingOperationException`, `RequestNotValidException`, `RequestTooCostlyException`, `ResourceNotSupportedException`, `UnsupportedConfigurationException`.
+**Effort**: S
+
+### P1 — Dead Domain/Caching subsystem, registered in DI, containing latent cache-poisoning and no-op-invalidation bugs
+**Location**: `src/Application/Ignixa.Domain/Caching/ConformanceResourceResolver.cs`, `Caching/InMemoryConformanceCache.cs`, `Caching/IFhirConformanceCache.cs`, `Abstractions/IConformanceResourceResolver.cs`; registration at `src/Application/Ignixa.Api/Registrations/ValidationServicesRegistration.cs:126-137`
+**Issue**: `IConformanceResourceResolver` is registered as a singleton but **never injected anywhere** — the entire 4-file subsystem is dead code, superseded by the ADR-2512 event-sourced design. It is not harmless dead code:
+1. **Version-key mismatch / cache poisoning**: `InMemoryConformanceCache.GetAsync` builds keys including the version (`InMemoryConformanceCache.cs:44,154-159`), but `SetAsync` and `InvalidateAsync` always build the key with `version: null` (`:71`, `:124`). So versioned lookups can never hit the cache, and `ConformanceResourceResolver.ResolveAsync` (`ConformanceResourceResolver.cs:84`) caches an *exact-version* resolution under the *unversioned* ("latest") key — a subsequent unversioned request would get a pinned old version.
+2. **Silent no-op invalidation**: `InMemoryConformanceCache.InvalidateTenantAsync` (`:137-149`) does nothing, while `ConformanceResourceResolver.InvalidateTenantCacheAsync` logs "Invalidating conformance cache for tenant" at Information level (`:232`) — a caller would believe invalidation succeeded and serve stale conformance resources for up to 24h. CLAUDE.md rule: no silent failures.
+3. The design also contradicts accepted ADR-2510 ("No TTL/expiration" as a caching design principle) — this cache uses 24h absolute + 1h sliding TTLs.
+Because it is registered and discoverable, any future handler that injects `IConformanceResourceResolver` inherits these bugs silently — in a server whose conformance resources drive validation, that is dangerous.
+**Recommendation**: Delete all four files and the `RegisterConformanceServices` block, and drop the now-unneeded `Microsoft.Extensions.Caching.Memory` PackageReference from `Ignixa.Domain.csproj`. If the resolver is ever needed again, ADR-2512's `ConformanceState` projection is the sanctioned mechanism.
+**Effort**: S
+
+### P1 — Six dead terminology model classes duplicated by DataLayer entities
+**Location**: `src/Application/Ignixa.Domain/Terminology/TermCodeSystem.cs`, `TermConcept.cs`, `TermConceptMap.cs`, `TermConceptMapElement.cs`, `TermValueSet.cs`, `TermValueSetExpansion.cs`
+**Issue**: None of these six classes is instantiated or referenced as a type anywhere in the solution — every match outside the Domain folder is a code comment. The real implementations are parallel EF entities in `src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Entities/Terminology/*Entity.cs` (e.g., `TermCodeSystemEntity`). Even if they were live, they are relational row mirrors (surrogate PKs, FK ID columns, `GroupIndex`, JSON-blob columns) — persistence shapes, not domain models, and they hardcode R4 semantics (`TermConceptMapElement.Equivalence` — R5 renamed this to `relationship`) in a server that targets STU3–R6. ~350 lines of misleading dead code. Classic early-agent artifact: model written to a plan, implementation later diverged into DataLayer, original never deleted.
+**Recommendation**: Delete all six classes. Keep `ITerminologyImporter.cs`, `TerminologyImportResult.cs`, `TerminologyImportStatus.cs`, which are live (used by `PackageResource` and the DataLayer importers).
+**Effort**: S
+
+### P1 — `object`-typed search indexes in the core write contract
+**Location**: `src/Application/Ignixa.Domain/Models/ResourceWrapper.cs:34` (`IReadOnlyList<object>? SearchIndices`); `src/Application/Ignixa.Domain/Abstractions/IFhirRepository.cs:51` (`IReadOnlyList<object> searchIndexes` inside the `BatchWriteAsync` tuple)
+**Issue**: The runtime type is always `SearchIndexEntry` (`src/Core/Ignixa.Search/Indexing/SearchIndexEntry.cs`; populated at `src/Application/Ignixa.Application/Features/Resource/CreateOrUpdateResourceHandler.cs:226,337`), and `Ignixa.Domain` **already references `Ignixa.Search`**, so there is no layering reason for `object`. Every data layer must downcast, and a wrong element type becomes a runtime failure instead of a compile error. This is the single worst type-safety hole in the domain contract.
+**Recommendation**: Change both to `IReadOnlyList<SearchIndexEntry>`. While touching `BatchWriteAsync`, replace the 6-element tuple parameter with a small record (e.g., `BatchWriteOperation`) — a positional 6-tuple in a public repository contract is unreadable at call sites.
+**Effort**: M
+
+### P1 — ADR-2509 dependency claim is false; implementation code lives in Domain
+**Location**: `src/Application/Ignixa.Domain/Ignixa.Domain.csproj:9-17`; `docs/adr/adr-2509-vertical-slice-architecture.md:56`
+**Issue**: The ADR states `Ignixa.Domain → Models and abstractions (no dependencies)`. Today the project references `Ignixa.Serialization`, `Ignixa.Search` (project refs), `Microsoft.Extensions.Caching.Memory` (an *implementation* package), and `Microsoft.Extensions.Logging.Abstractions`, and contains concrete classes with I/O-adjacent behavior (`Caching/ConformanceResourceResolver.cs`, `Caching/InMemoryConformanceCache.cs`) and algorithmic helpers (`Abstractions/IdHelper.cs`). The Core project refs are defensible (they are `Ignixa.*` building blocks, and `ResourceWrapper`/`SearchEntryResult` legitimately need `ResourceJsonNode`) — but the ADR should say so instead of claiming "no dependencies". `Caching.Memory` is not defensible in a contracts project.
+**Recommendation**: (a) Delete the Caching subsystem (see finding above), which removes `Caching.Memory`; (b) amend ADR-2509 (or add a superseding note) to state the actual allowed dependency set: `Ignixa.Domain → Ignixa.Serialization, Ignixa.Search only`; (c) treat any future `Microsoft.Extensions.*` implementation package in Domain as a review blocker.
+**Effort**: S (after Caching deletion)
+
+### P1 — Folder placement contradicts the layering: DataLayer depends on projects under `src/Application/`
+**Location**: `src/Application/Ignixa.Domain/`, `src/Application/Ignixa.Conformance.Events/`; consumed by `src/DataLayer/Ignixa.DataLayer.{SqlEntityFramework,InMemoryIndex,FileSystem,BlobStorage}/*.csproj`
+**Issue**: Both projects physically live inside `src/Application/`, yet all four DataLayer projects reference them. ADR-2509 draws Domain as its own layer below Application; CLAUDE.md's dependency diagram does the same. The folder layout tells a new reader "this is Application code," which is exactly wrong — these are the shared contracts of the whole system. Nothing in the ADRs or `src/Application/Directory.Build.props` documents this placement as deliberate (the props file only covers package-feed stability). Practical consequence: `src/Application/Directory.Build.props` policies (internal-feed stable packaging per ADR-2606/2607) silently apply to Domain and Conformance.Events, which may not be intended for contract packages.
+**Recommendation**: Either move both projects to `src/Domain/` (or a `src/Contracts/` sibling of Core/DataLayer/Application) or document the placement explicitly in ADR-2509 with the reason. Moving is a solution-file and path edit — cheap now, more expensive every month.
+**Effort**: M
+
+### P1 — Pervasive `ct` parameter naming — explicit CLAUDE.md "critical violation"
+**Location**: `Abstractions/IFhirRepository.cs` (all 12 methods), `Abstractions/ISearchService.cs`, `Abstractions/IQueryExecutionStrategy.cs`, `Abstractions/ISearchServiceFactory.cs`, `Abstractions/IFhirRepositoryFactory.cs`, `Abstractions/ITenantConfigurationStore.cs`
+**Issue**: CLAUDE.md lists "Async methods without `CancellationToken` parameter → Name it `cancellationToken` (not `ct`)" as a critical violation. Six of the most-implemented interfaces in the codebase use `ct`, while the other half of the same folder (`IPackageResourceRepository`, `IBackgroundJobRepository`, `ISystemRepository`, `IConformanceResourceResolver`) uses `cancellationToken`. Because these are interfaces, every implementation inherits the wrong name, and named-argument call sites (`ct: token`) will break when this is eventually fixed — the cost grows with time.
+**Recommendation**: Rename `ct` → `cancellationToken` across the six interfaces and their implementations in one mechanical PR (Roslyn rename, no behavior change).
+**Effort**: M (wide but mechanical)
+
+### P1 — Conformance.Events README documents event types that do not exist — and ships in the NuGet package
+**Location**: `src/Application/Ignixa.Conformance.Events/README.md:44-56`
+**Issue**: The README's event tables list `SearchParameterRegistered`, `SearchParameterStatusChanged`, `StructureDefinitionRegistered`, `StructureDefinitionStatusChanged`. None of these exist. The actual events are `SearchParameterActivated/ReindexStarted/ReindexCompleted/ReindexFailed/Deactivated/Deleted` and `StructureDefinitionActivated/Deactivated`. Root `Directory.Build.props:65-67` packs `README.md` into the package (`IsPackable=true` in the csproj), so this fabricated API surface is the published documentation of a shipped package.
+**Recommendation**: Rewrite the two tables from the real types in `Events/SearchParameterEvents.cs` and `Events/StructureDefinitionEvents.cs`.
+**Effort**: S
+
+### P1 — Event-type ↔ CLR-type mapping owned by DataLayer; renames silently break replay; no versioning story
+**Location**: contract: `src/Application/Ignixa.Conformance.Events/SourceEvent.cs` (`string EventType`, `object Data`); mapping: `src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/EventStore/SqlSourceEventStore.cs:138-156`
+**Issue**: The persisted discriminator is `nameof(RecordType)`, and the string→Type switch lives in the SQL store. Consequences: (1) renaming any event record in Conformance.Events breaks deserialization of all historical events — the compiler cannot catch it because the coupling crosses the package boundary via a string; (2) adding an event requires editing DataLayer (shotgun surgery, and any second store implementation must duplicate the switch); (3) `SourceEvent.Data` as `object` plus a free-text `EventType` makes invalid states representable (`EventType` says X, `Data` is Y) — ADR-2512's own audit-trail goal depends on this envelope staying coherent. There is also no event-versioning/upcasting strategy anywhere, which every event-sourced system eventually needs. Minor related defect: `SqlSourceEventStore.AppendAsync:62-67` returns `SourceEvent`s without propagating `entity.TransactionId`, so appended events report `TransactionId = 0` to callers while replayed ones carry the real value.
+**Recommendation**: Move the registry into Ignixa.Conformance.Events (e.g., a `ConformanceEventTypes` static map, or a marker interface `IConformanceEvent` with a `[EventType("...")]` attribute decoupling persisted names from CLR names). Have the store consume that registry. Document "event records are append-only; never rename" in the package README until versioning exists.
+**Effort**: M
+
+### P1 — `Ignixa.Domain.Exceptions.NotImplementedException` shadows `System.NotImplementedException`
+**Location**: `src/Application/Ignixa.Domain/Exceptions/NotImplementedException.cs`
+**Issue**: With `ImplicitUsings` enabled, any file that also imports `Ignixa.Domain.Exceptions` gets an ambiguous-reference error on `throw new NotImplementedException()` — or worse, code that imports only one namespace throws a different exception than the author believes (System's derives from `Exception` → 500; Domain's derives from `FhirException` → 501). Framework Design Guidelines explicitly prohibit reusing BCL type names.
+**Recommendation**: Rename to `OperationNotImplementedException` (or `FhirNotImplementedException`).
+**Effort**: S
+
+### P1 — Copy-pasted exception hierarchy: duplicated issue construction, three inconsistent validation styles, issue-less default constructors
+**Location**: all 13 files in `src/Application/Ignixa.Domain/Exceptions/`
+**Issue**: Every subclass duplicates an identical `Issues.Add(new IssueComponent { Severity, Code, Diagnostics })` block in both its message constructors (~200 redundant lines across the folder). Message validation is inconsistent three ways: `Debug.Assert` (`EverythingOperationException.cs:23`, five others — vanishes in Release builds), `EnsureArg.IsNotNull` *after* the base call has already consumed the message (`RequestNotValidException.cs:23`), and nothing at all (`BadRequestException`). Every subclass also exposes a parameterless constructor producing an exception with no message and no issues — the middleware then serializes an empty OperationOutcome. And `ResourceNotSupportedException.cs:28` calls `string.Format(CultureInfo.CurrentCulture, $"{resourceType} not supported", resourceType)` — an interpolated string passed to `string.Format` with an unused argument (copy-paste damage from the microsoft/fhir-server original, which used a composite format string).
+**Recommendation**: Add one protected `FhirException(string message, IssueSeverity severity, IssueType code)` constructor in the base (or a protected `AddIssue` helper) and collapse every subclass to 3–8 lines. Delete the parameterless constructors. Fix the `string.Format` misuse. Seal the leaf types.
+**Effort**: M
+
+### P1 — Stringly-typed job and tenant models: invalid states are representable everywhere
+**Location**: `Models/BackgroundJob.cs:27,37` (`JobType` is `int` despite `Models/BackgroundJobType.cs` existing; `Status` is free-text `"Queued"/"Running"/...`); `Models/ImportJobDefinition.cs:35` (`Mode` string `"InitialLoad"/"IncrementalLoad"`); `Models/TenantConfiguration.cs:74` (`ValidationDepth` string `"Spec"`), `:90` (`TenantStorageConfiguration.Type` string), `:122` (`TenantSearchConfiguration.Type` string); `Abstractions/IBackgroundJobRepository.cs:50` (`int? jobType`)
+**Issue**: A `BackgroundJobType` enum exists but the model and repository contract take raw `int`; job status, import mode, validation depth, and storage/search provider types are all magic strings. A typo (`"Runnning"`) compiles and fails at runtime in status filters. CLAUDE.md/standards: make invalid state unrepresentable. Also, `BackgroundJob<T>` XML docs call `Definition` "immutable" while every property on the class is `get; set;`, and `Models/ExportJobDefinition.cs:58` (`GroupId`) is the lone `set` among `init` siblings.
+**Recommendation**: Use `BackgroundJobType` in `BackgroundJob<T>`/`IBackgroundJobRepository`; introduce `JobStatus`, `ImportMode`, `ValidationDepth`, `StorageType`, `SearchType` enums (serialize as strings for the JSON payloads). Change `GroupId` to `init`.
+**Effort**: M
+
+### P1 — Dead `BulkImportJob` model
+**Location**: `src/Application/Ignixa.Domain/Models/BulkImportJob.cs`
+**Issue**: Referenced by nothing outside its own file. It is the pre-`BackgroundJob<T>` merged model (its fields are the union of `ImportJobDefinition` + `ImportJobProgress` + `ImportJobResult`, plus a "Phase 6" comment block). Near-duplicate models are the most confusing kind of dead code because both look plausible.
+**Recommendation**: Delete.
+**Effort**: S
+
+### P1 — `TenantContext` is vestigial: string-typed tenant ID, only ever used as `TenantContext.Default`
+**Location**: `src/Application/Ignixa.Domain/TenantContext.cs`; consumers `src/Application/Ignixa.Application/Features/Search/SearchOptionsBuilderFactory.cs:26-27,41,48` and two MCP diagnostic tools
+**Issue**: Every other tenant identifier in the system is `int` (`TenantConfiguration.TenantId`, `IFhirRepositoryFactory`, `IJobDefinition`); `TenantContext.TenantId` is `string?` and `Create` is never called with a real value — `SearchOptionsBuilderFactory` keys two `ConcurrentDictionary` caches on a component that is always `TenantContext.Default` (a constant), while carrying the *actual* tenant as a separate `int? tenantId` tuple member. The class also sits in the project root rather than `Models/`, and manually implements `Equals`/`GetHashCode` where a record would do.
+**Recommendation**: Delete `TenantContext` and remove it from the cache keys (the `int? tenantId` member already does the job). If a richer context is ever needed, it should carry `int TenantId` to match the rest of the system.
+**Effort**: S
+
+### P1 — `IPackageResourceRepository` is an 18-method god interface with drifting conventions
+**Location**: `src/Application/Ignixa.Domain/Abstractions/IPackageResourceRepository.cs`
+**Issue**: One interface covers package CRUD/lifecycle, StructureDefinition queries, SearchParameter queries, OperationDefinition lookup, StructureMap lookup, custom-resource-type extraction, and activation loading. Conventions drift across it: `GetResourcesForActivationAsync:266` returns `PackageResource[]` while everything else returns `IReadOnlyList<>`; `ListLoadedPackagesAsync:94` returns raw tuples; `PackageVersionExistsAsync:175` takes `int tenantId = 0` — defaulting to the *reserved system partition* that the rest of the codebase forbids touching; `CancellationToken` is required on some methods and defaulted on others. Every new conformance feature has appended a method here (visible accretion pattern).
+**Recommendation**: Split into `IPackageRepository` (lifecycle), `IConformanceQueryRepository` (SD/SP/OD/SM lookups), keeping the pair in Domain. Normalize returns to `IReadOnlyList<>`, replace the tuple with a `LoadedPackage(string Id, string Version)` record, remove the `tenantId = 0` default.
+**Effort**: L
+
+### P1 — Undeclared transitive dependency on `Ensure.That`
+**Location**: `Abstractions/IdHelper.cs:7`, `Exceptions/RequestNotValidException.cs:6`, `Exceptions/RequestTooCostlyException.cs:6`, `Exceptions/ResourceNotSupportedException.cs:7`
+**Issue**: `Ignixa.Domain.csproj` does not reference `Ensure.That`; it compiles only because `Ignixa.Serialization` happens to reference it (`src/Core/Ignixa.Serialization/Ignixa.Serialization.csproj:21`). If Serialization ever drops or privatizes that dependency, Domain breaks. The codebase otherwise standardizes on `ArgumentNullException.ThrowIfNull` / `ArgumentException` — `EnsureArg` here is copy-paste residue from microsoft/fhir-server.
+**Recommendation**: Replace the four `EnsureArg` call sites with BCL guard clauses (`ArgumentException.ThrowIfNullOrWhiteSpace`, `ArgumentOutOfRangeException.ThrowIfGreaterThan`) and drop the `using EnsureThat;` lines. No new PackageReference needed.
+**Effort**: S
+
+### P2 — One-type-per-file violations (explicit CLAUDE.md rule)
+**Location**:
+- `Abstractions/IAuditLogger.cs` (+ `HttpRequestAuditEvent`)
+- `Abstractions/IMetricsService.cs` (+ `FhirOperationMetrics`)
+- `Abstractions/IExportStreamWriter.cs` (+ `IExportStreamWriterFactory`)
+- `Abstractions/IPartitionStrategy.cs` (+ `PartitionResolutionContext`)
+- `Models/RequestPartition.cs` (+ `PartitionMode` enum)
+- `Models/TenantConfiguration.cs` (4 types: `TenantPackageConfiguration`, `TenantConfiguration`, `TenantStorageConfiguration`, `TenantSearchConfiguration`)
+- `Ignixa.Conformance.Events/SourceEvent.cs` (+ `NewSourceEvent`)
+- `Events/PackageEvents.cs` (3 records), `Events/SearchParameterEvents.cs` (7 records), `Events/StructureDefinitionEvents.cs` (2 records)
+**Issue**: CLAUDE.md: "ONE TYPE PER FILE". The event files are the defensible end of the spectrum (tiny cohesive records), but the Domain cases hide real types — `HttpRequestAuditEvent` and `FhirOperationMetrics` are substantial models a reader will not find by filename.
+**Recommendation**: Split the Domain files. For the event-record files, either split or get an explicit convention exemption recorded in CLAUDE.md; the current state violates the written rule.
+**Effort**: S
+
+### P2 — Copyright-header chaos: three styles, wrong attribution, malformed text
+**Location**: pervasive; e.g. banner-style "Microsoft Corporation" (`Abstractions/IFhirRepository.cs`), XML `<copyright>` style (`Models/HistoryQueryParameters.cs:1-4`), "Ignixa Contributors" (`Models/SearchEntryMode.cs:2`), no header at all (`Models/TransactionId.cs`, `Caching/*.cs`, all Conformance.Events files), malformed "Corporation.All rights reserved" missing spaces (`Exceptions/BadRequestException.cs:2`, 9 more exception files)
+**Issue**: `Directory.Build.props` declares `Authors: Ignixa Contributors`, yet most Domain files claim Microsoft copyright — some genuinely derived from microsoft/fhir-server (fine, MIT permits it, but then it should be acknowledged deliberately), most just copy-paste template propagation by agents. The malformed headers prove nobody is reading them.
+**Recommendation**: Pick one header (or none — the repo suppresses IDE0073) and apply it repo-wide with a script; add acknowledgment of microsoft/fhir-server-derived files in NOTICE if any remain substantially copied.
+**Effort**: S
+
+### P2 — Almost nothing is sealed
+**Location**: all `Exceptions/*.cs`, `Caching/InMemoryConformanceCache.cs`, `Caching/ConformanceResourceResolver.cs`, `Models/BackgroundJob.cs`, `Models/BulkImportJob.cs`, `Models/PackageResource.cs`, all `Terminology/Term*.cs`, `Models/ExportJob*.cs`, `Models/ImportJob*.cs`
+**Issue**: House style is seal-by-default. Only `TenantContext`, `HistoryQueryParameters`, and the `sealed record`s in `IAuditLogger.cs`/`IMetricsService.cs` comply. None of these classes are designed for inheritance.
+**Recommendation**: Seal them (records too, where not already).
+**Effort**: S
+
+### P2 — Roadmap/phase-number comments embedded in contracts
+**Location**: `Abstractions/IPartitionStrategy.cs:49,69` ("Phase 20.2+"), `Abstractions/IQueryExecutionStrategy.cs:21,33` ("Phase 20 / 20.2+"), `Models/TenantMode.cs:19`, `Models/RequestPartition.cs:44`, `Models/PackageResource.cs:77` ("Phase 1"), `Models/BulkImportJob.cs:31` ("Phase 6"), `Caching/ConformanceResourceResolver.cs:11` ("Phase 2"), `Constants/SystemConstants.cs:21` ("ADR-2523 Phase 20" — no ADR-2523 exists in docs/adr)
+**Issue**: Phase numbers reference a plan that lives nowhere in the repo and has already rotted (ADR-2523 doesn't exist). CLAUDE.md: comments explain *why*, not roadmap position.
+**Recommendation**: Delete phase references; keep the behavioral content ("distributed mode may return multiple partitions — not yet implemented") where it documents a real contract nuance.
+**Effort**: S
+
+### P2 — `IdHelper`: implementation logic filed under Abstractions
+**Location**: `src/Application/Ignixa.Domain/Abstractions/IdHelper.cs`
+**Issue**: A static class with bit-shifting surrogate-ID math and a `DateTime.TruncateToMillisecond` extension is not an abstraction; it sits among 19 interfaces. It also carries the `EnsureArg` transitive-dependency problem (see P1) and trailing whitespace at line 38 (evidence the analyzer set isn't catching style in this file).
+**Recommendation**: Move to `Ignixa.Domain/Helpers/` or alongside `TransactionId` in `Models/`; swap `EnsureArg.IsLte` for `ArgumentOutOfRangeException.ThrowIfGreaterThan`.
+**Effort**: S
+
+### P2 — Collection and tuple hygiene in contracts
+**Location**: `Abstractions/IBlobStorageClient.cs:55` (`Task<List<string>> ListBlobsAsync` — mutable concrete list in a contract; standard says `IReadOnlyList<>`); `Abstractions/ISearchService.cs:55` (`IReadOnlyList<(long StartId, long EndId)>` tuples; also an export-only concern (`GetExportRangesAsync`) bolted onto the search abstraction); `Abstractions/IPackageResourceRepository.cs:94` (tuple list)
+**Recommendation**: `IReadOnlyList<string>`; introduce `ExportRange(long StartId, long EndId)` record; consider moving `GetExportRangesAsync` to an export-specific interface when it next changes.
+**Effort**: S
+
+### P2 — Weakly-typed generic search options
+**Location**: `Abstractions/ISearchService.cs:25-41`, `Abstractions/IQueryExecutionStrategy.cs:43-69` (`<TSearchOptions> where TSearchOptions : class`)
+**Issue**: An unconstrained `class` generic is `object` with extra steps — implementations must runtime-check the concrete options type. The stated reason ("avoid circular dependencies with SearchOptions") no longer holds: Domain references `Ignixa.Search` directly. Either constrain to the real options type/marker interface from `Ignixa.Search`, or document why multiple unrelated option types genuinely flow through here.
+**Recommendation**: Add a marker interface (e.g., `ISearchOptions`) in `Ignixa.Search` and constrain to it.
+**Effort**: M
+
+### P2 — `PackageResource` mixes persistence, import-tracking, and crypto into one mutable model
+**Location**: `src/Application/Ignixa.Domain/Models/PackageResource.cs`
+**Issue**: Database surrogate key (`PackageResourceId:20`), terminology-import state machine columns (`:84-114`), and an SHA-256 helper (`ComputeContentHash:132-137`) live on one all-`set` class shared across layers. Not wrong enough to block, but it is the shape of an EF entity, not a domain model, and each concern (identity, content, import state) changes for different reasons.
+**Recommendation**: When terminology import is next touched, extract the import-tracking block into its own type and move `ComputeContentHash` to the importer that consumes it.
+**Effort**: M
+
+### P2 — Duplicate `Isolated/Distributed` enums
+**Location**: `Models/TenantMode.cs` vs `PartitionMode` in `Models/RequestPartition.cs:30-46`
+**Issue**: Two enums with identical members and near-identical doc text; one describes system-wide config, the other per-request mode, but nothing prevents them from drifting and every reader must figure out which to use.
+**Recommendation**: Collapse to one enum (`TenantMode`) referenced by `RequestPartition`.
+**Effort**: S
+
+### P2 — `IConformanceResourceResolver` design defects (relevant only if the subsystem is revived instead of deleted)
+**Location**: `Abstractions/IConformanceResourceResolver.cs`
+**Issue**: (a) `tenantId` is `string` while the whole system uses `int`; (b) the interface mixes resource resolution with cache-invalidation operations, leaking the caching strategy into the contract; (c) `ConformanceResourceResolver.ResolveFromPackageAsync` validates `tenantId` then never uses it (dead parameter); (d) `InMemoryConformanceCache.SetManyAsync` throws on an empty dictionary (an empty batch is a no-op, not an error) and silently skips null/whitespace entries.
+**Recommendation**: Moot if deleted per the P1; recorded here so a revival doesn't copy the interface as-is.
+**Effort**: —
+
+### P2 — Documentation drift in contracts
+**Location**: `Terminology/ITerminologyImporter.cs:23-26` (three methods each take a leading `int tenantId` with no `<param>` doc — the docs were written for a signature without it); `Abstractions/IRequireCapability.cs:16` (example code implements `IRequiresCapability` — wrong name); `Abstractions/IFhirRepository.cs:60` ("renaming the lock file" — FileSystem-implementation detail stated as the contract for all providers)
+**Recommendation**: Fix the three doc blocks.
+**Effort**: S
+
+### P2 — ADR-2512 status is still "Proposed" though fully implemented
+**Location**: `docs/adr/adr-2512-event-sourced-conformance.md:3`
+**Issue**: The event store, events, `ConformanceState` projection, sync services, and SQL migration (`20251223154537_AddSourceEventsTable`) all exist. The ADR index treats status as meaningful; a "Proposed" ADR that already shipped misleads reviewers about what is settled.
+**Recommendation**: Flip to Accepted (with implementation date).
+**Effort**: S
+
+## Architectural Observations
+
+1. **Ignixa.Domain has become a junk drawer.** Its legitimate core — `IFhirRepository`, `ResourceWrapper`, `ResourceKey`-adjacent models, `SearchEntryResult`, tenancy models, exceptions — is sound and matches ADR-2509's intent. Around it has accreted: a dead caching implementation, dead terminology entities, a dead import model, a vestigial `TenantContext`, and helper implementations. Roughly 15 of 74 files (~20%) are deletable today with zero behavioral change. That deletion is the single highest-leverage action for this subsystem.
+
+2. **Dependency direction is correct; the map is wrong.** Verified: Domain references only Core (`Ignixa.Serialization`, `Ignixa.Search`) — no Application, no DataLayer, no `Hl7.Fhir.*`. Conformance.Events references only `Ignixa.Specification`. DataLayer and Application both depend on Domain, as designed. But ADR-2509 says "no dependencies" (false), diagrams `ResourceKey` in Domain (it lives in `src/Core/Ignixa.Abstractions/ResourceKey.cs`), and the physical folder layout puts both reviewed projects under `src/Application/` while DataLayer consumes them. Every map a newcomer would consult misdescribes the actual structure.
+
+3. **Two conformance-resolution generations coexist, one dead.** ADR-2512's event-sourced pipeline (Conformance.Events + `ConformanceState` + `SqlSourceEventStore`) is the live system. The Domain/Caching resolver chain is the pre-ADR generation, still registered in DI, never consumed, contradicting both ADR-2510 (no-TTL principle) and ADR-2512 (which explicitly replaced multi-cache invalidation). Early-agent signature: superseded designs are wired up, not removed.
+
+4. **The domain model is anemic by design — and that's mostly fine here.** ADR-2509 deliberately scopes Domain to "models and abstractions"; behavior lives in Application handlers. Within that constraint, the type-system usage is inconsistent rather than absent: `TransactionId` and `HistoryQueryParameters` show the team knows how to make invalid states unrepresentable, while job status strings, `int` job types, and `IReadOnlyList<object>` search indices show where speed won. The P1s above target exactly those gaps.
+
+5. **Conformance.Events is the healthiest code reviewed** — small immutable records, one clean abstraction, correct `cancellationToken` naming, minimal dependencies, `TreatWarningsAsErrors` set locally as well as inherited. Its risks are all at the boundary: the string-keyed type registry in DataLayer, the `object Data` envelope, and a README describing an API that doesn't exist. Fix the boundary, and this package is done.
+
+6. **Provenance is visible and unmanaged.** A large fraction of Domain (exceptions, `IdHelper`, several models) is adapted from microsoft/fhir-server, carrying its headers, its `EnsureArg` idiom, and in one case a broken `string.Format`. Adapted code is fine; unacknowledged, half-converted adapted code is where the malformed headers, dead parameters, and undeclared dependencies came from.
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Override `StatusCode` (404) on `ResourceNotFoundException`; fix `MethodNotAllowedException` (405 + issue type); audit remaining 400-inheritors | S | 2–8 exception files |
+| P1 | Delete dead Domain/Caching subsystem + DI registration; drop `Caching.Memory` package ref | S | 5 files |
+| P1 | Delete 6 dead `Term*` model classes | S | 6 files |
+| P1 | Delete `BulkImportJob`; delete/replace `TenantContext` | S | 4 files |
+| P1 | Type `SearchIndices`/`BatchWriteAsync` as `SearchIndexEntry`; replace 6-tuple with record | M | 2 Domain files + all repo implementations |
+| P1 | Rename `ct` → `cancellationToken` across 6 interfaces + implementations | M | ~6 Domain files + implementations |
+| P1 | Fix Conformance.Events README event tables (published package docs) | S | 1 file |
+| P1 | Move event-type registry from `SqlSourceEventStore` into Conformance.Events; document rename prohibition; fix `TransactionId` drop in `AppendAsync` | M | 3 files |
+| P1 | Rename `NotImplementedException` → `OperationNotImplementedException` | S | 1 file + call sites |
+| P1 | Base-class issue constructor; collapse exception copy-paste; delete parameterless ctors; fix `string.Format` misuse | M | 14 files |
+| P1 | Replace stringly-typed job/config fields with enums (`JobStatus`, `ImportMode`, `ValidationDepth`, storage/search types); use `BackgroundJobType` | M | ~8 files + handlers |
+| P1 | Split `IPackageResourceRepository`; normalize return types; remove `tenantId = 0` default | L | 1 interface + implementations |
+| P1 | Replace `EnsureArg` with BCL guards (removes undeclared transitive dependency) | S | 4 files |
+| P1 | Amend ADR-2509 dependency claim; move (or document placement of) Domain + Conformance.Events out of `src/Application/` | M | ADR + solution/paths |
+| P2 | One-type-per-file splits; seal classes; header cleanup; delete phase comments; relocate `IdHelper`; `List<string>` → `IReadOnlyList<string>`; constrain `TSearchOptions`; merge `TenantMode`/`PartitionMode`; fix doc drift; flip ADR-2512 to Accepted | S–M | broad |

--- a/docs/features/application-layer-modernization/investigations/experimental-feature-review.md
+++ b/docs/features/application-layer-modernization/investigations/experimental-feature-review.md
@@ -1,0 +1,236 @@
+# Investigation: Features/Experimental Review
+
+**Feature**: application-layer-modernization
+**Status**: Complete
+**Created**: 2026-07-11
+**Scope**: Ignixa.Application/Features/Experimental (103 .cs files, not 97 as commonly quoted)
+
+## Summary
+
+`Features/Experimental` is a deliberate, documented mechanism — a config-toggled staging area (master switch + per-feature flags, `docs/features/experimental-library/`, ADR-2512) — not an agent dumping ground. Its size is explained by five unrelated subsystems sharing only a feature flag: GraphQL (33 files, newest, highest quality), MCP (31), IPS $summary (18), Transform (9), Terminology (6). However, the original plan (a separate `Ignixa.Application.Experimental` project) was half-executed: the code landed as a folder inside `Ignixa.Application`, the "remove old code" migration phase was never finished (13 byte-identical dead twins remain in `Ignixa.Application.Operations`), and the folder carries serious latent defects — MCP authorization is entirely dead wiring (fail-open), and IPS package-driven strategies are silently discarded by a broken handler→service handoff.
+
+## Contents Inventory
+
+| Subsystem | Files | What it is | Reachable in production? |
+|---|---|---|---|
+| `Configuration/` | 2 | `ExperimentalOptions` (master + per-feature flags), `GraphQlExperimentalOptions` | Yes — bound at startup |
+| `Infrastructure/` | 2 | Autofac + IServiceCollection registration, gated per feature flag | Yes — called from `Ignixa.Api/Extensions/ServiceCollectionExtensions.cs:60,115` |
+| `GraphQl/` | 33 | FHIR `$graphql` operation: HotChocolate type module generated from FHIR schema, resolvers, directives (`@flatten`/`@first`/`@singleton`/`@slice`), scalars, error mapping, schema warmup | Yes — `GraphQlEndpoints.cs`; enabled by default |
+| `Ips/` | 18 | Patient `$summary` (International Patient Summary): strategies, registry, StructureDefinition-driven section parsing, bundle assembly | Yes — `SummaryEndpoints.cs`; enabled by default |
+| `Mcp/` | 31 | Model Context Protocol server tools: FHIR read/search/history/patch, package install/uninstall/search, tenant listing, diagnostic spike, authorization service, 10 DTOs | Yes — `McpEndpoints.cs` maps `/mcp` |
+| `Terminology/` | 6 | `$expand`, `$translate`, `$subsumes` handlers (thin wrappers over `ITerminologyService`) | Yes — `TerminologyEndpoints.cs` |
+| `Transform/` | 9 | StructureMap `$transform` via FHIR Mapping Language: handler, map/expression caches, ConceptMap resolver, timeout-guarded FHIRPath | Yes — `TransformEndpoints.cs` |
+
+The folder is cohesive in *mechanism* (everything is flag-gated and registered through the two Infrastructure files) but not in *content* — the five subsystems share nothing else. Endpoints live correctly in `Ignixa.Api/Endpoints/Experimental/`.
+
+**Cross-project leakage**: `Ignixa.Application.BackgroundOperations/JobManagement/*Tool.cs` consumes `Experimental/Mcp/Dtos/JobStatusDto.cs` and `JobSummaryDto.cs` — MCP job-management tools live *outside* the Experimental folder but depend on DTOs *inside* it. "Experimental" is not actually isolated.
+
+**Not deleted after migration**: `Ignixa.Application.Operations/Features/Transform/` (7 files) and `Ignixa.Application.Operations/Features/Terminology/` (6 files) are byte-identical (modulo namespace/usings) to the Experimental copies. Nothing in `src` references the old namespaces except the files themselves; production DI registers only the Experimental copies (`ExperimentalAutofacRegistration.cs`). The old copies are kept compiled solely by `test/Ignixa.Application.Tests/Features/Transform/*` — meaning the *live* Transform/Terminology code has no direct tests, and the *tested* code is dead.
+
+## Strengths
+
+- **GraphQL subsystem is genuinely good.** `GraphQlExecutionService.cs`, `FlattenResultProcessor.cs`, `ReferenceResolver.cs`, `FhirGraphQlErrorMapping.cs` show careful error taxonomy (coded errors mapped to FHIR OperationOutcome issue types in `FhirGraphQlErrorFilter.cs`), deliberate `OperationCanceledException` pass-through in every resolver catch, comments that explain *why* (e.g., `CreateResultWithData` documenting the `IsDataSet` trap, directive types documenting why post-processing is used instead of HC middleware), and thorough tests (10 test files in `test/Ignixa.Application.Tests/Features/Experimental/GraphQl/`).
+- **The feature-flag registration pattern works.** `ExperimentalAutofacRegistration.cs` / `ExperimentalServicesRegistration.cs` are clean, master-switch-first, per-feature gated — exactly what the library proposal specified.
+- **Security-conscious defaults in GraphQL options**: `EnableGraphQlIde` and `IncludeExceptionDetails` default to `false` with doc comments explaining the exposure (`GraphQlExperimentalOptions.cs:16-31`).
+- **IPS FHIRPath usage**: `StructureDefinitionStrategyFactory.cs` and `SectionMetadataParser.cs` use FHIRPath (`Select`/`Scalar`) for StructureDefinition navigation per the project convention.
+- **`FlattenResultProcessor` ordering invariant** (@slice before @flatten) is documented and tested.
+
+## Findings
+
+### P0 — MCP authorization is dead wiring; all MCP tools run without authorization
+**Location**: `Features/Experimental/Mcp/Tools/TenantAwareMcpTool.cs:35-83`, every tool constructor (e.g. `GetResourceTool.cs:33`, `PatchResourceTool.cs:35`, `UninstallPackageTool.cs:29`), `Ignixa.Api/Endpoints/Experimental/McpEndpoints.cs:27`
+**Issue**: A complete authorization layer exists (`IMcpAuthorizationService`, `McpAuthorizationService` — registered in `ExperimentalAutofacRegistration.cs:112-114`) but is never invoked. `TenantAwareMcpTool` takes the service as an *optional* constructor parameter "for backward compatibility" and silently skips checks when it is null (`EnsureMcpAccessAsync` is a no-op). Grep confirms: **no tool passes it to the base, and no tool calls `EnsureMcpAccessAsync`/`EnsureOperationAuthorizedAsync`.** `McpEndpoints.MapMcp("/mcp")` adds no `RequireAuthorization` either. Tools include writes (`patch_fhir_resource`, `patch_resource_field`), admin operations (`install_fhir_package`, `uninstall_fhir_package`), and tenant enumeration (`list_tenants_info`). This is fail-open by construction: a missing registration silently disables security rather than failing.
+**Recommendation**: Make `IMcpAuthorizationService` a required base-class dependency; call `EnsureOperationAuthorizedAsync` with the correct `McpOperationType` at the top of every tool method; add `RequireAuthorization` to the MCP endpoint group. Delete the null-tolerant "backward compatibility" path — nothing depends on it.
+**Effort**: M
+
+### P0 — IPS package-registered strategies are silently discarded (broken handler→service handoff)
+**Location**: `Features/Experimental/Ips/Generator/IpsGeneratorService.cs:48-50,132-142` vs `Ips/Generator/IpsGeneratorHandler.cs:68-109` and `Ips/Events/PackageInstalledStrategyRegistrationHandler.cs`
+**Issue**: The whole point of `PackageInstalledStrategyRegistrationHandler` + `IpsGenerationStrategyRegistry` is to add StructureDefinition-driven strategies at runtime when packages install. The handler correctly resolves such a strategy from the registry, then passes only `strategy.BundleProfile` (a string) to `IpsGeneratorService.GenerateIpsAsync`. The service re-resolves the strategy — but from `IEnumerable<IIpsGenerationStrategy>` (constructor-injected DI enumerable, which contains **only** `DefaultIpsGenerationStrategy`), never from the registry. `_strategyByProfile.TryGetValue` misses and falls back to `_defaultStrategy`. Net effect: every dynamically registered strategy is registered, selected, logged — and then ignored. The strategy-selection logic is also duplicated across handler and service.
+**Recommendation**: Inject `IIpsGenerationStrategyRegistry` into `IpsGeneratorService` (or pass the resolved `IIpsGenerationStrategy` instance instead of a profile string) and delete one of the two `SelectStrategy` implementations.
+**Effort**: S
+
+### P0 — PatchResourceTool numeric values are always emitted as `valueString`
+**Location**: `Features/Experimental/Mcp/Tools/FhirOperations/PatchResourceTool.cs:206` vs `:281-306`
+**Issue**: `ParseOperationsJson` converts JSON numbers to `decimal` (`valueProp.GetDecimal()`), but `BuildPatchParameters` only pattern-matches `bool`/`int`/`double`/`string`/`JsonNode`. A `decimal` matches none of these and falls into the fallback `valuePart["valueString"] = JsonSerializer.Serialize(op.Value)` — so every numeric patch value is sent to the patch handler as `valueString` instead of `valueDecimal`/`valueInteger`. Arrays/objects likewise degrade to raw-text strings. `PatchResourceFieldTool.cs:263-296` duplicates the same `CreateValuePart` logic with the same gap, and its `object value` parameter will typically arrive as `JsonElement` from the MCP SDK, matching *no* branch.
+**Recommendation**: Handle `decimal` (and `JsonElement`) explicitly; add a unit test that patches a numeric field through the MCP tool. Extract the duplicated `BuildPatchParameters`/`CreateValuePart` into one shared helper.
+**Effort**: S
+
+### P0 — 13 dead byte-identical files in Ignixa.Application.Operations; live code untested, dead code tested
+**Location**: `src/Application/Ignixa.Application.Operations/Features/Transform/` (7 files), `.../Features/Terminology/` (6 files); tests at `test/Ignixa.Application.Tests/Features/Transform/*.cs`
+**Issue**: Migration Phase 5 ("remove old code from source projects", `docs/features/experimental-library/investigations/library-proposal.md:599-604`) was never executed. Production DI and endpoints reference only the `Experimental` namespaces; the Operations copies are unreachable, but their unit tests (`FhirPathEvaluatorWithTimeoutTests`, `MapRegistryCacheTests`, `TransformResourceHandlerTests`, `ConceptMapResolverServiceTests`, `FhirPathExpressionCacheTests`) still target the dead twins. Any fix applied to the live copy will not be covered — and a fix applied only to the tested copy does nothing. This is the classic divergence trap; today the copies are identical only by luck.
+**Recommendation**: Delete the Operations `Transform/` and `Terminology/` folders; retarget the five test files at the `Experimental` namespaces. Verify `Ignixa.Application.Operations` still builds (nothing else references them).
+**Effort**: S
+
+### P1 — MapRegistryCache is per-request: the "performance cache" never caches, and invalidation is a no-op
+**Location**: `Infrastructure/ExperimentalAutofacRegistration.cs:143-146` (`.InstancePerLifetimeScope()`), `Transform/MapRegistryCache.cs:36-49` (claims "200-500 transforms/sec (cached)"), `Transform/Events/PackageLoadedMapCacheInvalidationHandler.cs`
+**Issue**: `MapRegistryCache` was written as a long-lived cache (ConcurrentDictionary, TTL, hit/miss statistics, package-aware invalidation) but is registered per-lifetime-scope because it depends on the request-scoped `StructureMapParser`. Every request gets a fresh empty cache, so every `$transform` by canonical URL re-loads and re-parses the StructureMap; the statistics, TTL, and `InvalidatePackage` machinery are inert. Worse, `PackageLoadedMapCacheInvalidationHandler` (registered `InstancePerDependency`) resolves its *own* fresh `MapRegistryCache`, invalidates it, and logs success — a complete no-op that reads as if it works.
+**Recommendation**: Either make the cache a true singleton keyed by (FhirVersion, url) with the parser resolved per-call, or delete the cache/statistics/invalidation machinery and load maps directly. Half-singleton semantics with per-request lifetime is the worst of both.
+**Effort**: M
+
+### P1 — Sync-over-async in the Transform pipeline
+**Location**: `Transform/FhirPathEvaluatorWithTimeout.cs:102-108` (`.GetAwaiter().GetResult()`), `Transform/ConceptMapResolverService.cs:122-148` (same), `Transform/FhirPathEvaluatorWithTimeout.cs:64` (`Task.Run`)
+**Issue**: The synchronous `MappingEvaluator` forces blocking wrappers. `Evaluate()` blocks on `EvaluateAsync` and drops the caller's `CancellationToken` entirely (`CancellationToken.None`); the `Task.Run` "timeout" cannot actually stop a runaway FHIRPath evaluation — the thread-pool thread keeps burning after `TimeoutException` is thrown. `ConceptMapResolverService.Translate` additionally wraps the block in `catch (Exception) → return null`, silently converting terminology-service failures into "no translation found" — directly contradicting the `ErrorMode.Strict` the handler configures (`TransformResourceHandler.cs:110`) and the async version's deliberate rethrow.
+**Recommendation**: Short term: remove the swallow-to-null in `Translate` (let it throw; Strict mode wants that) and document the timeout limitation. Long term: give `MappingEvaluator` async callbacks so tokens propagate.
+**Effort**: M (short-term S)
+
+### P1 — Empty catch blocks swallowing everything, including cancellation
+**Location**: `Mcp/Tools/FhirOperations/SearchResourcesTool.cs:184-187`, `Mcp/Tools/FhirOperations/FhirPathQueryCapabilityStatementTool.cs:142-145`
+**Issue**: `catch { /* If tenant resolution fails, use default R4 */ }` — bare catch, no logging, swallows `OperationCanceledException` and turns any store failure into a silent R4 fallback. Searching an R5 tenant whose config lookup transiently fails would build R4 search expressions against R5 data with no trace. CLAUDE.md is explicit: "empty catch blocks are bugs". The identical `ResolveFhirVersionAsync` helper is copy-pasted into both tools.
+**Recommendation**: Extract one helper (on `TenantAwareMcpTool`), catch specific exceptions, log the fallback, and let cancellation propagate.
+**Effort**: S
+
+### P1 — Dead configuration knobs: appsettings values that nothing reads
+**Location**: `Configuration/ExperimentalOptions.cs:75` (`Mcp.Transport`), `:91` (`Transform.TimeoutSeconds`), `:124-129` (`Summary.MaxResources`, `Summary.AllowedResourceTypes`); `Ignixa.Web/appsettings.json:211,221-222`
+**Issue**: `Transform.TimeoutSeconds` (default 30, set to 30 in appsettings) is never read — the FHIRPath timeout is hardcoded to 5 seconds in `ExperimentalAutofacRegistration.cs:157`. `Summary.MaxResources` is never read — `IpsGeneratorService.cs:46` hardcodes `DefaultMaxIpsResources = 1000`. `Summary.AllowedResourceTypes` and `Mcp.Transport` are read by nothing. Operators tuning these values are being lied to.
+**Recommendation**: Wire each option through (pass `IOptions<ExperimentalOptions>` where the hardcoded values live) or delete the properties and the appsettings entries.
+**Effort**: S
+
+### P1 — Registration-time config binding prevents test/host config overrides
+**Location**: `Infrastructure/ExperimentalAutofacRegistration.cs:61-63`, `Infrastructure/ExperimentalServicesRegistration.cs:36-38`, `Ignixa.Api/Endpoints/Experimental/ExperimentalEndpointExtensions.cs`
+**Issue**: Feature enablement is decided by `configuration.Get<ExperimentalOptions>()` executed during `ConfigureServices`/container build, in three separate places (services, Autofac, endpoints). Config sources added after host build, reloadable providers, and `WebApplicationFactory` overrides applied late don't take effect, and the three read points can disagree if configuration changes between them. This is the documented blocker on PR #277 (GraphQL off-by-default) — the E2E config-bind timing split.
+**Recommendation**: Bind once via `IOptions<ExperimentalOptions>` and gate endpoints/handlers at request time (or a startup filter), not at registration time. At minimum, read the config exactly once and share the snapshot.
+**Effort**: M
+
+### P1 — Dead code: public `StructureDefinitionBasedStrategy` shadowed by a private nested duplicate
+**Location**: `Ips/Strategy/StructureDefinitionBasedStrategy.cs:18` (dead), `Ips/Strategy/StructureDefinitionStrategyFactory.cs:336-384` (live private nested class of the same name)
+**Issue**: Two classes named `StructureDefinitionBasedStrategy` exist. The factory's `new StructureDefinitionBasedStrategy(sections, bundleProfile)` at line 56 binds to its private nested copy; the public top-level class (different constructor: takes `StructureDefinitionJsonNode`) is referenced by nothing in src or test. It also carries two fields (`_compositionProfile`, `_compositionProfileUrl`) that are assigned and never read. Classic copy-then-abandon.
+**Recommendation**: Delete `Strategy/StructureDefinitionBasedStrategy.cs`; if a public type is wanted, promote the nested one instead of keeping both.
+**Effort**: S
+
+### P1 — `SectionMetadataParser` duplicates ~200 lines of the factory and is production-dead
+**Location**: `Ips/Metadata/SectionMetadataParser.cs:20-251` vs `Ips/Strategy/StructureDefinitionStrategyFactory.cs:126-334`
+**Issue**: `ParseSections`/`ParseSection`/`ExtractLoincCode`/`ExtractTitle`/`DetermineCardinality`/`ExtractEntryProfiles`/`ExtractResourceTypeFromProfile` exist twice, near-identically. `SectionMetadataParser` is not registered in DI and is referenced only by its own unit tests (`SectionMetadataParserTests.cs`) — so the tests exercise the copy production doesn't use, while the factory's live copy is untested (same pattern as the Transform twins). ADR-2512 names `SectionMetadataParser` as the intended component.
+**Recommendation**: Make `StructureDefinitionStrategyFactory` delegate to `SectionMetadataParser` (register it in DI) and delete the inline duplicate — this honors the ADR and fixes the coverage inversion.
+**Effort**: S
+
+### P1 — `StructureMapTransformFeature` is never registered: $transform absent from CapabilityStatement
+**Location**: `Transform/StructureMapTransformFeature.cs:14`; registrations at `ExperimentalAutofacRegistration.cs:120-171` (no `IPackageFeature` registration for Transform) vs `:101-103` (GraphQL registers `GraphQlFeature`)
+**Issue**: The GraphQL feature registers an `IPackageFeature` so `$graphql` is advertised in the CapabilityStatement; Transform has the equivalent class but never registers it (in either the live or dead copy). Consumers inspecting `/metadata` won't discover `$transform` even when it is enabled. The class is instantiated only by `OperationsSegmentTests`.
+**Recommendation**: Register it inside `RegisterTransformHandlers()` (mirroring GraphQL), or delete it if non-advertisement is intentional.
+**Effort**: S
+
+### P1 — Half-finished IPS surface: identifier lookup always throws, dead TODO block
+**Location**: `Ips/Generator/IpsGeneratorService.cs:112-130` (`GenerateIpsByIdentifierAsync` throws `NotSupportedException` after a `logger.LogWarning`), `Ips/Generator/IpsGeneratorHandler.cs:28-31,46-50` (validates and routes to it anyway), `:87-100` (13-line commented-out CapabilityStatement lookup block)
+**Issue**: The handler accepts `PatientIdentifier`, validates it, splits system|value — then calls a method whose only behavior is to throw. The interface, endpoint parameter, and handler plumbing all advertise a capability that doesn't exist. The commented-out "Priority 2" block is dead planning residue.
+**Recommendation**: Either implement identifier-based lookup (token search on `identifier`) or remove the parameter from `IpsGeneratorQuery`, the interface method, and the endpoint until it exists. Delete the commented block.
+**Effort**: M (implement) / S (remove)
+
+### P1 — Inconsistent tenant plumbing and duplicate dependency injection across MCP tools
+**Location**: `Mcp/Tools/FhirOperations/GetResourceTool.cs:28-37` and `SearchResourcesTool.cs:37-51` (inject `IFhirRequestContextAccessor` twice under two parameter names; mutate `requestContext.TenantId` at `GetResourceTool.cs:72`, `SearchResourcesTool.cs:132`); `PatchResourceTool.cs:114` (passes `TenantId` in the command instead); `GetResourceHistoryTool.cs:90` (hardcodes `baseUrl = "https://localhost"`)
+**Issue**: Three different tenant-propagation mechanisms across sibling tools: mutate the ambient request context, pass tenant in the command, or ignore it. Two tools take the same service as two constructor parameters (`fhirRequestContextAccessor` for the base, `contextAccessor` for the field) — an obvious generated-code artifact. Mutating the ambient `IFhirRequestContext.TenantId` from a tool is a side effect on shared per-request state that other components read.
+**Recommendation**: Standardize on command-carried tenant IDs (the `PatchResourceCommand` pattern); remove the duplicate constructor parameters.
+**Effort**: M
+
+### P1 — Error-contract inconsistency across MCP tools; broad catches eat cancellation
+**Location**: `Mcp/Tools/FhirOperations/PatchResourceTool.cs:82-106,140-148`, `PatchResourceFieldTool.cs:83-91,139-147` (return `Success=false` DTOs from `catch (Exception)`) vs `GetResourceTool.cs:61`, `SearchPackagesTool.cs:47`, `InstallPackageTool.cs:58` (throw)
+**Issue**: Half the tools throw on bad input; the other half return result-object errors — an LLM client gets two different failure shapes from sibling tools. The patch tools' `catch (Exception)` also converts `OperationCanceledException` into `Success=false, ErrorMessage="Patch operation failed: The operation was canceled."`.
+**Recommendation**: Pick one contract (result DTOs are reasonable for MCP), apply it uniformly, and add `catch (OperationCanceledException) { throw; }` before the broad catches (the GraphQL resolvers already model this correctly).
+**Effort**: M
+
+### P1 — DiagnosticTool: a phase-1 spike exposed as a production MCP tool
+**Location**: `Mcp/Tools/DiagnosticTool.cs:13-15` ("Phase 1: Spike to validate MapGroup tenant parameter accessibility"), `Mcp/Tools/DiagnosticResult.cs`
+**Issue**: A self-described spike that dumps HTTP route values, request path, and internal context items to any MCP client. Combined with the missing authorization (first P0), this is internal-state disclosure with zero remaining diagnostic purpose — the MapGroup question it validated is long settled.
+**Recommendation**: Delete both files.
+**Effort**: S
+
+### P1 — GetResourceTool documentation promises parameters that don't exist
+**Location**: `Mcp/Tools/FhirOperations/GetResourceTool.cs:40-44` vs signature `:45-55`; `:84-85` ("TODO: Phase 2 add filtering")
+**Issue**: The `[Description]` — which is exactly what an LLM reads to call the tool — instructs `Use elements='id,field1,field2'` and `Use summary='true'`, but the method has no `elements` or `summary` parameters. Every model following the docs will produce invalid tool calls. A `TODO` in the body confirms the feature was never built.
+**Recommendation**: Remove the claims from the description (or implement the parameters, as `SearchResourcesTool` did). No TODOs left behind.
+**Effort**: S
+
+### P1 — Test placement is split across three projects with no rule
+**Location**: `test/Ignixa.Application.Experimental.Tests/` (Ips + options only, 4 files), `test/Ignixa.Application.Tests/Features/Experimental/GraphQl/` (10 files), `test/Ignixa.Application.Tests/Features/Transform/` (5 files targeting the dead Operations twins), `test/Ignixa.Api.Tests/Mcp/` (1 file)
+**Issue**: A test project named for the never-created `Ignixa.Application.Experimental` library exists but holds only IPS tests; GraphQL tests live in the main test project; Transform tests target dead code; MCP tools (including both patch tools with the P0 value bug) have essentially no coverage. Nobody can answer "where do tests for an Experimental feature go?"
+**Recommendation**: Consolidate all Experimental tests into `Ignixa.Application.Experimental.Tests` (or fold that project away and use `Features/Experimental/` inside the main test project — either, but one).
+**Effort**: M
+
+### P2 — One-type-per-file violations
+**Location**: `Configuration/ExperimentalOptions.cs` (6 types), `Mcp/Tools/PackageManagement/SearchPackagesTool.cs:125-224` (5 types), `Mcp/Tools/PackageManagement/ListPackagesTool.cs:75-112` (3), `Ips/Generator/IpsGeneratorQuery.cs:17-42` (3), `Transform/MapRegistryCache.cs:28,341` (3), `Transform/FhirPathExpressionCache.cs:138` (2), `Ips/Api/Section.cs:52` (2), Terminology query files (2 each: query + result)
+**Issue**: CLAUDE.md mandates one type per file. Query+Result pairs are arguably tolerable; a tool class trailing four DTO records is not.
+**Recommendation**: Split at least the tool files and `ExperimentalOptions.cs`.
+**Effort**: S
+
+### P2 — Copyright-header archaeology marks authorship generations
+**Location**: "Microsoft Corporation" headers on all of Mcp/, Transform/, `ExperimentalOptions.cs`, `ExperimentalServicesRegistration.cs`; "Ignixa Contributors" on GraphQl/, Ips/, `GraphQlExperimentalOptions.cs`, `ExperimentalAutofacRegistration.cs`; *no header at all* on all six Terminology files
+**Issue**: Three header conventions in one folder. The Microsoft headers are copy-paste residue from the microsoft/fhir-server codebase and are simply wrong for this repository.
+**Recommendation**: Normalize to the Ignixa header (a mechanical sweep; consider a repo-guard test).
+**Effort**: S
+
+### P2 — Mixed constructor styles and redundant null checks
+**Location**: Old-style ctors with manual `?? throw new ArgumentNullException` throughout Mcp/ and Terminology (e.g. `McpAuthorizationService.cs:28-41`, `ExpandValueSetHandler.cs:23-29`) vs primary constructors in GraphQl/, Ips/, `InstallPackageTool.cs:22-34` (which does *both*: primary ctor + null-check-into-field boilerplate)
+**Issue**: The codebase standard is primary constructors; DI-injected dependencies don't need null guards. The `InstallPackageTool` hybrid is pure noise.
+**Recommendation**: Convert during any touch of these files; don't do a big-bang sweep.
+**Effort**: S (opportunistic)
+
+### P2 — Unused injected loggers in Terminology handlers
+**Location**: `Terminology/Expand/ExpandValueSetHandler.cs:21,28`, `Terminology/Subsumes/SubsumesHandler.cs:15,22`, `Terminology/Translate/TranslateCodeHandler.cs:15,22`
+**Issue**: `_logger` is injected, assigned, never used, in all three handlers (in both the live and dead copies).
+**Recommendation**: Delete the parameter or log something useful.
+**Effort**: S
+
+### P2 — `TenantId` parameters accepted and ignored in all Terminology queries
+**Location**: `Terminology/Expand/ExpandValueSetQuery.cs:11`, `Subsumes/SubsumesQuery.cs:11`, `Translate/TranslateCodeCommand.cs:11`, with identical "Future enhancement" remarks in each handler
+**Issue**: Three copies of a doc comment explaining that a parameter does nothing. Honest, but a signature should not carry dead parameters across three operations.
+**Recommendation**: Either thread tenant into `ITerminologyService` or drop the parameter until tenant-scoped terminology exists.
+**Effort**: S
+
+### P2 — Direct JSON navigation where FHIRPath is the stated convention
+**Location**: `Ips/Strategy/DefaultIpsGenerationStrategy.cs:73-138` (`MutableNode["clinicalStatus"]` chains, `GetCodeFromCodeableConcept` taking `coding[0]` only), `Ips/Generator/IpsGeneratorHandler.cs:123-150` (`CountSections` walking `MutableNode` arrays)
+**Issue**: CLAUDE.md explicitly prefers FHIRPath over `MutableNode` navigation. `GetCodeFromCodeableConcept` also only inspects the first coding — a clinicalStatus with a non-primary coding order would mis-classify.
+**Recommendation**: Move status checks to cached FHIRPath (`element.IsTrue("clinicalStatus.coding.where(code='inactive' or code='resolved').exists()")` style) or at least scan all codings.
+**Effort**: S
+
+### P2 — `JsonDocument` instances stored in DTOs and never disposed
+**Location**: `Mcp/Tools/FhirOperations/GetResourceTool.cs:86`, `SearchResourcesTool.cs:144`, `GetResourceHistoryTool.cs:107`; `Mcp/Dtos/ResourceDto.cs`, `ResourceEntryDto.cs`
+**Issue**: `JsonDocument.Parse` rents pooled buffers returned only on `Dispose`; parking them in DTOs handed to the MCP serializer leaks pool arrays under load. `JsonElement` (clone) or raw `JsonNode` would be the right DTO currency.
+**Recommendation**: Parse to `JsonElement` via `JsonSerializer.Deserialize<JsonElement>` (as GraphQL's `FieldResolver.ParseResourceBytes` already does) or dispose after cloning the root element.
+**Effort**: S
+
+### P2 — Broken indentation block in FhirTypeModule
+**Location**: `GraphQl/Schema/FhirTypeModule.cs:373-388`
+**Issue**: The `connectionField.Resolve` lambda body is indented one level too deep relative to its siblings — cosmetic, but it's the kind of artifact `dotnet format` should have caught.
+**Recommendation**: Reformat.
+**Effort**: S
+
+### P2 — GraphQL still enabled by default despite the off-by-default decision
+**Location**: `Configuration/GraphQlExperimentalOptions.cs:12` (`Enabled = true`)
+**Issue**: The project decision (PR #277) is GraphQL off-by-default; it remains on because #277 is blocked on the config-bind timing split (see the registration-time binding finding above, which is the actual root cause to fix first).
+**Recommendation**: Land the request-time gating fix, then flip the default with #277.
+**Effort**: S (after the P1 config finding)
+
+## Graduation / Deletion Candidates
+
+| Item | Recommendation | Rationale |
+|------|-----|-----|
+| `Ignixa.Application.Operations/Features/Transform` + `Terminology` (13 files) | **Delete** (retarget tests first) | Byte-identical dead twins of the live Experimental copies; migration Phase 5 never finished |
+| `Ips/Strategy/StructureDefinitionBasedStrategy.cs` (public class) | **Delete** | Never referenced; shadowed by the factory's private nested duplicate |
+| `Ips/Metadata/SectionMetadataParser.cs` | **Keep + wire in** (or delete) | ADR-2512's named component; currently test-only while the factory carries an inline duplicate — make the factory use it, or delete it and its tests |
+| `Mcp/Tools/DiagnosticTool.cs` + `DiagnosticResult.cs` | **Delete** | Self-described phase-1 spike; discloses internal HTTP state; purpose long served |
+| `Transform/StructureMapTransformFeature.cs` | **Register or delete** | Dead in both copies; $transform silently missing from CapabilityStatement |
+| GraphQl/ (33 files) | **Graduate** (after #277) | Highest-quality, best-tested subsystem in the folder; blocked only by the off-by-default config work |
+| Terminology/ (6 files) | **Graduate** | Thin, stable wrappers over `ITerminologyService`; nothing experimental about them once the dead twins are removed |
+| Transform/ (9 files) | **Keep-Experimental** | Sync-over-async pipeline, dead cache lifetime, unreached config — needs the P1 fixes before promotion |
+| Ips/ (18 files) | **Keep-Experimental** | Broken strategy handoff and half-finished identifier lookup; the feature demonstrably doesn't do what its event handlers claim |
+| Mcp/ (31 files) | **Keep-Experimental** | Must not graduate until authorization is actually enforced (P0) |
+| `Mcp/Dtos/JobStatusDto.cs`, `JobSummaryDto.cs` | **Relocate** | Consumed by `Ignixa.Application.BackgroundOperations/JobManagement` — Experimental is not an isolation boundary while other projects import from it |
+
+## Recommendations Summary
+
+| Priority | Recommendation | Effort | Files affected |
+|----------|---------------|--------|-----------------|
+| P0 | Enforce MCP authorization: required dep in `TenantAwareMcpTool`, `Ensure*` calls in every tool, `RequireAuthorization` on `/mcp` | M | ~12 (base + 9 tools + endpoint) |
+| P0 | Fix IPS strategy handoff — service must consult the registry | S | 2 |
+| P0 | Fix patch value type mapping (decimal/JsonElement) + shared helper + tests | S | 2-3 |
+| P0 | Delete 13 dead Operations Transform/Terminology files; retarget 5 test files | S | 18 |
+| P1 | Fix or remove `MapRegistryCache` lifetime/invalidation contradiction | M | 3 |
+| P1 | Remove swallow-to-null in `ConceptMapResolverService.Translate`; document timeout limits | S | 2 |
+| P1 | Replace empty catches with logged, specific handling; dedupe `ResolveFhirVersionAsync` | S | 3 |
+| P1 | Wire or delete dead config knobs (Transform timeout, Summary limits, Mcp transport) | S | 4 |
+| P1 | Move Experimental gating from registration time to request time (unblocks #277) | M | 3-4 |
+| P1 | Delete dead `StructureDefinitionBasedStrategy`; wire `SectionMetadataParser` into the factory | S | 3 |
+| P1 | Register `StructureMapTransformFeature` (or delete) | S | 2 |
+| P1 | Implement or remove IPS identifier lookup; delete commented TODO block | S-M | 3 |
+| P1 | Standardize MCP tenant plumbing + error contract; remove duplicate ctor params; delete DiagnosticTool; fix GetResourceTool docs | M | ~10 |
+| P1 | Consolidate Experimental tests into one project; add MCP tool coverage | M | test tree |
+| P2 | One-type-per-file splits, header normalization, primary ctors, unused loggers, dead TenantId params, FHIRPath adoption in IPS, JsonDocument disposal, formatting, GraphQL default flip | S each | ~25 |

--- a/docs/features/application-layer-modernization/readme.md
+++ b/docs/features/application-layer-modernization/readme.md
@@ -1,0 +1,42 @@
+# Feature: Application Layer Modernization
+
+**Status**: Exploring
+**Created**: 2026-07-11
+
+## Problem Statement
+
+`src/Application` (Ignixa.Api, Ignixa.Api.OpenIddict, Ignixa.Application, Ignixa.Application.BackgroundOperations,
+Ignixa.Application.Operations, Ignixa.Conformance.Events, Ignixa.Domain, Ignixa.Sidecar.Contracts, Ignixa.Web —
+~743 source files) was largely built by early-generation coding agents over the project's first 6 months. It has
+never had a holistic architectural/technical review. Before continuing to build on it, we want a clear picture of:
+
+- Where it drifts from the layering rules in `docs/adr/adr-2509-vertical-slice-architecture.md` and root `CLAUDE.md`
+- Tech debt, dead code, over/under-engineering, and inconsistent patterns typical of early-agent output
+- Correctness and maintainability risks (error handling, async/cancellation, nullability, testability)
+- A prioritized, phased roadmap for remediation
+
+## Constraints
+
+- Must respect existing layer dependency direction: API → Application → Domain, DataLayer implements Domain
+- No `Hl7.Fhir.*` in Application/DataLayer (use `Ignixa.*` abstractions)
+- Minimal API only (no MVC controllers)
+- Nullable reference types enabled; warnings-as-errors
+- Changes must not require a big-bang rewrite — the server must keep running (F5 zero-dependency experience per ADR 2509)
+
+## Investigations
+
+| Investigation | Status | Summary |
+|--------------|--------|---------|
+| [api-http-layer-review](investigations/api-http-layer-review.md) | Complete | Ignixa.Api/.OpenIddict/.Web — 3 P0 (authz filter masks errors as 500, systemic authz/audit bypass on several endpoint families, OpenIddict dev-auth open in prod), 14 P1, God-file `FhirEndpoints.cs` |
+| [domain-conformance-events-review](investigations/domain-conformance-events-review.md) | Complete | Ignixa.Domain/.Conformance.Events — 1 P0 (wrong HTTP status on not-found), ~20% of Domain is dead code, ADR-2509 "no dependencies" claim is false |
+| [application-core-infra-review](investigations/application-core-infra-review.md) | Complete | Application Events/Infrastructure/Utilities + Authorization/Admin/Conformance/Metadata/Specification/Packages — 4 P0 (fail-open authz, unsynchronized ConformanceState race, R6 metadata crash, dead OIDC discovery), extensive dead "sophisticated infrastructure" |
+| [crud-vertical-slices-review](investigations/crud-vertical-slices-review.md) | Complete | Resource/Bundle/Patch/ConditionalOperations/History/Search/Compartment/Export — 8 P0 (validation never runs, If-Match unenforced, bundles not atomic, PATCH data-integrity bugs, parser PHI leak) |
+| [experimental-feature-review](investigations/experimental-feature-review.md) | Complete | Features/Experimental (103 files: GraphQL/MCP/IPS/Transform/Terminology) — legitimate staging mechanism, not a dumping ground, but 4 P0 (MCP auth dead wiring, IPS strategy handoff broken, patch value-type bug, dead duplicate files) |
+| [background-operations-review](investigations/background-operations-review.md) | Complete | BackgroundOperations/Operations/Sidecar.Contracts — 5 P0 (failed jobs reported Completed, export paths don't match storage, non-deterministic orchestration I/O, silent partial export, zero retry policy) |
+
+## Decision
+
+*No ADR yet.* Findings are synthesized into [`roadmap.md`](roadmap.md): a phased plan (0. security/data-integrity
+emergency, 1. reliability/observability, 2. layering/dead-code cleanup, 3. mechanical consistency sweep, 4. feature-fate
+decisions). Per the Transformer Mandate, this is a set of ranked options — prioritization, scope cut-line, and
+acceptance are a human call, not committed here.

--- a/docs/features/application-layer-modernization/roadmap.md
+++ b/docs/features/application-layer-modernization/roadmap.md
@@ -1,0 +1,162 @@
+# Application Layer Modernization — Roadmap
+
+**Status**: Draft for human decision (no ADR yet)
+**Created**: 2026-07-11
+**Basis**: Six independent Fable-model architecture reviews of `src/Application` (743 files / 9 projects), full findings in `investigations/*.md`.
+
+This is a menu of options, not a decision. Per the project's Transformer Mandate, prioritization and scope are a human call — this document ranks by evidence-based severity and groups by the kind of decision required, so you can pick a cut line.
+
+## Headline numbers
+
+| Subsystem | Files reviewed | P0 | P1 | P2 |
+|---|---|---|---|---|
+| API/HTTP (Ignixa.Api, .OpenIddict, .Web) | ~77 | 3 | 14 | 8 groups |
+| Domain & Conformance.Events | ~80 | 1 | 13 | 12 |
+| Application core infra + admin features | ~150 | 4 | 17 (+3 addendum) | 15 |
+| FHIR CRUD/REST vertical slices | ~120 | 8 | 19 | 9 |
+| Features/Experimental | 103 | 4 | 14 | 12 |
+| Background operations + sidecar contracts | ~75 | 5 | 13 | 10 |
+| **Total** | **~743** (some double-counted dead duplicates) | **~25** | **~90** | **~80** |
+
+For a codebase built largely by early-generation agents over 6 months with no prior holistic review, this is roughly what you'd expect: the "happy path" mostly works (it demos, F5 works, ADR macro-architecture mostly holds), and the damage is concentrated in error handling, concurrency, authorization completeness, and abandoned/superseded designs left wired into DI.
+
+## Cross-cutting root causes (read this before the phase list)
+
+The ~25 P0s and ~90 P1s are not 115 unrelated bugs. They cluster into a handful of recurring authorship patterns — fixing the pattern is cheaper than fixing each instance:
+
+1. **"Skip means pass" fail-open logic.** The FHIR authorization pipeline, the MCP tool authorization, and several endpoint-filter registrations are all built as "each check either denies or defers" with no terminal default-deny. This one shape produced 4 of the 25 P0s (API systemic bypass, core-infra fail-open pipeline, MCP dead wiring, OpenIddict dev-auth-in-prod) — plus a related but architecturally distinct gap: bundle-entry execution bypasses the middleware pipeline outright, so even a correctly-configured endpoint's authorization never runs when reached through a bundle (item 5b below).
+2. **Sophisticated infrastructure around dead code.** The composite schema provider + 4-stage debounce invalidation chain, the capability version-hash mechanism, the `MemoryCapabilityCache.ClearAsync` no-op, `MapRegistryCache`'s per-request "cache", and the Domain `Caching/` subsystem are all elaborate, plausible-looking machinery whose critical path is unreachable, uncalled, or a no-op. Roughly 800–1,000 lines fall into this category in `Ignixa.Application` alone, plus ~20% of `Ignixa.Domain`.
+3. **Wiring built on both ends, never connected in the middle.** `If-Match` is parsed by the API, carried on the command, and never read by any handler. `IValidationBehavior` targets the wrong generic type and silently never runs. IPS strategy registration resolves strategies that the generator service never looks up. Same shape, three different features.
+4. **Orchestrations/handlers designed to "never fail."** Background job orchestrations catch everything and return a failure payload instead of throwing, so `OrchestrationStatus.Failed` is unreachable and the status handler reports failed jobs as Completed. This single decision explains several background-ops P0s and P1s at once.
+5. **Exception-message-substring control flow.** At least 6 separate locations (`ex.Message.Contains("conflict")`, `"not found"`, `"already loaded"`, etc.) decide HTTP status or business branching by string-matching exception text — silently breaks the moment a message is reworded.
+6. **Tenant ID as three type systems.** `int` (routes, config, partition strategy) vs `string` (Admin commands, authorization claims) vs occasionally ignored entirely. Every seam is a parse/`ToString()` with its own failure mode; this caused real bugs (`LoadPackageHandler`'s post-hoc `int.Parse` after work already committed).
+7. **ADR/reality drift.** ADR-2509 claims Domain has "no dependencies" (false) and diagrams `ResourceKey` in Domain (it's in Core). ADR-2512 is marked "Proposed" though fully implemented. The physical folder layout (`Ignixa.Domain` living under `src/Application/`) contradicts the layer diagram every reviewer read first. Nobody has needed to correct these because nobody had read the whole layer before this.
+8. **Provenance markers, not malice.** Pervasive "Microsoft Corporation" copyright headers (this is `Ignixa Contributors`' code), `EnsureArg`/`ct` naming from the microsoft/fhir-server lineage, roadmap "Phase N" comments referencing plans that exist nowhere in the repo. Harmless individually; collectively they mean **comments in this codebase should be treated as unverified until re-checked against the code**, which several findings above depended on doing.
+
+## Phase 0 — Security & data-integrity emergency
+
+Target: before any further feature work. These are either unauthenticated access to PHI, or silent data corruption/loss on the core FHIR write path. Sequencing within the phase doesn't matter much — none depend on each other — but the security items are the ones that matter most if this server is (or will be) internet-reachable with auth enabled.
+
+### Security / auth bypass
+
+| # | Finding | Location | Effort |
+|---|---|---|---|
+| 1 | `FhirAuthorizationFilter` catch-all turns every intentional 400/404/412 into a 500 once auth is enabled — the reason the bypass below went unnoticed (tests run with auth off) | `Ignixa.Api/Filters/FhirAuthorizationFilter.cs:68-121` | S |
+| 2 | Systemic authz/audit bypass: `$export`, `$import`, admin package endpoints, system `/_history`, all agnostic operation routes never get the filter stack. **Fix constraint (verified)**: a global ASP.NET `FallbackPolicy` is *not* a sufficient alternative fix — `AspNetCorePipelineExecutor` invokes matched endpoints' `RequestDelegate`s directly for bundle entries, bypassing `AuthorizationMiddleware` entirely, so policy-based enforcement silently wouldn't apply inside bundles anyway (see item 5b). The fix must be filter-based (or the executor must run the real middleware pipeline) | `ExportEndpoints.cs`, `ImportEndpoints.cs`, `AdminPackageEndpoints.cs`, `HistoryEndpoints.cs`, `OperationEndpoints.cs`, `DeIdOperationEndpoints.cs` | M |
+| 3 | OpenIddict `/connect/authorize` auto-approves every request as `dev-user`, gated only by a config flag with no environment check; checked-in prod-shaped config ships it enabled | `Ignixa.Api.OpenIddict/Endpoints/AuthorizationEndpoints.cs`, `OpenIddictServiceExtensions.cs` | S |
+| 4 | Authorization pipeline fails open: an authenticated principal with zero roles and zero SMART scopes gets full CRUD (no terminal default-deny handler) | `Features/Authorization/Handlers/RbacAuthorizationHandler.cs`, `SmartScopeAuthorizationHandler.cs`, `FhirAuthorizationService.cs` | S |
+| 5 | MCP tool authorization is entirely dead wiring — every MCP tool (including patch and package install/uninstall) runs with no authorization check at all | `Features/Experimental/Mcp/Tools/TenantAwareMcpTool.cs` + all tool constructors | M |
+| 5b | Bundle entries bypass ASP.NET Core's middleware pipeline entirely (routing is hand-executed and the matched endpoint's `RequestDelegate` is invoked directly), and the mini `HttpContext` built for each entry never copies the parent request's `User` — so any endpoint whose authorization is enforced via middleware/endpoint metadata is silently skipped when reached through a bundle, running as an anonymous principal. A caller can write through a bundle to an endpoint they couldn't reach directly. Verified via cross-agent review handoff between the API and CRUD-slices passes | `Ignixa.Api/Infrastructure/AspNetCorePipelineExecutor.cs:108`, `Ignixa.Application/Features/Bundle/BundleEntryExecutor.cs` | M |
+
+### Silent data corruption / spec-conformance failures on the write path
+
+| # | Finding | Location | Effort |
+|---|---|---|---|
+| 6 | `ValidationBehavior` targets the wrong generic response type — **resource validation never runs on create/update**, regardless of tenant config | `Infrastructure/Behaviors/ValidationBehavior.cs`, `ApplicationServicesRegistration.cs` | S |
+| 7 | `If-Match`/optimistic concurrency is parsed everywhere and enforced nowhere — stale-version writes silently succeed | `Features/Resource/CreateOrUpdateResourceHandler.cs`, `Features/Patch/PatchResourceHandler.cs`, both conditional handlers | M |
+| 8 | Intra-bundle `urn:uuid` reference rewriting isn't implemented — transaction bundles persist literal `urn:uuid:...` strings instead of resolved references | `Features/Bundle/ReferenceResolutionContext.cs`, `BundleEntryExecutor.cs` | L |
+| 9 | Transaction bundles aren't atomic (split commit across two coordinators, one already logs "rollback not implemented"), and Phase-2 response mapping can throw/misassign responses to the wrong entry | `Features/Bundle/BundleProcessor.cs`, `BundleChannelExecutor.cs` | L |
+| 10 | Streaming batch path throws (aborting the whole batch) on any entry URL containing `?` — rejects legal `GET Patient?name=...`, `DELETE Patient?identifier=...` | `BundleChannelExecutor.cs`, `BundleProcessor.cs` | M |
+| 11 | PATCH rejects legal `identifier` patches via a substring bug (`path.Contains(".ID")` matches `PATIENT.IDENTIFIER`) | `Features/Patch/Validation/ImmutablePathChecker.cs` | S |
+| 12 | PATCH persists resources with **no search indices** and hardcodes `FhirVersion = "4.0"` regardless of tenant version — patched resources vanish from search and get silently rewritten to R4 | `Features/Patch/PatchResourceHandler.cs` | M |
+| 13 | Streaming bundle parser can't handle any JSON string token > 8KB (routine for `Binary.data`/attachments) — throws "stuck in infinite loop" and leaks raw patient data into the exception message | `Features/Bundle/Serialization/StreamingBundleParser.cs` | M |
+| 14 | Batch bundles processed via the streaming path never call `CommitAsync` — writes may be invisible/orphaned depending on backend transaction handling | `Features/Bundle/StreamingBundleContext.cs`, `BundleProcessor.cs` | S |
+| 15 | IPS `$summary`: package-registered generation strategies are resolved, logged, and silently discarded — the generator always falls back to the default strategy | `Features/Experimental/Ips/Generator/IpsGeneratorService.cs` vs `IpsGeneratorHandler.cs` | S |
+| 16 | MCP patch tools: numeric patch values are always sent as `valueString` instead of `valueDecimal`/`valueInteger` (type mismatch in the value-part builder) | `Features/Experimental/Mcp/Tools/FhirOperations/PatchResourceTool.cs` | S |
+| 17 | `ResourceNotFoundException` returns HTTP 400 instead of 404 (base `StatusCode` never overridden); `MethodNotAllowedException` similarly wrong | `Ignixa.Domain/Exceptions/ResourceNotFoundException.cs` | S |
+
+### Availability / crash / reliability
+
+| # | Finding | Location | Effort |
+|---|---|---|---|
+| 18 | `/metadata` (and every capability-enforced request) crashes for R6 tenants — version-string switch omits R6 despite R6 being otherwise wired | `Features/Metadata/Segments/OperationsSegment.cs` | S |
+| 19 | OIDC discovery deserialization can't bind RFC 8414 snake_case fields — SMART configuration discovery is dead on arrival for every fetch | `Features/Authorization/Services/OidcDiscoverySmartConfigurationProvider.cs` | S |
+| 20 | `ConformanceState`: writers lock, readers don't — plain `Dictionary` read concurrent with locked writes on the request hot path (can throw or return corrupt state) | `Features/Conformance/ConformanceState.cs`, `ActiveSearchParameter.cs` | M |
+| 21 | Two eternal orchestrations (TransactionWatcher, TtlCleanup) perform non-deterministic tenant-store I/O directly inside `RunTask` — a DurableTask determinism violation | `TransactionWatcherOrchestration.cs`, `TtlCleanupOrchestration.cs` | M |
+| 22 | Failed background jobs are reported as Completed — orchestrations swallow exceptions into a "Completed" state with a failure payload; the status handler never inspects it | `Jobs/GetJobStatusHandler.cs`, `ImportOrchestration.cs`, `ExportOrchestration.cs` | M |
+| 23 | Export job results record `tenant/...` paths while workers write to `partition/...` — every reported bulk-export output file is a 404 | `Export/Orchestrations/ExportOrchestration.cs` | S |
+| 24 | Type-less `$export` silently exports only 6 hardcoded resource types instead of "all", contradicting both the command's own doc and the bulk-export spec | `ExportOrchestration.cs` | S/M |
+| 25 | Zero retry policy anywhere in background operations (`ScheduleWithRetry` unused) — the entire fault-tolerance justification for choosing DurableTask (ADR 2510) is unimplemented | all orchestrations | M |
+
+**13 dead byte-identical duplicate files** (`Ignixa.Application.Operations/Features/{Transform,Terminology}`) are flagged separately below (Phase 2) — not a correctness bug today, but the reason two of the fixes above (FHIRPath timeout, ConceptMap null-swallow) need to be applied to the *live* copy only, and the dead copy deleted so it can't silently diverge.
+
+## Phase 1 — Reliability & observability
+
+Once Phase 0 stops active bleeding, these fix the "we can't tell what's broken" problem — mostly background-ops and cross-cutting audit/metrics debt:
+
+- Fix the failure-channel inversion in background jobs properly (orchestrations throw; status handler reconciles from real DurableTask state) — this one change collapses several P1s (empty catch compensation blocks, progress reporting, zombie-job detection).
+- Replace fake fire-and-forget audit/metrics (`SidecarAuditLogger`, `FhirAuditFilter`/`FhirMetricsFilter`) with a real bounded-channel background flusher; stop fabricating audit field values (hardcoded `127.0.0.1`, invented status codes).
+- Add job cancellation (`TerminateAsync` + cooperative checks in long loops) — nothing can currently stop a multi-hour export.
+- Cap/stream import error accumulation instead of buffering full resource JSON (PHI) through orchestration state; write import error logs to blob storage, not local disk.
+- Fix denied/unauthenticated requests never being audited (filter ordering).
+- Deterministic IDs for ID-less import rows so retries (once retry policy exists) don't duplicate data.
+- MemberMatch: match on `system|value`, not bare value — current behavior risks a wrong-patient match.
+- Patient `$everything` truncates at 50 with no paging signal — make truncation visible at minimum.
+
+Full list: see each investigation's P1 table, especially `background-operations-review.md` and `application-core-infra-review.md`.
+
+## Phase 2 — Layering & dead-code cleanup
+
+This is where the codebase gets meaningfully smaller and the ADR stops lying. No user-facing behavior change; mechanical or near-mechanical once each decision below is made (some require a one-line "graduate or delete" call):
+
+**Delete outright** (verified zero live references):
+- Domain `Caching/` subsystem (4 files) — dead, registered in DI, contains a cache-poisoning bug and a silent no-op invalidation
+- 6 dead `Term*` terminology model classes in Domain (~350 lines, superseded by DataLayer entities)
+- `BulkImportJob`, vestigial `TenantContext` (Domain)
+- Composite schema provider eager-load path + its 4-stage debounce invalidation chain (`CompositeStructureDefinitionSummaryProvider`, `CompositeSchemaProviderRegistry`, `DebounceInvalidationStrategy`) — **or** finish it; it currently does nothing (zero callers, `ToTypeDefinition` is a stub)
+- Capability version-hash mechanism (`ICapabilitySegment.GetVersionHashAsync` across 6 segments) — the mismatch branch is structurally unreachable
+- `MemoryCapabilityCache.ClearAsync` no-op + 3 unused `ICapabilityCacheInvalidator` methods
+- 13 dead byte-identical Transform/Terminology files in `Ignixa.Application.Operations` (retarget the 5 test files that currently cover only the dead copies)
+- `Ips/Strategy/StructureDefinitionBasedStrategy.cs` (shadowed dead public class), `Mcp/Tools/DiagnosticTool.cs` (phase-1 spike exposing internal HTTP state)
+- ~15 miscellaneous dead files/methods catalogued in the background-ops and API reviews (unused activities, unreferenced helpers, commented-out pseudo-code blocks)
+
+**Architectural decisions needed** (pick one path, don't leave both):
+- `Ignixa.Domain`/`Ignixa.Conformance.Events` physically live under `src/Application/` while all DataLayer projects depend on them, and ADR-2509 claims "no dependencies" (false — it references `Ignixa.Search`, `Caching.Memory`). Either move the projects to a `src/Domain/` sibling or amend the ADR to document the real, intentional dependency set.
+- `Ignixa.DataLayer.SqlEntityFramework` has a project reference to `Ignixa.Application` (package/terminology event contracts) — violates the documented dependency direction. Move those event contracts to Domain.
+- `HttpContext` and ASP.NET Core packages are compiled into `Ignixa.Application` (`FhirAuthorizationContext.HttpContext`, `IPipelineExecutor`, `FhirVersionExtractor`) — makes the authorization pipeline untestable without a web server. Project the specific HTTP facts needed (method, correlation id) instead of the whole context.
+- Terminology import activity constructs concrete SQL DataLayer types directly from the Application layer (service-locates `SqlEntityFrameworkRepositoryFactory`, hand-builds raw SQL) — define `ITerminologyImportStore` in Domain, implement in SqlEntityFramework.
+- `MapRegistryCache` (Transform) is built as a long-lived cache but registered per-request-scope, so its entire cache/TTL/invalidation apparatus is inert — decide singleton-keyed-by-tenant vs. delete the machinery.
+- `IPackageResourceRepository` is an 18-method god interface accreted one method per feature — split into lifecycle vs. query-lookup interfaces.
+
+**ADR hygiene**: amend ADR-2509's dependency claims, flip ADR-2512 from "Proposed" to "Accepted" (it's fully implemented), fix the Conformance.Events published README (documents 4 event types that don't exist).
+
+## Phase 3 — Consistency sweep (mechanical, batchable)
+
+Every review found the same style-drift issues, attributable to different code having been written by different agent generations. None of these are individually urgent; all are cheap to fix in bulk with a script/analyzer pass rather than a manual PR per file:
+
+- Rename `ct` → `cancellationToken` (CLAUDE.md calls this out explicitly as a critical violation; ~10+ files, mechanical Roslyn rename)
+- One-type-per-file splits (~50+ files across all six reviews)
+- Seal classes by default (~40+ classes never designed for inheritance)
+- Copyright header normalization — most files claim "Microsoft Corporation," this is Ignixa's code (legal-hygiene issue, not just style)
+- Replace stringly-typed state (`JobStatus`, `ImportMode`, `ValidationDepth`, storage/search provider types) with enums — several are magic strings that compile a typo into a runtime bug
+- Re-enable suppressed Roslyn analyzers currently NoWarn'd that would have caught several findings above (CA1031 broad-catch, CA1852 seal-types, CA1508 dead-conditions)
+- Delete stray "Phase N" roadmap comments referencing plans that exist nowhere in the repo (including one citing an ADR number that doesn't exist)
+
+## Phase 4 — Feature-fate decisions (need a product/eng call, not just a fix)
+
+These aren't bugs so much as "is this thing supposed to exist" questions the reviews surfaced:
+
+| Feature | Current state | Options |
+|---|---|---|
+| GraphQL (`Features/Experimental/GraphQl`, 33 files) | Highest-quality, best-tested code in the whole layer; blocked from graduating only by the registration-time config-binding issue (the same one blocking PR #277 off-by-default) | Fix config-bind timing, then graduate out of Experimental |
+| Terminology (`Features/Experimental/Terminology`, 6 files) | Thin, stable wrappers; nothing experimental about them once the dead Operations duplicates are removed | Graduate |
+| Transform (`Features/Experimental/Transform`, 9 files) | Real feature, but sync-over-async FHIRPath timeout that doesn't cancel, dead-lifetime cache, unread config | Fix P1s first, then reconsider |
+| IPS `$summary` (`Features/Experimental/Ips`, 18 files) | Broken strategy handoff (Phase 0 #15), half-finished identifier lookup that always throws | Needs the P0 fix + a decision on identifier lookup (implement or remove the parameter) |
+| MCP (`Features/Experimental/Mcp`, 31 files) | Must not graduate until authorization is enforced (Phase 0 #5) | Fix, then reassess |
+| Composite schema provider eager-load | Zero callers, stub conversion method | Implement (if package-profile type resolution is actually wanted) or delete (Phase 2) |
+| Capability version-hash validation | Structurally unreachable | Delete (Phase 2) — the segments' hash computation is nontrivial and entirely unused |
+
+## What this review deliberately didn't do
+
+- No code was changed. This is read-only analysis in an isolated worktree (`worktree-application-layer-review`).
+- `src/Core` and `src/DataLayer` were out of scope except where an Application-layer finding required tracing a reference into them (e.g., the DataLayer→Application layering violation, the SQL terminology entity duplication). A DataLayer-focused pass would likely surface its own findings — the background-ops review flagged one open question (transaction heartbeat semantics under long-running imports) that needs DataLayer-side verification.
+- Findings are as-observed on 2026-07-11; no attempt was made to check whether any have already been fixed on other branches.
+
+## Source material
+
+- [`investigations/api-http-layer-review.md`](investigations/api-http-layer-review.md)
+- [`investigations/domain-conformance-events-review.md`](investigations/domain-conformance-events-review.md)
+- [`investigations/application-core-infra-review.md`](investigations/application-core-infra-review.md)
+- [`investigations/crud-vertical-slices-review.md`](investigations/crud-vertical-slices-review.md)
+- [`investigations/experimental-feature-review.md`](investigations/experimental-feature-review.md)
+- [`investigations/background-operations-review.md`](investigations/background-operations-review.md)


### PR DESCRIPTION
## Summary

Six parallel Fable-model architecture reviews of `src/Application` (743 files across 9 projects: Ignixa.Api, Ignixa.Api.OpenIddict, Ignixa.Application, Ignixa.Application.BackgroundOperations, Ignixa.Application.Operations, Ignixa.Conformance.Events, Ignixa.Domain, Ignixa.Sidecar.Contracts, Ignixa.Web), synthesized into a phased improvement roadmap. This is docs only — no source code changes.

Headline: **~25 P0s, ~90 P1s, ~80 P2s**. Macro architecture (ADR 2509's vertical-slice shape, no `Hl7.Fhir.*` in Application, minimal API, mediator dispatch) mostly holds. Findings cluster into recurring patterns rather than random rot:

- **Auth fails open, repeatedly**: bulk export/import/admin endpoints skip the authorization filter stack; the authorization pipeline grants access to any authenticated principal with zero roles/scopes; MCP tools have an authorization service that's never called; OpenIddict auto-approves every token request behind a config flag with no environment gate; bundle entries bypass ASP.NET Core's authorization middleware entirely and run as an anonymous principal.
- **The write path silently corrupts or drops data**: resource validation doesn't run on create/update (wrong generic type in the pipeline registration), `If-Match` concurrency is parsed and never enforced, transaction bundles aren't atomic and don't rewrite intra-bundle references, PATCH drops search indices and rejects legal `identifier` patches.
- **Background jobs misreport their own status**: failures get swallowed into "Completed", export result paths don't match where files are actually written, there's no retry policy anywhere despite that being the reason ADR 2510 chose DurableTask.
- **Sophisticated-looking dead infrastructure**: a capability cache-invalidation system, a schema eager-load path, ~20% of `Ignixa.Domain`, all registered in DI and doing nothing.
- **Layering ADR drift**: Domain claims "no dependencies" but has some; DataLayer references Application; HttpContext is compiled into the Application assembly.

## What's included

- `docs/features/application-layer-modernization/readme.md` — feature area index
- `docs/features/application-layer-modernization/roadmap.md` — phased plan: Phase 0 (security/data-integrity emergency) → Phase 1 (reliability/observability) → Phase 2 (layering/dead-code cleanup) → Phase 3 (mechanical consistency sweep) → Phase 4 (Experimental feature-fate decisions)
- `docs/features/application-layer-modernization/investigations/*.md` — six per-subsystem findings files with file:line citations (api-http-layer, domain-conformance-events, application-core-infra, crud-vertical-slices, experimental-feature, background-operations)

Per the project's Transformer Mandate, this is a set of ranked options, not a committed decision — prioritization and scope are a human call.

## Test plan

- [ ] Docs-only change; no build/test impact
- [ ] Human review of roadmap prioritization and phase cut-lines before any implementation work begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)