### PR TITLE
Add auth header, make FHIR TestReport the default conformance CLI output

### DIFF
--- a/docs/site/docs/core-sdk/testscript.md
+++ b/docs/site/docs/core-sdk/testscript.md
@@ -55,6 +55,22 @@ var testReport = TestReportResourceGenerator.Generate(report);
 Console.WriteLine(testReport.ToJsonString());
 ```
 
+`Generate` takes an optional `TestReportContext` carrying the facts the engine cannot infer from the
+run itself — who executed the script, which server was exercised, and what to call the script. Supply
+it to populate `tester`, the `server` participant, and `testScript.display`:
+
+```csharp
+var testReport = TestReportResourceGenerator.Generate(report, new TestReportContext
+{
+    Tester = "my-server",
+    ServerUri = "https://your-fhir-server",
+    TestScriptDisplay = "Search/intervals.json"
+});
+```
+
+Omitting it is fine: `testScript.display` falls back to the script's name, and the `server`
+participant is dropped rather than emitted with a placeholder URI.
+
 The parser is strict: unknown assert operators, unsupported criteria fields, malformed actions, and
 type-mismatched fields all produce `ParseSeverity.Error` entries rather than silently changing test
 semantics. Always check `IsSuccess` and surface `Errors` — a script that fails to parse never reaches
@@ -259,14 +275,21 @@ merges per-implementation reports into a published conformance matrix:
 ```bash
 dotnet tool install -g Ignixa.ConformanceMatrix.Cli
 
-# Run a conformance suite against a server, producing a per-impl report
+# Run a conformance suite against a server, writing a Bundle of FHIR TestReport resources
 ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
   --impl my-server --out ./reports/my-server.json
+
+# merge reads the native per-impl report, not TestReport, so ask for --format json
+ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
+  --impl my-server --out ./reports/my-server.json --format json
 
 # Merge per-impl reports into the matrix (runs/ + index.json)
 ignixa-matrix merge --results ./reports --out ./matrix \
   --commit "$(git rev-parse HEAD)" --branch main
 ```
+
+`--out` is always the report file; `--format` chooses its shape — `fhir` (default) for a `Bundle` of
+`TestReport` resources, or `json` for the native per-impl report that `merge` consumes.
 
 `run` exits non-zero when any test fails *or errors* (an engine/transport error is never reported as
 a pass), prints parse warnings per file, and records crashed scripts as `error` cells rather than

--- a/docs/superpowers/plans/2026-07-13-conformance-cli-auth-and-testreport-plan.md
+++ b/docs/superpowers/plans/2026-07-13-conformance-cli-auth-and-testreport-plan.md
@@ -1,0 +1,180 @@
+# Conformance CLI Auth Header and TestReport Output Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the conformance CLI with opt-in auth-header support and FHIR TestReport output while preserving the existing matrix report behavior.
+
+**Architecture:** Add two new options to the `run` command, apply the auth header to the shared `HttpClient` used by the TestScript engine, and serialize each executed `TestScriptReport` into a FHIR `TestReport` resource or a `Bundle` collection when multiple scripts run.
+
+**Tech Stack:** C#, .NET 10, System.CommandLine, Ignixa.TestScript, System.Text.Json.Nodes
+
+---
+
+### Task 1: Add auth-header parsing helpers and tests
+
+**Files:**
+- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
+- Modify: `test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs`
+
+- [ ] **Step 1: Write failing tests for auth header normalization**
+
+```csharp
+[Fact]
+public void GivenBareTokenValue_WhenNormalizingAuthHeader_ThenUsesAuthorizationHeader()
+{
+    var (name, value) = RunCommand.ParseAuthHeader("Bearer abc123");
+
+    name.ShouldBe("Authorization");
+    value.ShouldBe("Bearer abc123");
+}
+
+[Fact]
+public void GivenExplicitHeaderValue_WhenNormalizingAuthHeader_ThenPreservesHeaderName()
+{
+    var (name, value) = RunCommand.ParseAuthHeader("X-Test: value");
+
+    name.ShouldBe("X-Test");
+    value.ShouldBe("value");
+}
+```
+
+- [ ] **Step 2: Run the focused CLI tests to verify they fail**
+
+Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
+Expected: FAIL because `ParseAuthHeader` does not exist yet.
+
+- [ ] **Step 3: Implement auth-header parsing and application**
+
+```csharp
+internal static (string Name, string Value) ParseAuthHeader(string input)
+{
+    var trimmed = input.Trim();
+    if (trimmed.Contains(':') && !trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) &&
+        !trimmed.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+    {
+        var parts = trimmed.Split(new[] { ':' }, 2);
+        return (parts[0].Trim(), parts[1].Trim());
+    }
+
+    return ("Authorization", trimmed);
+}
+```
+
+- [ ] **Step 4: Run the focused CLI tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
+Expected: PASS
+
+### Task 2: Add the new CLI options and wire them into the run flow
+
+**Files:**
+- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
+- Modify: `tools/Ignixa.ConformanceMatrix.Cli/README.md`
+
+- [ ] **Step 1: Add CLI options for auth and TestReport output**
+
+```csharp
+var authHeaderOption = new Option<string?>("--auth-header")
+{
+    Description = "Authentication header value to apply to every request (for example 'Bearer <token>' or 'Authorization: Bearer <token>')"
+};
+
+var testReportOption = new Option<string?>("--test-report")
+{
+    Description = "Optional path to write a FHIR TestReport JSON resource or Bundle"
+};
+```
+
+- [ ] **Step 2: Pass the new values into the run method and apply the header to the `HttpClient`**
+
+```csharp
+var authHeader = parseResult.GetValue(authHeaderOption);
+var testReportPath = parseResult.GetValue(testReportOption);
+return RunAsync(server, tests, impl, outPath, fhirVersion, authHeader, testReportPath, cancellationToken);
+```
+
+- [ ] **Step 3: Update the command help text and README examples**
+
+Add examples showing `--auth-header` and `--test-report` to `tools/Ignixa.ConformanceMatrix.Cli/README.md`.
+
+### Task 3: Generate FHIR TestReport output files
+
+**Files:**
+- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
+- Modify: `test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs`
+
+- [ ] **Step 1: Write failing tests for TestReport payload assembly**
+
+```csharp
+[Fact]
+public void GivenSingleReport_WhenBuildingPayload_ThenReturnsTestReportResource()
+{
+    var payload = RunCommand.BuildTestReportPayload([new JsonObject { ["resourceType"] = "TestReport" }]);
+    payload.ShouldNotBeNull();
+    payload! ["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
+}
+
+[Fact]
+public void GivenMultipleReports_WhenBuildingPayload_ThenReturnsBundleCollection()
+{
+    var payload = RunCommand.BuildTestReportPayload([
+        new JsonObject { ["resourceType"] = "TestReport" },
+        new JsonObject { ["resourceType"] = "TestReport" }
+    ]);
+
+    payload.ShouldNotBeNull();
+    payload!["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
+    payload["type"]!.GetValue<string>().ShouldBe("collection");
+}
+```
+
+- [ ] **Step 2: Run the focused CLI tests to verify they fail**
+
+Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
+Expected: FAIL because `BuildTestReportPayload` does not exist yet.
+
+- [ ] **Step 3: Implement payload assembly and file writing**
+
+```csharp
+internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports)
+{
+    if (reports.Count == 1)
+        return reports[0];
+
+    return new JsonObject
+    {
+        ["resourceType"] = "Bundle",
+        ["type"] = "collection",
+        ["entry"] = new JsonArray(reports.Select(report => new JsonObject { ["resource"] = report }).ToArray())
+    };
+}
+```
+
+- [ ] **Step 4: Run the focused CLI tests to verify they pass**
+
+Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
+Expected: PASS
+
+### Task 4: Validate the end-to-end CLI flow
+
+**Files:**
+- No new files; run the existing CLI against a server
+
+- [ ] **Step 1: Run the CLI against the deployed server with both new options**
+
+```bash
+dotnet run --project tools/Ignixa.ConformanceMatrix.Cli/Ignixa.ConformanceMatrix.Cli.csproj -- run \
+  --server https://bkowitz-testdeploy.azurewebsites.net \
+  --tests <testscripts-folder> \
+  --impl bkowitz-testdeploy \
+  --out ./reports/bkowitz-testdeploy.json \
+  --auth-header "Bearer <token>" \
+  --test-report ./reports/bkowitz-testdeploy.testreport.json
+```
+
+- [ ] **Step 2: Inspect the generated TestReport file and confirm the payload is valid JSON**
+
+- [ ] **Step 3: Run the full CLI tests for the conformance tool**
+
+Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj -v minimal`
+Expected: PASS

--- a/docs/superpowers/plans/2026-07-13-conformance-cli-auth-and-testreport-plan.md
+++ b/docs/superpowers/plans/2026-07-13-conformance-cli-auth-and-testreport-plan.md
@@ -1,180 +1,163 @@
-# Conformance CLI Auth Header and TestReport Output Plan
+# Conformance CLI Auth Header and FHIR Output — As-Built
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers: DELIVERED — do not implement this plan.** The work shipped in PR #342
+> (`695a65b5`, `88c13004`, `61e22c78`, `ee223860`). This file has been rewritten to describe the
+> design **as built**, because what shipped diverged substantially from what was originally planned.
+> Read it as a record of decisions and their reasons, not as a task list. The paired design doc is
+> `docs/superpowers/specs/2026-07-13-conformance-cli-auth-and-testreport-design.md`.
 
-**Goal:** Extend the conformance CLI with opt-in auth-header support and FHIR TestReport output while preserving the existing matrix report behavior.
+**Goal:** Add authentication support to `ignixa-matrix run` and make FHIR `TestReport` its default
+output.
 
-**Architecture:** Add two new options to the `run` command, apply the auth header to the shared `HttpClient` used by the TestScript engine, and serialize each executed `TestScriptReport` into a FHIR `TestReport` resource or a `Bundle` collection when multiple scripts run.
-
-**Tech Stack:** C#, .NET 10, System.CommandLine, Ignixa.TestScript, System.Text.Json.Nodes
+**Tech Stack:** C#, .NET 10, System.CommandLine 2.0.1, Ignixa.TestScript, System.Text.Json.Nodes
 
 ---
 
-### Task 1: Add auth-header parsing helpers and tests
+## How the shipped design differs from the original plan
 
-**Files:**
-- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
-- Modify: `test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs`
+The original plan proposed a `--test-report <path>` option alongside `--out`. **That is not what
+shipped and should not be reintroduced.** Two output paths can disagree with each other; `--out` is
+now the single report file and `--format` selects its shape.
 
-- [ ] **Step 1: Write failing tests for auth header normalization**
+| Original plan | As built |
+|---|---|
+| `--test-report <path>` as a second output path | `--format <fhir\|json>`; `--out` is the only path |
+| Matrix JSON was the only/default output | `fhir` is the **default**; `json` is the matrix shape |
+| Bare `TestReport` for one script, `Bundle` for many | **Always** a `Bundle` |
+| `ParseAuthHeader` hardcodes `Bearer`/`Basic`/`Digest` | No scheme list — see below |
 
-```csharp
-[Fact]
-public void GivenBareTokenValue_WhenNormalizingAuthHeader_ThenUsesAuthorizationHeader()
-{
-    var (name, value) = RunCommand.ParseAuthHeader("Bearer abc123");
+---
 
-    name.ShouldBe("Authorization");
-    value.ShouldBe("Bearer abc123");
-}
+## Decisions and their reasons
 
-[Fact]
-public void GivenExplicitHeaderValue_WhenNormalizingAuthHeader_ThenPreservesHeaderName()
-{
-    var (name, value) = RunCommand.ParseAuthHeader("X-Test: value");
+Each of these was a real bug found in review. Re-introducing any of them repeats a defect.
 
-    name.ShouldBe("X-Test");
-    value.ShouldBe("value");
-}
-```
+### `--format`, not a second output path
 
-- [ ] **Step 2: Run the focused CLI tests to verify they fail**
+`--format fhir` (default) writes a `Bundle` (`type: collection`) of `TestReport` resources.
+`--format json` writes the native `ImplReport` — the shape `merge` deserializes. **`merge` only
+consumes `json`**; handed a Bundle it fails loudly (`JsonException`, non-zero exit) rather than
+producing a wrong matrix. Any pipeline feeding `merge` must pass `--format json`.
 
-Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
-Expected: FAIL because `ParseAuthHeader` does not exist yet.
+The `json` shape is byte-compatible with [fhir262](https://github.com/HealthSamurai/fhir262)'s
+reporter output. Keep it that way; that compatibility is the point of the format existing.
 
-- [ ] **Step 3: Implement auth-header parsing and application**
+### `ParseAuthHeader` must not enumerate schemes
 
-```csharp
-internal static (string Name, string Value) ParseAuthHeader(string input)
-{
-    var trimmed = input.Trim();
-    if (trimmed.Contains(':') && !trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) &&
-        !trimmed.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
-    {
-        var parts = trimmed.Split(new[] { ':' }, 2);
-        return (parts[0].Trim(), parts[1].Trim());
-    }
+An HTTP header name cannot contain whitespace. Text before the first colon with no whitespace is a
+header name; anything else is a bare credential for `Authorization`. This handles `Negotiate`,
+`NTLM`, `AWS4-HMAC-SHA256`, and credentials containing colons without listing schemes. The original
+hardcoded `Bearer`/`Basic`/`Digest` list broke on every scheme not on it.
 
-    return ("Authorization", trimmed);
-}
-```
+### `ApplyAuthHeader` must fail, never return quietly
 
-- [ ] **Step 4: Run the focused CLI tests to verify they pass**
+Applying no header runs the whole suite unauthenticated and reports every 401 as a legitimate test
+failure — indistinguishable from a broken server. Two traps, both of which shipped broken once:
 
-Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
-Expected: PASS
+- **Guard on `authHeader is null`, not `IsNullOrWhiteSpace`.** An omitted flag is `null` and means
+  "no auth"; an explicit `""` is a mistake worth reporting — usually an env var that expanded to
+  nothing, which is the common CI failure. `IsNullOrWhiteSpace` conflates them and made the
+  empty-value guard below unreachable for the only input that matters.
+- **Check `TryAddWithoutValidation`'s return.** It returns `false` — it does not throw — for a name
+  that is not a valid HTTP token (e.g. `Api@Key`), silently dropping the credential.
 
-### Task 2: Add the new CLI options and wire them into the run flow
+### FHIR validity rules that keep getting missed
 
-**Files:**
-- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
-- Modify: `tools/Ignixa.ConformanceMatrix.Cli/README.md`
+The generator's whole purpose is valid FHIR. These were each violated at least once:
 
-- [ ] **Step 1: Add CLI options for auth and TestReport output**
+- **No empty arrays.** FHIR JSON prohibits them. `Bundle.entry` is omitted when there are no
+  resources, not emitted as `[]`.
+- **No null-valued object properties.** FHIR permits `null` only *inside* arrays, to align a
+  primitive with its `_`-prefixed extension. `test.description` is omitted when absent.
+- **`TestReport.testScript` is 1..1.** Always emitted. A relative file path goes in `display`, never
+  `reference` — a relative `Reference.reference` is parsed as `[type]/[id]`, so
+  `Search/intervals.json` would read as a resource of type `Search`.
+- **`Bundle.entry.fullUrl` must be absolute** and agree with `Resource.id`. These TestReports are
+  never persisted and carry no `id`, so `urn:uuid:` is the correct form. It is also collision-free,
+  unlike the slugified path it replaced.
 
-```csharp
-var authHeaderOption = new Option<string?>("--auth-header")
-{
-    Description = "Authentication header value to apply to every request (for example 'Bearer <token>' or 'Authorization: Bearer <token>')"
-};
+### `TestReport.tester` is the tool, not the server
 
-var testReportOption = new Option<string?>("--test-report")
-{
-    Description = "Optional path to write a FHIR TestReport JSON resource or Bundle"
-};
-```
+Verbatim R4: *"Name of the tester producing this report (Organization or individual)."* That is
+`Ignixa.ConformanceMatrix.Cli`. The server under test is `participant[server]`, and `--impl` belongs
+in that participant's `display`. Setting `tester = impl` made the report claim the server tested
+itself. **Note:** ignixa-lab's `frontend/src/lib/testReport.ts` has this bug. Its shape is otherwise
+the reference for ours — do not copy this part of it, nor its encoding of the impl name into the
+`test-engine` participant URI.
 
-- [ ] **Step 2: Pass the new values into the run method and apply the header to the `HttpClient`**
+### `score` excludes skipped tests
 
-```csharp
-var authHeader = parseResult.GetValue(authHeaderOption);
-var testReportPath = parseResult.GetValue(testReportOption);
-return RunAsync(server, tests, impl, outPath, fhirVersion, authHeader, testReportPath, cancellationToken);
-```
+`TestScriptReport.OverallOutcome` has no `Skip` branch, so an all-skipped script reports
+`result: "pass"`. Counting skips as misses therefore produced `"result": "pass"` with `"score": 0` —
+a self-contradicting resource — for exactly the scripts that `fhirVersion` gating and
+`requiresCapability` are designed to skip. It also disagreed with `MatrixBuilder`, which keeps
+skipped out of both pass and fail, so the two formats scored the same run differently. Skips are out
+of both numerator and denominator; `score` is omitted entirely (it is 0..1) when nothing was scored.
 
-- [ ] **Step 3: Update the command help text and README examples**
+### Scripts that never ran become `OperationOutcome`, not `TestReport`
 
-Add examples showing `--auth-header` and `--test-report` to `tools/Ignixa.ConformanceMatrix.Cli/README.md`.
+A file that failed to parse was never a TestScript, and `TestReport.testScript` references the script
+that was executed — so there is no honest TestReport to write. Without an entry, a suite whose
+scripts all failed to parse wrote a `Bundle` with no entries, indistinguishable from a clean run of
+nothing.
 
-### Task 3: Generate FHIR TestReport output files
+**Do not use `TestReport.status = "entered-in-error"` for this.** Its official definition is *"This
+test report was entered or created in error"* — a retraction, asserting the report should not exist.
+`stopped` is *"manually stopped"*. `completed` is *"all test operations have completed"*, false when
+none ran. There is no status code for "could not read the script" because the resource cannot express
+it.
 
-**Files:**
-- Modify: `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs`
-- Modify: `test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs`
+`OperationOutcome` is the FHIR-native carrier, and `Bundle.type = collection` has no homogeneity
+constraint, so the two coexist legally:
 
-- [ ] **Step 1: Write failing tests for TestReport payload assembly**
+- parse failure → `code: "structure"` — *"unable to parse the content completely, invalid syntax"*
+- evaluator exception → `code: "exception"` — *"An unexpected internal error has occurred"*
 
-```csharp
-[Fact]
-public void GivenSingleReport_WhenBuildingPayload_ThenReturnsTestReportResource()
-{
-    var payload = RunCommand.BuildTestReportPayload([new JsonObject { ["resourceType"] = "TestReport" }]);
-    payload.ShouldNotBeNull();
-    payload! ["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
-}
+### `TestReportContext` owns its own invariants
 
-[Fact]
-public void GivenMultipleReports_WhenBuildingPayload_ThenReturnsBundleCollection()
-{
-    var payload = RunCommand.BuildTestReportPayload([
-        new JsonObject { ["resourceType"] = "TestReport" },
-        new JsonObject { ["resourceType"] = "TestReport" }
-    ]);
+Blank and whitespace-only strings normalize to `null` in the init accessors, so "absent" has exactly
+one representation. Before this, the generator's three consumption sites each invented their own
+answer and one emitted `"display": ""`. `ServerUri` is a `Uri` and rejects a relative one at
+construction — `Uri` permits `UriKind.Relative`, which `participant.uri` does not.
 
-    payload.ShouldNotBeNull();
-    payload!["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
-    payload["type"]!.GetValue<string>().ShouldBe("collection");
-}
-```
+`Ignixa.TestScript` is a **packable** library. `Generate(report, context = null)` must keep working
+with `context` omitted (`EndToEndTests.cs`, `docs/site/docs/core-sdk/testscript.md` call it that
+way), and changing a public member's type is breaking once released.
 
-- [ ] **Step 2: Run the focused CLI tests to verify they fail**
+### Exit codes
 
-Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
-Expected: FAIL because `BuildTestReportPayload` does not exist yet.
+| Code | Meaning |
+|------|---------|
+| `0` | Every test passed or was skipped. |
+| `1` | The suite ran; at least one test failed or errored. |
+| `2` | Usage error — unusable `--tests`, `--server`, `--auth-header`, or `--out`. Nothing ran. |
+| `3` | Unexpected internal failure; the full exception is printed. |
 
-- [ ] **Step 3: Implement payload assembly and file writing**
+CI otherwise cannot tell "auth misconfigured, nothing ran" from "the suite ran and 3 tests failed".
+`--out` is validated **before** the suite runs so a typo cannot discard a completed run.
 
-```csharp
-internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports)
-{
-    if (reports.Count == 1)
-        return reports[0];
+---
 
-    return new JsonObject
-    {
-        ["resourceType"] = "Bundle",
-        ["type"] = "collection",
-        ["entry"] = new JsonArray(reports.Select(report => new JsonObject { ["resource"] = report }).ToArray())
-    };
-}
-```
+## Where the code lives
 
-- [ ] **Step 4: Run the focused CLI tests to verify they pass**
+| Concern | File |
+|---|---|
+| CLI options, run loop, payload/format selection, auth | `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs` |
+| `--format` values | `tools/Ignixa.ConformanceMatrix.Cli/Commands/ReportFormat.cs` |
+| `OperationOutcome` for never-run scripts | `tools/Ignixa.ConformanceMatrix.Cli/Reporting/OperationOutcomeResourceGenerator.cs` |
+| `TestReport` generation | `src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs` |
+| Run-scoped context for the above | `src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs` |
+| Native report shape (`merge` input) | `tools/Ignixa.ConformanceMatrix.Cli/Reporting/ImplReport.cs` |
+| Tests | `test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs`, `test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs` |
 
-Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests -v minimal`
-Expected: PASS
+## Known gaps (not defects — deliberately deferred)
 
-### Task 4: Validate the end-to-end CLI flow
-
-**Files:**
-- No new files; run the existing CLI against a server
-
-- [ ] **Step 1: Run the CLI against the deployed server with both new options**
-
-```bash
-dotnet run --project tools/Ignixa.ConformanceMatrix.Cli/Ignixa.ConformanceMatrix.Cli.csproj -- run \
-  --server https://bkowitz-testdeploy.azurewebsites.net \
-  --tests <testscripts-folder> \
-  --impl bkowitz-testdeploy \
-  --out ./reports/bkowitz-testdeploy.json \
-  --auth-header "Bearer <token>" \
-  --test-report ./reports/bkowitz-testdeploy.testreport.json
-```
-
-- [ ] **Step 2: Inspect the generated TestReport file and confirm the payload is valid JSON**
-
-- [ ] **Step 3: Run the full CLI tests for the conformance tool**
-
-Run: `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj -v minimal`
-Expected: PASS
+- **`/metadata` 401/403 fails open.** A rejected credential still runs the whole suite, producing the
+  "every test 401s" outcome the auth guards exist to prevent. Narrow to auth-specific statuses, or
+  detect systemic auth failure across the run. No conformance test currently expects a 401, so a
+  detector would not false-positive today.
+- **Setup-failure granularity differs between formats.** When setup fails, `--format json` reports
+  each test as `fail` (`ReportMapper.MapSetupFailure`) while `--format fhir` reports `skip` actions.
+  Both agree at the top level (`result: fail`, exit 1).
+- **Parse warnings** (`parseResult.IsSuccess` with non-empty `Errors`) reach stderr only, never
+  either artifact.

--- a/docs/superpowers/specs/2026-07-13-conformance-cli-auth-and-testreport-design.md
+++ b/docs/superpowers/specs/2026-07-13-conformance-cli-auth-and-testreport-design.md
@@ -1,0 +1,44 @@
+# Conformance CLI auth header and TestReport output
+
+## Summary
+Add two opt-in CLI features to `ignixa-matrix run`:
+
+- `--auth-header <value>` sets an authentication header for all HTTP requests made during the run.
+- `--test-report <path>` writes the executed TestScript results as a FHIR `TestReport` JSON file (or a `Bundle` of `TestReport` resources when more than one script is executed).
+
+## User experience
+
+The existing matrix report output remains unchanged. The new options are optional and do not alter the default behavior of the command.
+
+Examples:
+
+```bash
+ignixa-matrix run \
+  --server https://example.org/fhir \
+  --tests ./testscripts \
+  --impl my-server \
+  --auth-header "Bearer abc123" \
+  --test-report ./reports/test-report.json
+```
+
+The auth option accepts either:
+
+- a raw header value such as `Bearer abc123`
+- a full header declaration such as `Authorization: Bearer abc123`
+
+If a raw value is supplied without a header name, the CLI applies it as the `Authorization` header.
+
+## Implementation notes
+
+- Extend `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs` with the new options.
+- Apply the auth header to the shared `HttpClient` used by the TestScript engine so every request inherits the configured header.
+- Capture each executed `TestScriptReport` and serialize it via the existing `TestReportResourceGenerator`.
+- If multiple scripts are executed, write a `Bundle` with `type=collection` and one `entry.resource` per `TestReport`.
+- Keep the current `--out` JSON matrix output behavior intact.
+
+## Testing
+
+Add tests for:
+
+- parsing/normalizing the auth header input
+- bundling one or more generated `TestReport` resources into the output payload

--- a/docs/superpowers/specs/2026-07-13-conformance-cli-auth-and-testreport-design.md
+++ b/docs/superpowers/specs/2026-07-13-conformance-cli-auth-and-testreport-design.md
@@ -1,44 +1,80 @@
 # Conformance CLI auth header and TestReport output
 
 ## Summary
-Add two opt-in CLI features to `ignixa-matrix run`:
+Add authentication support to `ignixa-matrix run` and make FHIR `TestReport` its default output:
 
 - `--auth-header <value>` sets an authentication header for all HTTP requests made during the run.
-- `--test-report <path>` writes the executed TestScript results as a FHIR `TestReport` JSON file (or a `Bundle` of `TestReport` resources when more than one script is executed).
+- `--format <fhir|json>` selects the shape of the `--out` file. `fhir` (the default) writes a
+  `Bundle` of `TestReport` resources; `json` writes this tool's native per-impl report.
 
 ## User experience
 
-The existing matrix report output remains unchanged. The new options are optional and do not alter the default behavior of the command.
-
-Examples:
+`--out` is always the report file — the format is chosen by `--format`, not by a second path option.
 
 ```bash
 ignixa-matrix run \
   --server https://example.org/fhir \
   --tests ./testscripts \
   --impl my-server \
-  --auth-header "Bearer abc123" \
-  --test-report ./reports/test-report.json
+  --out ./reports/my-server.json \
+  --auth-header "Bearer abc123"
 ```
 
 The auth option accepts either:
 
-- a raw header value such as `Bearer abc123`
-- a full header declaration such as `Authorization: Bearer abc123`
+- a raw credential such as `Bearer abc123`
+- a full header declaration such as `Authorization: Bearer abc123` or `X-Api-Key: abc123`
 
 If a raw value is supplied without a header name, the CLI applies it as the `Authorization` header.
+An HTTP header name cannot contain whitespace, so the text before the first colon is treated as a
+header name only when it has none; anything else is a bare credential. This supports arbitrary
+schemes (`Negotiate`, `NTLM`, `AWS4-HMAC-SHA256`) and credentials containing colons without
+enumerating scheme names.
+
+### `--format`
+
+| Value | Output |
+|-------|--------|
+| `fhir` (default) | A `Bundle` (`type: collection`, with `timestamp`) of `TestReport` resources — one entry per executed TestScript, each with a `TestReport/<slug>` `fullUrl`. |
+| `json` | The native per-impl report (`ImplReport`) — the shape `merge` consumes to build the matrix. |
+
+**This changes the default.** Runs that feed `ignixa-matrix merge` must now pass `--format json`;
+`merge` deserializes `ImplReport` and rejects a `TestReport` Bundle with a JSON error and a non-zero
+exit rather than silently producing an incorrect matrix.
+
+The emitted `TestReport` matches the shape `ignixa-lab`'s frontend produces (`frontend/src/lib/testReport.ts`),
+so the two tools' output is interchangeable. Blob-permalink `testScript.reference` values are out of
+scope: `--tests` is an arbitrary folder path and the CLI has no equivalent of ignixa-lab's
+SourceLink-stamped package revision, so the script is identified by `testScript.display` only.
 
 ## Implementation notes
 
 - Extend `tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs` with the new options.
-- Apply the auth header to the shared `HttpClient` used by the TestScript engine so every request inherits the configured header.
-- Capture each executed `TestScriptReport` and serialize it via the existing `TestReportResourceGenerator`.
-- If multiple scripts are executed, write a `Bundle` with `type=collection` and one `entry.resource` per `TestReport`.
-- Keep the current `--out` JSON matrix output behavior intact.
+- Apply the auth header to the shared `HttpClient` used by the TestScript engine so every request
+  inherits it. An `--auth-header` that parses to an empty value throws rather than returning quietly —
+  running the suite unauthenticated would report every test as a legitimate 401 failure.
+- Capture each executed `TestScriptReport` and serialize it via `TestReportResourceGenerator`, passing
+  a `TestReportContext` carrying the impl name (`tester`), server URL (`server` participant), and the
+  suite-relative file path (`testScript.display`).
+- Always write a `Bundle`, even for a single script, so consumers do not have to branch on
+  `resourceType`.
+- Keep `--format json` output byte-compatible with the existing `ImplReport` shape.
+
+## Core change
+
+`TestReportResourceGenerator.Generate` did not emit `TestReport.testScript`, which is 1..1 in R4 —
+every consumer produced an invalid resource, not just this CLI. It now always emits a display-only
+`testScript` Reference, plus `score` and a `test-engine` participant. The new `TestReportContext`
+parameter is optional, so existing `Generate(report)` call sites are unaffected.
+
+A relative file path belongs in `testScript.display`, not `testScript.reference`: a relative
+`Reference.reference` is parsed as `[type]/[id]`, so `Search/intervals.json` would be read as a
+resource of type `Search`.
 
 ## Testing
 
-Add tests for:
-
-- parsing/normalizing the auth header input
-- bundling one or more generated `TestReport` resources into the output payload
+- parsing/normalizing the auth header input, including a custom scheme whose credential contains a colon
+- bundling generated `TestReport` resources, including `fullUrl` slugs and the Bundle `timestamp`
+- `testScript` fallback to the script name when no context is supplied
+- `score` as a percentage of passing tests, and the empty-test-list case
+- `participant` omitting the server entry when no server URI is supplied

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
@@ -1,0 +1,22 @@
+namespace Ignixa.TestScript.Reporting;
+
+/// <summary>
+/// Run-scoped facts the engine cannot infer from a <see cref="TestScriptReport"/> alone — which
+/// server was exercised, who ran the script, and what to call the script itself — supplied by the
+/// caller so <see cref="TestReportResourceGenerator"/> can populate the matching TestReport
+/// elements. Every member is optional; omitting one drops its element rather than inventing a value.
+/// </summary>
+public sealed record TestReportContext
+{
+    /// <summary><c>TestReport.tester</c> — the organisation or tool that executed the script.</summary>
+    public string? Tester { get; init; }
+
+    /// <summary>Base URL of the server under test, emitted as the <c>server</c> participant.</summary>
+    public string? ServerUri { get; init; }
+
+    /// <summary>
+    /// <c>TestReport.testScript.display</c> — how to name the source script, e.g. a suite-relative
+    /// path like <c>Search/intervals.json</c>. Defaults to the report's TestScript name.
+    /// </summary>
+    public string? TestScriptDisplay { get; init; }
+}

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
@@ -14,7 +14,8 @@ namespace Ignixa.TestScript.Reporting;
 public sealed record TestReportContext
 {
     private readonly string? _tester;
-    private readonly string? _serverUri;
+    private readonly Uri? _serverUri;
+    private readonly string? _serverDisplay;
     private readonly string? _testScriptDisplay;
 
     /// <summary><c>TestReport.tester</c> — the organisation or tool that executed the script.</summary>
@@ -24,11 +25,23 @@ public sealed record TestReportContext
         init => _tester = Normalize(value);
     }
 
-    /// <summary>Base URL of the server under test, emitted as the <c>server</c> participant.</summary>
-    public string? ServerUri
+    /// <summary>Base URL of the server under test, emitted as the <c>server</c> participant's <c>uri</c>.</summary>
+    public Uri? ServerUri
     {
         get => _serverUri;
-        init => _serverUri = Normalize(value);
+        init => _serverUri = value is not null && !value.IsAbsoluteUri
+            ? throw new ArgumentException("ServerUri must be an absolute URI.", nameof(value))
+            : value;
+    }
+
+    /// <summary>
+    /// Human-readable name of the server under test, emitted as the <c>server</c> participant's
+    /// <c>display</c>.
+    /// </summary>
+    public string? ServerDisplay
+    {
+        get => _serverDisplay;
+        init => _serverDisplay = Normalize(value);
     }
 
     /// <summary>

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportContext.cs
@@ -6,17 +6,41 @@ namespace Ignixa.TestScript.Reporting;
 /// caller so <see cref="TestReportResourceGenerator"/> can populate the matching TestReport
 /// elements. Every member is optional; omitting one drops its element rather than inventing a value.
 /// </summary>
+/// <remarks>
+/// Blank and whitespace-only values normalize to <c>null</c> on construction, so "absent" has
+/// exactly one representation. FHIR forbids empty strings, so a caller passing <c>""</c> means
+/// "I have no value" — treating that as present would emit an invalid resource.
+/// </remarks>
 public sealed record TestReportContext
 {
+    private readonly string? _tester;
+    private readonly string? _serverUri;
+    private readonly string? _testScriptDisplay;
+
     /// <summary><c>TestReport.tester</c> — the organisation or tool that executed the script.</summary>
-    public string? Tester { get; init; }
+    public string? Tester
+    {
+        get => _tester;
+        init => _tester = Normalize(value);
+    }
 
     /// <summary>Base URL of the server under test, emitted as the <c>server</c> participant.</summary>
-    public string? ServerUri { get; init; }
+    public string? ServerUri
+    {
+        get => _serverUri;
+        init => _serverUri = Normalize(value);
+    }
 
     /// <summary>
     /// <c>TestReport.testScript.display</c> — how to name the source script, e.g. a suite-relative
     /// path like <c>Search/intervals.json</c>. Defaults to the report's TestScript name.
     /// </summary>
-    public string? TestScriptDisplay { get; init; }
+    public string? TestScriptDisplay
+    {
+        get => _testScriptDisplay;
+        init => _testScriptDisplay = Normalize(value);
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -18,7 +18,7 @@ public static class TestReportResourceGenerator
             ["participant"] = GenerateParticipants(context)
         };
 
-        if (context?.Tester is { Length: > 0 } tester)
+        if (context?.Tester is { } tester)
             testReport["tester"] = tester;
 
         if (report.SetupResult is not null)
@@ -39,6 +39,9 @@ public static class TestReportResourceGenerator
     private static JsonObject GenerateTestScriptReference(TestScriptReport report, TestReportContext? context) =>
         new() { ["display"] = context?.TestScriptDisplay ?? report.TestScriptName };
 
+    // TestReportContext normalizes blank values to null, so a plain null check is enough here and
+    // an empty TestScriptDisplay falls back to the script name rather than emitting "display": "".
+
     // participant.uri is 1..1, so the server entry only appears once a URI is known. The
     // test-engine entry is this library, which is true regardless of what the caller supplies.
     private static JsonArray GenerateParticipants(TestReportContext? context)
@@ -53,7 +56,7 @@ public static class TestReportResourceGenerator
             }
         };
 
-        if (context?.ServerUri is { Length: > 0 } serverUri)
+        if (context?.ServerUri is { } serverUri)
         {
             participants.Insert(0, new JsonObject
             {

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -12,14 +12,17 @@ public static class TestReportResourceGenerator
             ["name"] = report.TestScriptName,
             ["status"] = "completed",
             ["testScript"] = GenerateTestScriptReference(report, context),
-            ["result"] = MapReportResult(report.OverallOutcome),
-            ["score"] = ComputeScore(report.TestResults),
-            ["issued"] = report.EndTime.ToString("o"),
-            ["participant"] = GenerateParticipants(context)
+            ["result"] = MapReportResult(report.OverallOutcome)
         };
+
+        if (ComputeScore(report.TestResults) is { } score)
+            testReport["score"] = score;
 
         if (context?.Tester is { } tester)
             testReport["tester"] = tester;
+
+        testReport["issued"] = report.EndTime.ToString("o");
+        testReport["participant"] = GenerateParticipants(context);
 
         if (report.SetupResult is not null)
             testReport["setup"] = GenerateSetup(report.SetupResult);
@@ -68,15 +71,22 @@ public static class TestReportResourceGenerator
         return participants;
     }
 
-    // TestReport.score is the percentage of tests that passed. Warning is a passing outcome for
-    // the report as a whole (see MapReportResult), so it counts toward the numerator here too.
-    private static double ComputeScore(IReadOnlyList<TestCaseResult> tests)
+    // TestReport.score is the percentage of tests that passed. Warning is a passing outcome for the
+    // report as a whole (see MapReportResult), so it counts toward the numerator here too.
+    //
+    // Skipped tests are excluded from both sides rather than scored as misses. A test gated out by
+    // fhirVersion or requiresCapability was never attempted, so counting it against the server would
+    // make an all-skipped script report "result": "pass" alongside "score": 0 — and would disagree
+    // with MatrixBuilder, which keeps skipped out of both pass and fail. Returns null when nothing
+    // was scored so the caller omits the element (score is 0..1) instead of asserting a 0.
+    private static double? ComputeScore(IReadOnlyList<TestCaseResult> tests)
     {
-        if (tests.Count == 0)
-            return 0;
+        var scored = tests.Count(t => t.Outcome is not TestScriptOutcome.Skip);
+        if (scored == 0)
+            return null;
 
         var passed = tests.Count(t => t.Outcome is TestScriptOutcome.Pass or TestScriptOutcome.Warning);
-        return Math.Round(100d * passed / tests.Count);
+        return Math.Round(100d * passed / scored);
     }
 
     private static JsonObject GenerateSetup(TestPhaseResult setup) =>
@@ -87,12 +97,13 @@ public static class TestReportResourceGenerator
         var result = new JsonArray();
         foreach (var test in tests)
         {
-            result.Add(new JsonObject
-            {
-                ["name"] = test.Name,
-                ["description"] = test.Description,
-                ["action"] = GenerateActionArray(test.Actions)
-            });
+            // FHIR JSON allows null only inside arrays, to align a primitive with its "_" extension;
+            // a null-valued object property is invalid, so an absent description is omitted.
+            var obj = new JsonObject { ["name"] = test.Name };
+            if (test.Description is not null)
+                obj["description"] = test.Description;
+            obj["action"] = GenerateActionArray(test.Actions);
+            result.Add(obj);
         }
         return result;
     }

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -39,11 +39,10 @@ public static class TestReportResourceGenerator
     // TestReport.testScript is 1..1, so it is always emitted. A display-only Reference satisfies
     // that without asserting a resolvable location for a script that only exists as a file on the
     // runner's disk — a relative path in Reference.reference would be read as [type]/[id].
+    // TestReportContext normalizes blanks to null, so the ?? also covers an empty display rather
+    // than emitting "display": "".
     private static JsonObject GenerateTestScriptReference(TestScriptReport report, TestReportContext? context) =>
         new() { ["display"] = context?.TestScriptDisplay ?? report.TestScriptName };
-
-    // TestReportContext normalizes blank values to null, so a plain null check is enough here and
-    // an empty TestScriptDisplay falls back to the script name rather than emitting "display": "".
 
     // participant.uri is 1..1, so the server entry only appears once a URI is known. The
     // test-engine entry is this library, which is true regardless of what the caller supplies.
@@ -61,11 +60,15 @@ public static class TestReportResourceGenerator
 
         if (context?.ServerUri is { } serverUri)
         {
-            participants.Insert(0, new JsonObject
+            var server = new JsonObject
             {
                 ["type"] = "server",
-                ["uri"] = serverUri
-            });
+                ["uri"] = serverUri.ToString()
+            };
+            if (context.ServerDisplay is { } serverDisplay)
+                server["display"] = serverDisplay;
+
+            participants.Insert(0, server);
         }
 
         return participants;

--- a/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
+++ b/src/Core/Ignixa.TestScript/Reporting/TestReportResourceGenerator.cs
@@ -4,16 +4,22 @@ namespace Ignixa.TestScript.Reporting;
 
 public static class TestReportResourceGenerator
 {
-    public static JsonObject Generate(TestScriptReport report)
+    public static JsonObject Generate(TestScriptReport report, TestReportContext? context = null)
     {
         var testReport = new JsonObject
         {
             ["resourceType"] = "TestReport",
             ["name"] = report.TestScriptName,
             ["status"] = "completed",
+            ["testScript"] = GenerateTestScriptReference(report, context),
             ["result"] = MapReportResult(report.OverallOutcome),
-            ["issued"] = report.EndTime.ToString("o")
+            ["score"] = ComputeScore(report.TestResults),
+            ["issued"] = report.EndTime.ToString("o"),
+            ["participant"] = GenerateParticipants(context)
         };
+
+        if (context?.Tester is { Length: > 0 } tester)
+            testReport["tester"] = tester;
 
         if (report.SetupResult is not null)
             testReport["setup"] = GenerateSetup(report.SetupResult);
@@ -25,6 +31,49 @@ public static class TestReportResourceGenerator
             testReport["teardown"] = GenerateTeardown(report.TeardownResult);
 
         return testReport;
+    }
+
+    // TestReport.testScript is 1..1, so it is always emitted. A display-only Reference satisfies
+    // that without asserting a resolvable location for a script that only exists as a file on the
+    // runner's disk — a relative path in Reference.reference would be read as [type]/[id].
+    private static JsonObject GenerateTestScriptReference(TestScriptReport report, TestReportContext? context) =>
+        new() { ["display"] = context?.TestScriptDisplay ?? report.TestScriptName };
+
+    // participant.uri is 1..1, so the server entry only appears once a URI is known. The
+    // test-engine entry is this library, which is true regardless of what the caller supplies.
+    private static JsonArray GenerateParticipants(TestReportContext? context)
+    {
+        var participants = new JsonArray
+        {
+            new JsonObject
+            {
+                ["type"] = "test-engine",
+                ["uri"] = "urn:ignixa:testscript-engine",
+                ["display"] = "Ignixa.TestScript"
+            }
+        };
+
+        if (context?.ServerUri is { Length: > 0 } serverUri)
+        {
+            participants.Insert(0, new JsonObject
+            {
+                ["type"] = "server",
+                ["uri"] = serverUri
+            });
+        }
+
+        return participants;
+    }
+
+    // TestReport.score is the percentage of tests that passed. Warning is a passing outcome for
+    // the report as a whole (see MapReportResult), so it counts toward the numerator here too.
+    private static double ComputeScore(IReadOnlyList<TestCaseResult> tests)
+    {
+        if (tests.Count == 0)
+            return 0;
+
+        var passed = tests.Count(t => t.Outcome is TestScriptOutcome.Pass or TestScriptOutcome.Warning);
+        return Math.Round(100d * passed / tests.Count);
     }
 
     private static JsonObject GenerateSetup(TestPhaseResult setup) =>

--- a/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
+++ b/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
@@ -200,7 +200,7 @@ public class RunCommandTests
         // Arrange: reachable when every script fails to parse.
 
         // Act
-        var payload = RunCommand.BuildTestReportPayload([], DateTimeOffset.UnixEpoch);
+        var payload = RunCommand.BuildFhirBundle([], DateTimeOffset.UnixEpoch);
 
         // Assert
         payload["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
@@ -210,7 +210,7 @@ public class RunCommandTests
     [Fact]
     public void GivenSingleReport_WhenBuildingPayload_ThenStillReturnsBundleCollection()
     {
-        var payload = RunCommand.BuildTestReportPayload([MakeTestReport("Search/basic.json")], DateTimeOffset.UnixEpoch);
+        var payload = RunCommand.BuildFhirBundle([MakeTestReport("Search/basic.json")], DateTimeOffset.UnixEpoch);
 
         payload.ShouldNotBeNull();
         payload["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
@@ -222,7 +222,7 @@ public class RunCommandTests
     public void GivenMultipleReports_WhenBuildingPayload_ThenEntriesCarryUniqueAbsoluteFullUrls()
     {
         // Arrange/Act: fullUrl must be absolute per R4, and unique within the Bundle per bdl-7.
-        var payload = RunCommand.BuildTestReportPayload(
+        var payload = RunCommand.BuildFhirBundle(
             [MakeTestReport("Search/intervals.json"), MakeTestReport("CRUD/basic.json")],
             DateTimeOffset.UnixEpoch);
 
@@ -241,9 +241,240 @@ public class RunCommandTests
     {
         var startedAt = new DateTimeOffset(2026, 7, 14, 9, 30, 0, TimeSpan.Zero);
 
-        var payload = RunCommand.BuildTestReportPayload([MakeTestReport("Search/basic.json")], startedAt);
+        var payload = RunCommand.BuildFhirBundle([MakeTestReport("Search/basic.json")], startedAt);
 
         payload["timestamp"]!.GetValue<string>().ShouldBe(startedAt.ToString("o"));
+    }
+
+    [Fact]
+    public void GivenParseFailure_WhenBuildingOutcome_ThenReportsStructureWithTheOffendingFile()
+    {
+        // Arrange/Act: 'structure' is FHIR's "unable to parse the content completely, invalid syntax".
+        var outcome = RunCommand.BuildParseErrorOutcome("Search/broken.json", "Required field 'name' is missing");
+
+        // Assert
+        outcome["resourceType"]!.GetValue<string>().ShouldBe("OperationOutcome");
+        var issue = outcome["issue"]!.AsArray().ShouldHaveSingleItem()!;
+        issue["severity"]!.GetValue<string>().ShouldBe("error");
+        issue["code"]!.GetValue<string>().ShouldBe("structure");
+        issue["diagnostics"]!.GetValue<string>()
+            .ShouldBe("Search/broken.json: Required field 'name' is missing");
+    }
+
+    [Fact]
+    public void GivenEvaluatorException_WhenBuildingOutcome_ThenReportsExceptionWithTheOffendingFile()
+    {
+        // Arrange: the message alone ("Object reference not set...") does not identify the failure,
+        // so the type is carried too.
+        var error = new InvalidOperationException("fixture 'obs-past' was never resolved");
+
+        // Act: 'exception' is FHIR's "An unexpected internal error has occurred".
+        var outcome = RunCommand.BuildEvaluatorErrorOutcome("Search/intervals.json", error);
+
+        // Assert
+        outcome["resourceType"]!.GetValue<string>().ShouldBe("OperationOutcome");
+        var issue = outcome["issue"]!.AsArray().ShouldHaveSingleItem()!;
+        issue["severity"]!.GetValue<string>().ShouldBe("error");
+        issue["code"]!.GetValue<string>().ShouldBe("exception");
+        issue["diagnostics"]!.GetValue<string>().ShouldBe(
+            "Search/intervals.json: InvalidOperationException: fixture 'obs-past' was never resolved");
+    }
+
+    [Fact]
+    public void GivenTestReportsAndOperationOutcomes_WhenBuildingBundle_ThenBothCoexistAsCollectionEntries()
+    {
+        // Arrange: Bundle.type = collection imposes no homogeneity constraint, so a run that both
+        // executed and failed to parse scripts is representable in one Bundle.
+        var outcome = OperationOutcomeResourceGenerator.Generate(
+            OperationOutcomeResourceGenerator.StructureIssueCode, "Search/broken.json: invalid syntax");
+
+        // Act
+        var payload = RunCommand.BuildFhirBundle(
+            [MakeTestReport("Search/intervals.json"), outcome], DateTimeOffset.UnixEpoch);
+
+        // Assert
+        payload["type"]!.GetValue<string>().ShouldBe("collection");
+        var entries = payload["entry"]!.AsArray();
+        entries.Count.ShouldBe(2);
+
+        var resourceTypes = entries.Select(e => e!["resource"]!["resourceType"]!.GetValue<string>()).ToList();
+        resourceTypes.ShouldBe(["TestReport", "OperationOutcome"]);
+
+        var fullUrls = entries.Select(e => e!["fullUrl"]!.GetValue<string>()).ToList();
+        fullUrls.ShouldAllBe(url => url.StartsWith("urn:uuid:", StringComparison.Ordinal));
+        fullUrls.Distinct().Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenUnparseableScript_WhenRunningAsFhir_ThenBundleRecordsItAsAnOperationOutcome()
+    {
+        // Arrange: without this the failure exists nowhere on disk — the Bundle would just be short
+        // an entry, which reads as a clean run of fewer scripts.
+        using var workspace = new TempWorkspace();
+        workspace.WriteScript("broken.json", "{ this is not a TestScript");
+
+        // Act
+        var exitCode = await RunCommand.RunAsync(
+            UnreachableServer, workspace.TestsPath, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: null, ReportFormat.Fhir, CancellationToken.None);
+
+        // Assert
+        exitCode.ShouldBe(1);
+
+        var bundle = JsonNode.Parse(await File.ReadAllTextAsync(workspace.OutPath))!;
+        var resources = bundle["entry"]!.AsArray().Select(e => e!["resource"]!).ToList();
+        var outcome = resources.ShouldHaveSingleItem();
+        outcome["resourceType"]!.GetValue<string>().ShouldBe("OperationOutcome");
+
+        var issue = outcome["issue"]!.AsArray().ShouldHaveSingleItem()!;
+        issue["code"]!.GetValue<string>().ShouldBe("structure");
+        issue["diagnostics"]!.GetValue<string>().ShouldContain("broken.json");
+    }
+
+    [Fact]
+    public async Task GivenUnparseableScript_WhenRunningAsJson_ThenNoOperationOutcomeIsEmitted()
+    {
+        // Arrange: the native report already records the failure as an "error" result; merge does
+        // not read FHIR resources.
+        using var workspace = new TempWorkspace();
+        workspace.WriteScript("broken.json", "{ this is not a TestScript");
+
+        // Act
+        var exitCode = await RunCommand.RunAsync(
+            UnreachableServer, workspace.TestsPath, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: null, ReportFormat.Json, CancellationToken.None);
+
+        // Assert
+        exitCode.ShouldBe(1);
+
+        var payload = await File.ReadAllTextAsync(workspace.OutPath);
+        payload.ShouldNotContain("OperationOutcome");
+
+        var parsed = JsonNode.Parse(payload)!;
+        parsed["impl"]!.GetValue<string>().ShouldBe("my-server");
+        parsed["results"]!.AsArray().ShouldHaveSingleItem()!["status"]!.GetValue<string>().ShouldBe("error");
+    }
+
+    [Fact]
+    public async Task GivenMissingTestsDirectory_WhenRunning_ThenReturnsUsageExitCodeDistinctFromTestFailure()
+    {
+        // Arrange: CI must tell "the invocation was wrong, nothing ran" from "the suite ran and
+        // tests failed" (1).
+        using var workspace = new TempWorkspace();
+        var missing = Path.Combine(workspace.TestsPath, "does-not-exist");
+
+        // Act
+        var exitCode = await RunCommand.RunAsync(
+            UnreachableServer, missing, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: null, ReportFormat.Fhir, CancellationToken.None);
+
+        // Assert
+        exitCode.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenRelativeServerUri_WhenRunning_ThenReturnsUsageExitCode()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteScript("broken.json", "{");
+
+        var exitCode = await RunCommand.RunAsync(
+            "not-a-uri", workspace.TestsPath, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: null, ReportFormat.Fhir, CancellationToken.None);
+
+        exitCode.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenEmptyTestsDirectory_WhenRunning_ThenReturnsUsageExitCode()
+    {
+        using var workspace = new TempWorkspace();
+
+        var exitCode = await RunCommand.RunAsync(
+            UnreachableServer, workspace.TestsPath, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: null, ReportFormat.Fhir, CancellationToken.None);
+
+        exitCode.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenUnusableAuthHeader_WhenRunning_ThenReturnsUsageExitCodeWithoutRunningTheSuite()
+    {
+        // Arrange: running unauthenticated would report every 401 as a legitimate test failure.
+        using var workspace = new TempWorkspace();
+        workspace.WriteScript("broken.json", "{");
+
+        // Act
+        var exitCode = await RunCommand.RunAsync(
+            UnreachableServer, workspace.TestsPath, "my-server", workspace.OutPath,
+            fhirVersion: null, authHeader: "Authorization:", ReportFormat.Fhir, CancellationToken.None);
+
+        // Assert
+        exitCode.ShouldBe(2);
+        File.Exists(workspace.OutPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenWritableOutPath_WhenPreparingOutputDirectory_ThenCreatesTheDirectory()
+    {
+        // Arrange: validated before the suite runs, so a typo cannot discard a completed run.
+        using var workspace = new TempWorkspace();
+        var nested = Path.Combine(workspace.Root, "reports", "nested", "out.json");
+
+        // Act
+        var error = RunCommand.PrepareOutputDirectory(nested);
+
+        // Assert
+        error.ShouldBeNull();
+        Directory.Exists(Path.GetDirectoryName(nested)!).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenOutPathWithInvalidCharacters_WhenPreparingOutputDirectory_ThenReportsErrorRatherThanThrowing()
+    {
+        // Arrange: Path.GetFullPath throws on these; that is a usage error, not an internal fault.
+        var error = RunCommand.PrepareOutputDirectory("\0invalid\0/report.json");
+
+        // Assert
+        error.ShouldNotBeNull();
+        error.ShouldContain("--out path is unusable");
+    }
+
+    // Loopback port 1 refuses immediately, so tests that must not reach a server stay fast and
+    // deterministic rather than waiting on a DNS or connect timeout.
+    private const string UnreachableServer = "http://127.0.0.1:1";
+
+    private sealed class TempWorkspace : IDisposable
+    {
+        public TempWorkspace()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"ignixa-matrix-tests-{Guid.NewGuid():N}");
+            TestsPath = Path.Combine(Root, "tests");
+            OutPath = Path.Combine(Root, "reports", "report.json");
+            Directory.CreateDirectory(TestsPath);
+        }
+
+        public string Root { get; }
+
+        public string TestsPath { get; }
+
+        public string OutPath { get; }
+
+        public void WriteScript(string name, string content) =>
+            File.WriteAllText(Path.Combine(TestsPath, name), content);
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Root))
+                    Directory.Delete(Root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leaked temp directory must not fail an otherwise passing test.
+            }
+        }
     }
 
     [Fact]

--- a/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
+++ b/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
@@ -56,26 +56,56 @@ public class RunCommandTests
         value.ShouldBe("value");
     }
 
-    [Fact]
-    public void GivenSingleReport_WhenBuildingPayload_ThenReturnsTestReportResource()
-    {
-        var payload = RunCommand.BuildTestReportPayload([new JsonObject { ["resourceType"] = "TestReport" }]);
+    private static JsonObject MakeTestReport(string display) =>
+        new()
+        {
+            ["resourceType"] = "TestReport",
+            ["testScript"] = new JsonObject { ["display"] = display }
+        };
 
-        payload.ShouldNotBeNull();
-        payload!["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
+    [Fact]
+    public void GivenCustomAuthScheme_WhenNormalizingAuthHeader_ThenTreatsItAsBareCredential()
+    {
+        // Arrange: a scheme not on any hardcoded list, whose credential contains a colon.
+        var (name, value) = RunCommand.ParseAuthHeader("AWS4-HMAC-SHA256 Credential=abc/20260714:xyz");
+
+        name.ShouldBe("Authorization");
+        value.ShouldBe("AWS4-HMAC-SHA256 Credential=abc/20260714:xyz");
     }
 
     [Fact]
-    public void GivenMultipleReports_WhenBuildingPayload_ThenReturnsBundleCollection()
+    public void GivenSingleReport_WhenBuildingPayload_ThenStillReturnsBundleCollection()
     {
-        var payload = RunCommand.BuildTestReportPayload([
-            new JsonObject { ["resourceType"] = "TestReport" },
-            new JsonObject { ["resourceType"] = "TestReport" }
-        ]);
+        var payload = RunCommand.BuildTestReportPayload([MakeTestReport("Search/basic.json")], DateTimeOffset.UnixEpoch);
 
         payload.ShouldNotBeNull();
-        payload!["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
+        payload["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
         payload["type"]!.GetValue<string>().ShouldBe("collection");
+        payload["entry"]!.AsArray().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenMultipleReports_WhenBuildingPayload_ThenEntriesCarryFullUrlSlugs()
+    {
+        var payload = RunCommand.BuildTestReportPayload(
+            [MakeTestReport("Search/intervals.json"), MakeTestReport("CRUD/basic.json")],
+            DateTimeOffset.UnixEpoch);
+
+        var entries = payload["entry"]!.AsArray();
+        entries.Count.ShouldBe(2);
+        entries[0]!["fullUrl"]!.GetValue<string>().ShouldBe("TestReport/search-intervals-json");
+        entries[1]!["fullUrl"]!.GetValue<string>().ShouldBe("TestReport/crud-basic-json");
+        entries[0]!["resource"]!["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
+    }
+
+    [Fact]
+    public void GivenReports_WhenBuildingPayload_ThenBundleCarriesRunTimestamp()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 14, 9, 30, 0, TimeSpan.Zero);
+
+        var payload = RunCommand.BuildTestReportPayload([MakeTestReport("Search/basic.json")], startedAt);
+
+        payload["timestamp"]!.GetValue<string>().ShouldBe(startedAt.ToString("o"));
     }
 
     [Fact]

--- a/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
+++ b/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
@@ -1,12 +1,83 @@
 using System.Net;
 using System.Text;
+using System.Text.Json.Nodes;
 using Shouldly;
 using Ignixa.ConformanceMatrix.Cli.Commands;
+using Ignixa.ConformanceMatrix.Cli.Reporting;
 
 namespace Ignixa.ConformanceMatrix.Cli.Tests;
 
 public class RunCommandTests
 {
+    private static ImplReportResult MakeResult(string status) =>
+        new()
+        {
+            Id = "test",
+            File = "test.json",
+            Status = status,
+            DurationMs = 0
+        };
+
+    [Fact]
+    public void GivenMixedResults_WhenFormattingSummary_ThenIncludesSkippedAndErrorCounts()
+    {
+        // Arrange
+        var results = new List<ImplReportResult>
+        {
+            MakeResult("pass"),
+            MakeResult("fail"),
+            MakeResult("skipped"),
+            MakeResult("error"),
+            MakeResult("skipped")
+        };
+
+        // Act
+        var summary = RunCommand.FormatOutcomeSummary(results);
+
+        // Assert
+        summary.ShouldBe("1 passed, 1 failed, 2 skipped, 1 error(s)");
+    }
+
+    [Fact]
+    public void GivenBareTokenValue_WhenNormalizingAuthHeader_ThenUsesAuthorizationHeader()
+    {
+        var (name, value) = RunCommand.ParseAuthHeader("Bearer abc123");
+
+        name.ShouldBe("Authorization");
+        value.ShouldBe("Bearer abc123");
+    }
+
+    [Fact]
+    public void GivenExplicitHeaderValue_WhenNormalizingAuthHeader_ThenPreservesHeaderName()
+    {
+        var (name, value) = RunCommand.ParseAuthHeader("X-Test: value");
+
+        name.ShouldBe("X-Test");
+        value.ShouldBe("value");
+    }
+
+    [Fact]
+    public void GivenSingleReport_WhenBuildingPayload_ThenReturnsTestReportResource()
+    {
+        var payload = RunCommand.BuildTestReportPayload([new JsonObject { ["resourceType"] = "TestReport" }]);
+
+        payload.ShouldNotBeNull();
+        payload!["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
+    }
+
+    [Fact]
+    public void GivenMultipleReports_WhenBuildingPayload_ThenReturnsBundleCollection()
+    {
+        var payload = RunCommand.BuildTestReportPayload([
+            new JsonObject { ["resourceType"] = "TestReport" },
+            new JsonObject { ["resourceType"] = "TestReport" }
+        ]);
+
+        payload.ShouldNotBeNull();
+        payload!["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
+        payload["type"]!.GetValue<string>().ShouldBe("collection");
+    }
+
     [Fact]
     public async Task GivenSuccessfulMetadataResponse_WhenFetching_ThenReturnsParsedCapabilityStatement()
     {

--- a/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
+++ b/test/Ignixa.ConformanceMatrix.Cli.Tests/RunCommandTests.cs
@@ -74,6 +74,140 @@ public class RunCommandTests
     }
 
     [Fact]
+    public void GivenNoAuthHeader_WhenApplying_ThenSucceedsWithoutSettingAHeader()
+    {
+        // Arrange
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, null);
+
+        // Assert
+        error.ShouldBeNull();
+        httpClient.DefaultRequestHeaders.Authorization.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Authorization:")]
+    [InlineData("X-Api-Key:   ")]
+    public void GivenAuthHeaderWithNoValue_WhenApplying_ThenReportsErrorRatherThanRunningUnauthenticated(string authHeader)
+    {
+        // Arrange: an env var expanding to empty is the common case; applying nothing would run the
+        // whole suite unauthenticated and report every 401 as a legitimate failure.
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, authHeader);
+
+        // Assert
+        error.ShouldNotBeNull();
+        error.ShouldContain("resolves to no header value");
+        httpClient.DefaultRequestHeaders.Authorization.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenInvalidHeaderName_WhenApplying_ThenReportsErrorRatherThanDroppingTheCredential()
+    {
+        // Arrange: '@' is not a valid HTTP token, so TryAddWithoutValidation returns false.
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, "Api@Key: abc123");
+
+        // Assert
+        error.ShouldNotBeNull();
+        error.ShouldContain("not a valid HTTP header name");
+    }
+
+    [Fact]
+    public void GivenBearerToken_WhenApplying_ThenSetsAuthorizationHeaderOnTheClient()
+    {
+        // Arrange
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, "Bearer abc123");
+
+        // Assert
+        error.ShouldBeNull();
+        httpClient.DefaultRequestHeaders.Authorization!.Scheme.ShouldBe("Bearer");
+        httpClient.DefaultRequestHeaders.Authorization.Parameter.ShouldBe("abc123");
+    }
+
+    [Fact]
+    public void GivenCustomHeaderName_WhenApplying_ThenAddsItToTheClient()
+    {
+        // Arrange
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, "X-Api-Key: abc123");
+
+        // Assert
+        error.ShouldBeNull();
+        httpClient.DefaultRequestHeaders.GetValues("X-Api-Key").ShouldBe(["abc123"]);
+    }
+
+    [Fact]
+    public void GivenUnparseableAuthorizationValue_WhenApplying_ThenFallsBackToAddingItVerbatim()
+    {
+        // Arrange: a credential Authorization cannot parse must still reach the wire.
+        using var httpClient = new HttpClient();
+
+        // Act
+        var error = RunCommand.ApplyAuthHeader(httpClient, "Authorization: AWS4-HMAC-SHA256 Credential=abc/20260714:xyz");
+
+        // Assert
+        error.ShouldBeNull();
+        httpClient.DefaultRequestHeaders.GetValues("Authorization")
+            .ShouldBe(["AWS4-HMAC-SHA256 Credential=abc/20260714:xyz"]);
+    }
+
+    [Fact]
+    public void GivenJsonFormat_WhenBuildingPayload_ThenProducesTheNativeImplReportShape()
+    {
+        // Arrange: this is the shape 'merge' deserializes; a regression breaks the matrix pipeline.
+        var results = new List<ImplReportResult> { MakeResult("pass") };
+
+        // Act
+        var payload = RunCommand.BuildPayload(ReportFormat.Json, "my-server", DateTimeOffset.UnixEpoch, 42, results, []);
+
+        // Assert
+        var parsed = JsonNode.Parse(payload)!;
+        parsed["impl"]!.GetValue<string>().ShouldBe("my-server");
+        parsed["duration_ms"]!.GetValue<long>().ShouldBe(42);
+        parsed["results"]!.AsArray().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenFhirFormat_WhenBuildingPayload_ThenProducesATestReportBundle()
+    {
+        // Act
+        var payload = RunCommand.BuildPayload(
+            ReportFormat.Fhir, "my-server", DateTimeOffset.UnixEpoch, 42, [], [MakeTestReport("Search/basic.json")]);
+
+        // Assert
+        var parsed = JsonNode.Parse(payload)!;
+        parsed["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
+        parsed["entry"]!.AsArray().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenNoReports_WhenBuildingPayload_ThenOmitsEntryBecauseFhirForbidsEmptyArrays()
+    {
+        // Arrange: reachable when every script fails to parse.
+
+        // Act
+        var payload = RunCommand.BuildTestReportPayload([], DateTimeOffset.UnixEpoch);
+
+        // Assert
+        payload["resourceType"]!.GetValue<string>().ShouldBe("Bundle");
+        payload.ContainsKey("entry").ShouldBeFalse();
+    }
+
+    [Fact]
     public void GivenSingleReport_WhenBuildingPayload_ThenStillReturnsBundleCollection()
     {
         var payload = RunCommand.BuildTestReportPayload([MakeTestReport("Search/basic.json")], DateTimeOffset.UnixEpoch);
@@ -85,16 +219,20 @@ public class RunCommandTests
     }
 
     [Fact]
-    public void GivenMultipleReports_WhenBuildingPayload_ThenEntriesCarryFullUrlSlugs()
+    public void GivenMultipleReports_WhenBuildingPayload_ThenEntriesCarryUniqueAbsoluteFullUrls()
     {
+        // Arrange/Act: fullUrl must be absolute per R4, and unique within the Bundle per bdl-7.
         var payload = RunCommand.BuildTestReportPayload(
             [MakeTestReport("Search/intervals.json"), MakeTestReport("CRUD/basic.json")],
             DateTimeOffset.UnixEpoch);
 
+        // Assert
         var entries = payload["entry"]!.AsArray();
         entries.Count.ShouldBe(2);
-        entries[0]!["fullUrl"]!.GetValue<string>().ShouldBe("TestReport/search-intervals-json");
-        entries[1]!["fullUrl"]!.GetValue<string>().ShouldBe("TestReport/crud-basic-json");
+
+        var fullUrls = entries.Select(e => e!["fullUrl"]!.GetValue<string>()).ToList();
+        fullUrls.ShouldAllBe(url => Uri.IsWellFormedUriString(url, UriKind.Absolute));
+        fullUrls.Distinct().Count().ShouldBe(2);
         entries[0]!["resource"]!["resourceType"]!.GetValue<string>().ShouldBe("TestReport");
     }
 

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -32,6 +32,118 @@ public class TestReportResourceGeneratorTests
     }
 
     [Fact]
+    public void GivenNoContext_WhenGenerating_ThenTestScriptFallsBackToScriptName()
+    {
+        // Arrange: testScript is 1..1 in R4, so it must be present even with nothing supplied.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "ReadPatientTest",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        json["testScript"]!["display"]!.GetValue<string>().ShouldBe("ReadPatientTest");
+        json["testScript"]!["reference"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenContext_WhenGenerating_ThenEmitsTesterParticipantAndTestScriptDisplay()
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "IntervalSearch",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+        var context = new TestReportContext
+        {
+            Tester = "my-server",
+            ServerUri = "https://example.org/fhir",
+            TestScriptDisplay = "Search/intervals.json"
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, context);
+
+        // Assert
+        json["tester"]!.GetValue<string>().ShouldBe("my-server");
+        json["testScript"]!["display"]!.GetValue<string>().ShouldBe("Search/intervals.json");
+
+        var participants = json["participant"]!.AsArray();
+        participants[0]!["type"]!.GetValue<string>().ShouldBe("server");
+        participants[0]!["uri"]!.GetValue<string>().ShouldBe("https://example.org/fhir");
+        participants[1]!["type"]!.GetValue<string>().ShouldBe("test-engine");
+    }
+
+    [Fact]
+    public void GivenNoServerUri_WhenGenerating_ThenOmitsServerParticipant()
+    {
+        // Arrange: participant.uri is 1..1, so a server entry with no URI must not be emitted.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "NoServer",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        var participants = json["participant"]!.AsArray();
+        participants.Count.ShouldBe(1);
+        participants[0]!["type"]!.GetValue<string>().ShouldBe("test-engine");
+    }
+
+    [Fact]
+    public void GivenMixedOutcomes_WhenGenerating_ThenScoreIsPercentageOfPassingTests()
+    {
+        // Arrange: 1 pass + 1 warning (a passing outcome) out of 4 => 50.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "Mixed",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch,
+            TestResults =
+            [
+                new TestCaseResult("A", null, [], TestScriptOutcome.Pass),
+                new TestCaseResult("B", null, [], TestScriptOutcome.Warning),
+                new TestCaseResult("C", null, [], TestScriptOutcome.Fail),
+                new TestCaseResult("D", null, [], TestScriptOutcome.Skip)
+            ]
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        json["score"]!.GetValue<double>().ShouldBe(50);
+    }
+
+    [Fact]
+    public void GivenNoTests_WhenGenerating_ThenScoreIsZeroRatherThanDivideByZero()
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "Empty",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        json["score"]!.GetValue<double>().ShouldBe(0);
+    }
+
+    [Fact]
     public void GivenFailingReport_WhenGenerating_ThenResultIsFail()
     {
         var report = new TestScriptReport

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -122,6 +122,32 @@ public class TestReportResourceGeneratorTests
     }
 
     [Fact]
+    public void GivenContextCopiedWithNewValue_WhenUsingWithExpression_ThenStillNormalizes()
+    {
+        // Arrange: the init accessors carry the normalization, so a 'with' copy must re-run them
+        // rather than smuggling a blank value straight into the backing field.
+        var context = new TestReportContext { Tester = "original" };
+
+        // Act
+        var copied = context with { Tester = "  spaced  ", ServerUri = "   " };
+
+        // Assert
+        copied.Tester.ShouldBe("spaced");
+        copied.ServerUri.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenContextsDifferingOnlyByBlankRepresentation_WhenComparing_ThenTheyAreEqual()
+    {
+        // Arrange: "" and null both mean absent, so they must not produce unequal contexts.
+        var empty = new TestReportContext { Tester = "" };
+        var nulled = new TestReportContext { Tester = null };
+
+        // Assert
+        empty.ShouldBe(nulled);
+    }
+
+    [Fact]
     public void GivenPaddedContextValues_WhenGenerating_ThenTrimsThem()
     {
         // Arrange
@@ -160,9 +186,10 @@ public class TestReportResourceGeneratorTests
     }
 
     [Fact]
-    public void GivenMixedOutcomes_WhenGenerating_ThenScoreIsPercentageOfPassingTests()
+    public void GivenMixedOutcomes_WhenGenerating_ThenScoreExcludesSkippedTestsFromTheDenominator()
     {
-        // Arrange: 1 pass + 1 warning (a passing outcome) out of 4 => 50.
+        // Arrange: 1 pass + 1 warning (a passing outcome) out of 3 attempted => 67. The skipped
+        // test was never run, so scoring it as a miss would understate the server.
         var report = new TestScriptReport
         {
             TestScriptName = "Mixed",
@@ -181,11 +208,36 @@ public class TestReportResourceGeneratorTests
         var json = TestReportResourceGenerator.Generate(report);
 
         // Assert
-        json["score"]!.GetValue<double>().ShouldBe(50);
+        json["score"]!.GetValue<double>().ShouldBe(67);
     }
 
     [Fact]
-    public void GivenNoTests_WhenGenerating_ThenScoreIsZeroRatherThanDivideByZero()
+    public void GivenEveryTestSkipped_WhenGenerating_ThenOmitsScoreRatherThanContradictingResult()
+    {
+        // Arrange: version- or capability-gated scripts skip every test. OverallOutcome has no Skip
+        // branch, so result is "pass" — emitting score 0 alongside it would contradict the resource.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "AllSkipped",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch,
+            TestResults =
+            [
+                new TestCaseResult("A", null, [], TestScriptOutcome.Skip),
+                new TestCaseResult("B", null, [], TestScriptOutcome.Skip)
+            ]
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        json["result"]!.GetValue<string>().ShouldBe("pass");
+        json["score"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNoTests_WhenGenerating_ThenOmitsScoreRatherThanDividingByZero()
     {
         // Arrange
         var report = new TestScriptReport
@@ -199,7 +251,28 @@ public class TestReportResourceGeneratorTests
         var json = TestReportResourceGenerator.Generate(report);
 
         // Assert
-        json["score"]!.GetValue<double>().ShouldBe(0);
+        json["score"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenTestWithoutDescription_WhenGenerating_ThenOmitsItRatherThanEmittingJsonNull()
+    {
+        // Arrange: FHIR JSON permits null only inside arrays; a null object property is invalid.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "NoDescription",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch,
+            TestResults = [new TestCaseResult("A", null, [], TestScriptOutcome.Pass)]
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report);
+
+        // Assert
+        var test = json["test"]!.AsArray()[0]!.AsObject();
+        test.ContainsKey("description").ShouldBeFalse();
+        test["name"]!.GetValue<string>().ShouldBe("A");
     }
 
     [Fact]

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -80,6 +80,65 @@ public class TestReportResourceGeneratorTests
         participants[1]!["type"]!.GetValue<string>().ShouldBe("test-engine");
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GivenBlankTestScriptDisplay_WhenGenerating_ThenFallsBackToScriptNameRatherThanEmittingEmptyString(string display)
+    {
+        // Arrange: FHIR forbids empty strings, so a blank display must not reach the resource.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "ReadPatientTest",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, new TestReportContext { TestScriptDisplay = display });
+
+        // Assert
+        json["testScript"]!["display"]!.GetValue<string>().ShouldBe("ReadPatientTest");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GivenBlankContextValues_WhenGenerating_ThenOmitsTesterAndServerParticipant(string blank)
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "Blank",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, new TestReportContext { Tester = blank, ServerUri = blank });
+
+        // Assert
+        json["tester"].ShouldBeNull();
+        json["participant"]!.AsArray().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenPaddedContextValues_WhenGenerating_ThenTrimsThem()
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "Padded",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, new TestReportContext { Tester = "  my-server  " });
+
+        // Assert
+        json["tester"]!.GetValue<string>().ShouldBe("my-server");
+    }
+
     [Fact]
     public void GivenNoServerUri_WhenGenerating_ThenOmitsServerParticipant()
     {

--- a/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
+++ b/test/Ignixa.TestScript.Tests/Reporting/TestReportResourceGeneratorTests.cs
@@ -63,7 +63,7 @@ public class TestReportResourceGeneratorTests
         var context = new TestReportContext
         {
             Tester = "my-server",
-            ServerUri = "https://example.org/fhir",
+            ServerUri = new Uri("https://example.org/fhir"),
             TestScriptDisplay = "Search/intervals.json"
         };
 
@@ -103,7 +103,7 @@ public class TestReportResourceGeneratorTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void GivenBlankContextValues_WhenGenerating_ThenOmitsTesterAndServerParticipant(string blank)
+    public void GivenBlankTester_WhenGenerating_ThenOmitsTesterAndServerParticipant(string blank)
     {
         // Arrange
         var report = new TestScriptReport
@@ -114,7 +114,7 @@ public class TestReportResourceGeneratorTests
         };
 
         // Act
-        var json = TestReportResourceGenerator.Generate(report, new TestReportContext { Tester = blank, ServerUri = blank });
+        var json = TestReportResourceGenerator.Generate(report, new TestReportContext { Tester = blank });
 
         // Assert
         json["tester"].ShouldBeNull();
@@ -129,22 +129,123 @@ public class TestReportResourceGeneratorTests
         var context = new TestReportContext { Tester = "original" };
 
         // Act
-        var copied = context with { Tester = "  spaced  ", ServerUri = "   " };
+        var copied = context with { Tester = "  spaced  ", TestScriptDisplay = "   " };
 
         // Assert
         copied.Tester.ShouldBe("spaced");
-        copied.ServerUri.ShouldBeNull();
+        copied.TestScriptDisplay.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenContextCopiedWithNewServerUri_WhenUsingWithExpression_ThenNewValueIsUsed()
+    {
+        // Arrange: ServerUri is a reference type with no normalization, but a 'with' copy must
+        // still carry the replaced value through like the string members above.
+        var context = new TestReportContext { ServerUri = new Uri("https://a.example.org") };
+
+        // Act
+        var copied = context with { ServerUri = new Uri("https://b.example.org") };
+
+        // Assert
+        copied.ServerUri.ShouldBe(new Uri("https://b.example.org"));
     }
 
     [Fact]
     public void GivenContextsDifferingOnlyByBlankRepresentation_WhenComparing_ThenTheyAreEqual()
     {
         // Arrange: "" and null both mean absent, so they must not produce unequal contexts.
-        var empty = new TestReportContext { Tester = "" };
-        var nulled = new TestReportContext { Tester = null };
+        var empty = new TestReportContext { Tester = "", ServerDisplay = "" };
+        var nulled = new TestReportContext { Tester = null, ServerDisplay = null };
 
         // Assert
         empty.ShouldBe(nulled);
+    }
+
+    [Fact]
+    public void GivenRelativeServerUri_WhenConstructingContext_ThenThrowsArgumentException()
+    {
+        // Arrange: TestReport.participant.uri must be absolute; a relative Uri is a programmer
+        // error at this library boundary and must fail fast rather than emit an invalid resource.
+        var relativeUri = new Uri("foo", UriKind.Relative);
+
+        // Act
+        var act = () => new TestReportContext { ServerUri = relativeUri };
+
+        // Assert
+        Should.Throw<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void GivenAbsoluteServerUri_WhenGenerating_ThenEmitsUriStringOnServerParticipant()
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "ServerUriTest",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+        var context = new TestReportContext { ServerUri = new Uri("https://fhir.example.org/r4") };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, context);
+
+        // Assert
+        var participants = json["participant"]!.AsArray();
+        participants[0]!["type"]!.GetValue<string>().ShouldBe("server");
+        participants[0]!["uri"]!.GetValue<string>().ShouldBe("https://fhir.example.org/r4");
+    }
+
+    [Fact]
+    public void GivenServerDisplay_WhenGenerating_ThenServerParticipantCarriesDisplay()
+    {
+        // Arrange
+        var report = new TestScriptReport
+        {
+            TestScriptName = "ServerDisplayTest",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+        var context = new TestReportContext
+        {
+            ServerUri = new Uri("https://fhir.example.org"),
+            ServerDisplay = "Reference Server"
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, context);
+
+        // Assert
+        var server = json["participant"]!.AsArray()[0]!.AsObject();
+        server["display"]!.GetValue<string>().ShouldBe("Reference Server");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GivenBlankOrNullServerDisplay_WhenGenerating_ThenServerParticipantHasNoDisplayKey(string? blank)
+    {
+        // Arrange: FHIR JSON permits null only inside arrays; a null object property is invalid,
+        // so an absent display must be omitted rather than emitted as null.
+        var report = new TestScriptReport
+        {
+            TestScriptName = "NoServerDisplayTest",
+            StartTime = DateTimeOffset.UnixEpoch,
+            EndTime = DateTimeOffset.UnixEpoch
+        };
+        var context = new TestReportContext
+        {
+            ServerUri = new Uri("https://fhir.example.org"),
+            ServerDisplay = blank
+        };
+
+        // Act
+        var json = TestReportResourceGenerator.Generate(report, context);
+
+        // Assert
+        var server = json["participant"]!.AsArray()[0]!.AsObject();
+        server.ContainsKey("display").ShouldBeFalse();
     }
 
     [Fact]

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/ReportFormat.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/ReportFormat.cs
@@ -1,0 +1,14 @@
+namespace Ignixa.ConformanceMatrix.Cli.Commands;
+
+/// <summary>Serialization shape for the <c>run</c> command's <c>--out</c> file.</summary>
+internal enum ReportFormat
+{
+    /// <summary>A FHIR <c>Bundle</c> of <c>TestReport</c> resources, one per executed TestScript.</summary>
+    Fhir,
+
+    /// <summary>
+    /// This tool's native per-impl report (<see cref="Reporting.ImplReport"/>) — the shape the
+    /// <c>merge</c> command consumes to build the conformance matrix.
+    /// </summary>
+    Json
+}

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -94,7 +94,12 @@ internal static class RunCommand
 
             var schema = new R4CoreSchemaProvider();
             using var httpClient = new HttpClient { BaseAddress = new Uri(server.TrimEnd('/') + '/') };
-            ApplyAuthHeader(httpClient, authHeader);
+            if (ApplyAuthHeader(httpClient, authHeader) is { } authError)
+            {
+                Console.Error.WriteLine($"error: {authError}");
+                return 1;
+            }
+
             if (fhirVersion is not null)
             {
                 var mediaType = $"application/fhir+json; fhirVersion={fhirVersion}";
@@ -201,9 +206,7 @@ internal static class RunCommand
             }
 
             var duration = (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-            var payload = format == ReportFormat.Json
-                ? SerializeImplReport(impl, startedAt, duration, allResults)
-                : BuildTestReportPayload(testReports, startedAt).ToJsonString(SerializerOptions);
+            var payload = BuildPayload(format, impl, startedAt, duration, allResults, testReports);
 
             EnsureDirectoryExists(outPath);
             await File.WriteAllTextAsync(outPath, payload, cancellationToken);
@@ -251,35 +254,47 @@ internal static class RunCommand
         return ("Authorization", trimmed);
     }
 
+    internal static string BuildPayload(
+        ReportFormat format,
+        string impl,
+        DateTimeOffset startedAt,
+        long durationMs,
+        IReadOnlyList<ImplReportResult> results,
+        IReadOnlyList<JsonObject> testReports) => format switch
+        {
+            ReportFormat.Json => SerializeImplReport(impl, startedAt, durationMs, results),
+            ReportFormat.Fhir => BuildTestReportPayload(testReports, startedAt).ToJsonString(SerializerOptions),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unhandled report format")
+        };
+
     internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports, DateTimeOffset timestamp)
     {
+        var payload = new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "collection",
+            ["timestamp"] = timestamp.ToString("o")
+        };
+
+        if (reports.Count == 0)
+            return payload;
+
         var entries = new JsonArray();
         foreach (var report in reports)
         {
+            // Bundle.entry.fullUrl must be absolute and agree with Resource.id; these TestReports
+            // are never persisted and carry no id, so urn:uuid is the form that fits — and it
+            // cannot collide the way a slugified file path can.
             entries.Add(new JsonObject
             {
-                ["fullUrl"] = $"TestReport/{SlugifyReport(report)}",
+                ["fullUrl"] = $"urn:uuid:{Guid.NewGuid()}",
                 ["resource"] = report
             });
         }
 
-        return new JsonObject
-        {
-            ["resourceType"] = "Bundle",
-            ["type"] = "collection",
-            ["timestamp"] = timestamp.ToString("o"),
-            ["entry"] = entries
-        };
-    }
-
-    private static string SlugifyReport(JsonObject report)
-    {
-        var source = report["testScript"]?["display"]?.GetValue<string>()
-            ?? report["name"]?.GetValue<string>()
-            ?? "testreport";
-
-        var normalized = new string([.. source.Select(c => char.IsAsciiLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-')]);
-        return string.Join('-', normalized.Split('-', StringSplitOptions.RemoveEmptyEntries));
+        // FHIR JSON prohibits empty arrays, so entry is omitted above rather than emitted as [].
+        payload["entry"] = entries;
+        return payload;
     }
 
     private static string SerializeImplReport(string impl, DateTimeOffset startedAt, long durationMs, IReadOnlyList<ImplReportResult> results) =>
@@ -299,28 +314,40 @@ internal static class RunCommand
     internal static int ClassifyExitCode(IReadOnlyList<ImplReportResult> results)
         => results.Any(r => MatrixBuilder.IsFail(r.Status)) ? 1 : 0;
 
-    private static void ApplyAuthHeader(HttpClient httpClient, string? authHeader)
+    /// <summary>
+    /// Applies <paramref name="authHeader"/> to <paramref name="httpClient"/>, returning an error
+    /// message when it cannot be applied and <c>null</c> on success.
+    /// </summary>
+    /// <remarks>
+    /// Every failure here must stop the run. Applying no header would exercise the whole suite
+    /// unauthenticated and report each 401 as a legitimate test failure, which is indistinguishable
+    /// from a broken server. Note the null check rather than IsNullOrWhiteSpace: an omitted flag is
+    /// null and means "no auth", while an explicit empty value is a mistake worth reporting — most
+    /// often an environment variable that expanded to nothing.
+    /// </remarks>
+    internal static string? ApplyAuthHeader(HttpClient httpClient, string? authHeader)
     {
-        if (string.IsNullOrWhiteSpace(authHeader))
-            return;
+        if (authHeader is null)
+            return null;
 
         var (name, value) = ParseAuthHeader(authHeader);
 
-        // Returning quietly here would run the whole suite unauthenticated and report every test
-        // as a legitimate 401 failure, which looks identical to a broken server.
         if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException($"--auth-header '{authHeader}' has no header value; expected 'Bearer <token>' or 'Header-Name: <value>'.", nameof(authHeader));
+            return $"--auth-header '{authHeader}' resolves to no header value; expected 'Bearer <token>' or 'Header-Name: <value>'. If an environment variable expands to empty, omit the flag instead of passing a blank value.";
 
-        if (name.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
+        if (name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)
+            && AuthenticationHeaderValue.TryParse(value, out var parsed))
         {
-            if (AuthenticationHeaderValue.TryParse(value, out var parsed))
-                httpClient.DefaultRequestHeaders.Authorization = parsed;
-            else
-                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(name, value);
-            return;
+            httpClient.DefaultRequestHeaders.Authorization = parsed;
+            return null;
         }
 
-        httpClient.DefaultRequestHeaders.TryAddWithoutValidation(name, value);
+        // TryAddWithoutValidation returns false (it does not throw) when the name is not a valid
+        // HTTP token, which would otherwise drop the credential without a trace.
+        if (!httpClient.DefaultRequestHeaders.TryAddWithoutValidation(name, value))
+            return $"--auth-header name '{name}' is not a valid HTTP header name.";
+
+        return null;
     }
 
     /// <summary>

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -19,6 +19,15 @@ internal static class RunCommand
 {
     private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
 
+    // TestReport.tester is "the name of the tester producing this report", which is this tool — not
+    // the server under test. The server is named by participant[server].display.
+    private const string ToolName = "Ignixa.ConformanceMatrix.Cli";
+
+    // Distinguishes "nothing ran because the invocation was wrong" from "the suite ran and tests
+    // failed" (ClassifyExitCode's 1), which a CI job otherwise cannot tell apart.
+    internal const int UsageErrorExitCode = 2;
+    internal const int InternalErrorExitCode = 3;
+
     public static Command Build()
     {
         var command = new Command("run", "Run a TestScript suite against a FHIR server and write a per-impl report");
@@ -64,20 +73,33 @@ internal static class RunCommand
         return command;
     }
 
-    private static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, string? authHeader, ReportFormat format, CancellationToken cancellationToken)
+    /// <summary>
+    /// Runs the suite and writes the report, returning the process exit code: 0 when everything
+    /// passed or was skipped, 1 when tests failed or errored, 2 when the invocation was unusable so
+    /// nothing ran, and 3 on an unexpected internal failure.
+    /// </summary>
+    internal static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, string? authHeader, ReportFormat format, CancellationToken cancellationToken)
     {
         try
         {
             if (!Directory.Exists(testsPath))
             {
                 Console.Error.WriteLine($"error: --tests directory not found: {testsPath}");
-                return 1;
+                return UsageErrorExitCode;
             }
 
             if (!Uri.TryCreate(server, UriKind.Absolute, out _))
             {
                 Console.Error.WriteLine($"error: --server is not a valid absolute URI: {server}");
-                return 1;
+                return UsageErrorExitCode;
+            }
+
+            // Before the suite runs, not at write time: a typo in --out that only surfaces after a
+            // full run against a live server discards every result it just spent minutes collecting.
+            if (PrepareOutputDirectory(outPath) is { } outError)
+            {
+                Console.Error.WriteLine($"error: {outError}");
+                return UsageErrorExitCode;
             }
 
             var startedAt = DateTimeOffset.UtcNow;
@@ -89,7 +111,7 @@ internal static class RunCommand
             if (files.Count == 0)
             {
                 Console.Error.WriteLine($"error: no .json files found in {testsPath} — no tests to run");
-                return 1;
+                return UsageErrorExitCode;
             }
 
             var schema = new R4CoreSchemaProvider();
@@ -97,7 +119,7 @@ internal static class RunCommand
             if (ApplyAuthHeader(httpClient, authHeader) is { } authError)
             {
                 Console.Error.WriteLine($"error: {authError}");
-                return 1;
+                return UsageErrorExitCode;
             }
 
             if (fhirVersion is not null)
@@ -118,7 +140,16 @@ internal static class RunCommand
             var capabilityStatement = await FetchCapabilityStatementAsync(httpClient, cancellationToken);
 
             var allResults = new List<ImplReportResult>();
-            var testReports = new List<JsonObject>();
+            var bundleResources = new List<JsonObject>();
+
+            // Only the FHIR bundle carries these; the native json report already records every
+            // failure as an "error" result, so the resource is not built at all under --format json.
+            void AddBundleResource(Func<JsonObject> resource)
+            {
+                if (format == ReportFormat.Fhir)
+                    bundleResources.Add(resource());
+            }
+
             foreach (var file in files)
             {
                 var relFile = Path.GetRelativePath(testsPath, file).Replace('\\', '/');
@@ -144,6 +175,7 @@ internal static class RunCommand
                         DurationMs = 0,
                         Error = new CellError { Assertion = "Parse exception", Received = ex.Message }
                     });
+                    AddBundleResource(() => BuildParseErrorOutcome(relFile, $"{ex.GetType().Name}: {ex.Message}"));
                     continue;
                 }
 
@@ -159,6 +191,7 @@ internal static class RunCommand
                         DurationMs = 0,
                         Error = new CellError { Assertion = "Parse error", Received = messages }
                     });
+                    AddBundleResource(() => BuildParseErrorOutcome(relFile, messages));
                     continue;
                 }
 
@@ -172,15 +205,13 @@ internal static class RunCommand
                 {
                     var report = await evaluator.ExecuteAsync(parseResult.Value!, cancellationToken,
                         fhirVersion: fhirVersion, capabilityStatement: capabilityStatement);
-                    if (format == ReportFormat.Fhir)
+                    AddBundleResource(() => TestReportResourceGenerator.Generate(report, new TestReportContext
                     {
-                        testReports.Add(TestReportResourceGenerator.Generate(report, new TestReportContext
-                        {
-                            Tester = impl,
-                            ServerUri = server,
-                            TestScriptDisplay = relFile
-                        }));
-                    }
+                        Tester = ToolName,
+                        ServerUri = httpClient.BaseAddress,
+                        ServerDisplay = impl,
+                        TestScriptDisplay = relFile
+                    }));
 
                     var mapped = ReportMapper.Map(report, relFile);
                     allResults.AddRange(mapped);
@@ -202,13 +233,13 @@ internal static class RunCommand
                         DurationMs = 0,
                         Error = new CellError { Assertion = "Evaluator error", Received = ex.Message }
                     });
+                    AddBundleResource(() => BuildEvaluatorErrorOutcome(relFile, ex));
                 }
             }
 
             var duration = (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-            var payload = BuildPayload(format, impl, startedAt, duration, allResults, testReports);
+            var payload = BuildPayload(format, impl, startedAt, duration, allResults, bundleResources);
 
-            EnsureDirectoryExists(outPath);
             await File.WriteAllTextAsync(outPath, payload, cancellationToken);
 
             Console.WriteLine($"\n{impl}: {FormatOutcomeSummary(allResults)} ({duration}ms) -> {outPath}");
@@ -220,9 +251,30 @@ internal static class RunCommand
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"error: {ex.GetType().Name}: {ex.Message}");
-            return 1;
+            // The full exception, not just Message: this catch only sees bugs and unhandled
+            // transport failures, where the stack and the inner chain are the actionable part —
+            // a bare "NullReferenceException: Object reference not set" is not, and an
+            // HttpRequestException's message hides the SocketException that explains it.
+            Console.Error.WriteLine($"error: unexpected failure: {ex}");
+            return InternalErrorExitCode;
         }
+    }
+
+    /// <summary>
+    /// Records a script the runner could not parse, so a failure that produces no TestReport still
+    /// appears in the FHIR bundle rather than only in the console scrollback.
+    /// </summary>
+    internal static JsonObject BuildParseErrorOutcome(string file, string detail) =>
+        OperationOutcomeResourceGenerator.Generate(
+            OperationOutcomeResourceGenerator.StructureIssueCode, $"{file}: {detail}");
+
+    /// <summary>Records a script whose execution threw rather than producing a report.</summary>
+    internal static JsonObject BuildEvaluatorErrorOutcome(string file, Exception error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return OperationOutcomeResourceGenerator.Generate(
+            OperationOutcomeResourceGenerator.ExceptionIssueCode,
+            $"{file}: {error.GetType().Name}: {error.Message}");
     }
 
     internal static string FormatOutcomeSummary(IReadOnlyList<ImplReportResult> results)
@@ -260,14 +312,18 @@ internal static class RunCommand
         DateTimeOffset startedAt,
         long durationMs,
         IReadOnlyList<ImplReportResult> results,
-        IReadOnlyList<JsonObject> testReports) => format switch
+        IReadOnlyList<JsonObject> bundleResources) => format switch
         {
             ReportFormat.Json => SerializeImplReport(impl, startedAt, durationMs, results),
-            ReportFormat.Fhir => BuildTestReportPayload(testReports, startedAt).ToJsonString(SerializerOptions),
+            ReportFormat.Fhir => BuildFhirBundle(bundleResources, startedAt).ToJsonString(SerializerOptions),
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unhandled report format")
         };
 
-    internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports, DateTimeOffset timestamp)
+    /// <summary>
+    /// Wraps the run's resources — a TestReport per executed script, an OperationOutcome per script
+    /// that could not be — in a <c>collection</c> Bundle.
+    /// </summary>
+    internal static JsonObject BuildFhirBundle(IReadOnlyList<JsonObject> resources, DateTimeOffset timestamp)
     {
         var payload = new JsonObject
         {
@@ -276,19 +332,19 @@ internal static class RunCommand
             ["timestamp"] = timestamp.ToString("o")
         };
 
-        if (reports.Count == 0)
+        if (resources.Count == 0)
             return payload;
 
         var entries = new JsonArray();
-        foreach (var report in reports)
+        foreach (var resource in resources)
         {
-            // Bundle.entry.fullUrl must be absolute and agree with Resource.id; these TestReports
+            // Bundle.entry.fullUrl must be absolute and agree with Resource.id; these resources
             // are never persisted and carry no id, so urn:uuid is the form that fits — and it
             // cannot collide the way a slugified file path can.
             entries.Add(new JsonObject
             {
                 ["fullUrl"] = $"urn:uuid:{Guid.NewGuid()}",
-                ["resource"] = report
+                ["resource"] = resource
             });
         }
 
@@ -302,13 +358,29 @@ internal static class RunCommand
             new ImplReport { Impl = impl, StartedAt = startedAt, DurationMs = durationMs, Results = results },
             SerializerOptions);
 
-    // Path.GetDirectoryName returns null for a root path (e.g. "C:\"), where there is nothing to
-    // create; Directory.CreateDirectory(null) would throw instead.
-    private static void EnsureDirectoryExists(string path)
+    /// <summary>
+    /// Creates the directory <paramref name="path"/> will be written to, returning an error message
+    /// when the path is unusable and <c>null</c> on success.
+    /// </summary>
+    /// <remarks>
+    /// Path.GetDirectoryName returns null for a root path (e.g. "C:\"), where there is nothing to
+    /// create; Directory.CreateDirectory(null) would throw instead. Path.GetFullPath rejects invalid
+    /// path characters by throwing, which is a usage error to report rather than an internal fault.
+    /// </remarks>
+    internal static string? PrepareOutputDirectory(string path)
     {
-        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
-        if (!string.IsNullOrEmpty(directory))
-            Directory.CreateDirectory(directory);
+        try
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+            return null;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException
+            or PathTooLongException or IOException or UnauthorizedAccessException)
+        {
+            return $"--out path is unusable: {path} ({ex.GetType().Name}: {ex.Message})";
+        }
     }
 
     internal static int ClassifyExitCode(IReadOnlyList<ImplReportResult> results)

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -26,7 +26,7 @@ internal static class RunCommand
         var serverOption = new Option<string>("--server") { Description = "Base URL of the FHIR server", Required = true };
         var testsOption = new Option<string>("--tests") { Description = "Folder containing TestScript .json files", Required = true };
         var implOption = new Option<string>("--impl") { Description = "Implementation name (column label in the matrix)", Required = true };
-        var outOption = new Option<string>("--out") { Description = "Output path for the per-impl report JSON", Required = true };
+        var outOption = new Option<string>("--out") { Description = "Output path for the report file; --format selects its shape", Required = true };
         var fhirVersionOption = new Option<string?>("--fhir-version")
         {
             Description = "FHIR version to test against (e.g. '4.0', '4.3', '5.0'). Sets fhirVersion on the Accept header and skips tests not tagged for this version. Omit to run all tests against any server."

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -3,9 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Ignixa.ConformanceMatrix.Cli.Reporting;
-using Ignixa.Models;
 using Ignixa.Serialization;
-using Ignixa.TestScript.Reporting;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.Generated;
 using Ignixa.TestScript.Client;
@@ -13,11 +11,14 @@ using Ignixa.TestScript.Evaluation;
 using Ignixa.TestScript.FhirFakes;
 using Ignixa.TestScript.Fixtures;
 using Ignixa.TestScript.Parsing;
+using Ignixa.TestScript.Reporting;
 
 namespace Ignixa.ConformanceMatrix.Cli.Commands;
 
 internal static class RunCommand
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
     public static Command Build()
     {
         var command = new Command("run", "Run a TestScript suite against a FHIR server and write a per-impl report");
@@ -34,9 +35,10 @@ internal static class RunCommand
         {
             Description = "Authentication header value to apply to every request (for example 'Bearer <token>' or 'Authorization: Bearer <token>')"
         };
-        var testReportOption = new Option<string?>("--test-report")
+        var formatOption = new Option<ReportFormat>("--format")
         {
-            Description = "Optional path to write FHIR TestReport output as a JSON resource or Bundle"
+            Description = "Shape of the --out file: 'fhir' (a Bundle of FHIR TestReport resources, the default) or 'json' (this tool's native per-impl report, which is what 'merge' consumes)",
+            DefaultValueFactory = _ => ReportFormat.Fhir
         };
 
         command.Options.Add(serverOption);
@@ -45,7 +47,7 @@ internal static class RunCommand
         command.Options.Add(outOption);
         command.Options.Add(fhirVersionOption);
         command.Options.Add(authHeaderOption);
-        command.Options.Add(testReportOption);
+        command.Options.Add(formatOption);
 
         command.SetAction((parseResult, cancellationToken) =>
         {
@@ -55,14 +57,14 @@ internal static class RunCommand
             var outPath = parseResult.GetValue(outOption)!;
             var fhirVersion = parseResult.GetValue(fhirVersionOption);
             var authHeader = parseResult.GetValue(authHeaderOption);
-            var testReportPath = parseResult.GetValue(testReportOption);
-            return RunAsync(server, tests, impl, outPath, fhirVersion, authHeader, testReportPath, cancellationToken);
+            var format = parseResult.GetValue(formatOption);
+            return RunAsync(server, tests, impl, outPath, fhirVersion, authHeader, format, cancellationToken);
         });
 
         return command;
     }
 
-    private static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, string? authHeader, string? testReportPath, CancellationToken cancellationToken)
+    private static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, string? authHeader, ReportFormat format, CancellationToken cancellationToken)
     {
         try
         {
@@ -165,8 +167,15 @@ internal static class RunCommand
                 {
                     var report = await evaluator.ExecuteAsync(parseResult.Value!, cancellationToken,
                         fhirVersion: fhirVersion, capabilityStatement: capabilityStatement);
-                    if (!string.IsNullOrWhiteSpace(testReportPath))
-                        testReports.Add(TestReportResourceGenerator.Generate(report));
+                    if (format == ReportFormat.Fhir)
+                    {
+                        testReports.Add(TestReportResourceGenerator.Generate(report, new TestReportContext
+                        {
+                            Tester = impl,
+                            ServerUri = server,
+                            TestScriptDisplay = relFile
+                        }));
+                    }
 
                     var mapped = ReportMapper.Map(report, relFile);
                     allResults.AddRange(mapped);
@@ -192,20 +201,12 @@ internal static class RunCommand
             }
 
             var duration = (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-            var implReport = new ImplReport
-            {
-                Impl = impl,
-                StartedAt = startedAt,
-                DurationMs = duration,
-                Results = allResults
-            };
+            var payload = format == ReportFormat.Json
+                ? SerializeImplReport(impl, startedAt, duration, allResults)
+                : BuildTestReportPayload(testReports, startedAt).ToJsonString(SerializerOptions);
 
-            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outPath))!);
-            var json = JsonSerializer.Serialize(implReport, new JsonSerializerOptions { WriteIndented = true });
-            await File.WriteAllTextAsync(outPath, json, cancellationToken);
-
-            if (!string.IsNullOrWhiteSpace(testReportPath))
-                await WriteTestReportAsync(testReportPath, testReports, cancellationToken);
+            EnsureDirectoryExists(outPath);
+            await File.WriteAllTextAsync(outPath, payload, cancellationToken);
 
             Console.WriteLine($"\n{impl}: {FormatOutcomeSummary(allResults)} ({duration}ms) -> {outPath}");
             return ClassifyExitCode(allResults);
@@ -230,49 +231,69 @@ internal static class RunCommand
         return $"{pass} passed, {fail} failed, {skipped} skipped, {error} error(s)";
     }
 
+    // An HTTP header name cannot contain whitespace, so text before the first colon that has none
+    // is a header name and anything else is a bare credential for Authorization. This holds for
+    // any scheme — Negotiate, NTLM, AWS4-HMAC-SHA256 — without enumerating them.
     internal static (string Name, string Value) ParseAuthHeader(string input)
     {
         var trimmed = input.Trim();
         if (trimmed.Length == 0)
             return ("Authorization", string.Empty);
 
-        if (trimmed.Contains(':')
-            && !trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-            && !trimmed.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)
-            && !trimmed.StartsWith("Digest ", StringComparison.OrdinalIgnoreCase))
+        var separatorIndex = trimmed.IndexOf(':');
+        if (separatorIndex > 0)
         {
-            var separatorIndex = trimmed.IndexOf(':');
-            return (trimmed[..separatorIndex].Trim(), trimmed[(separatorIndex + 1)..].Trim());
+            var name = trimmed[..separatorIndex].Trim();
+            if (name.Length > 0 && !name.Any(char.IsWhiteSpace))
+                return (name, trimmed[(separatorIndex + 1)..].Trim());
         }
 
         return ("Authorization", trimmed);
     }
 
-    internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports)
+    internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports, DateTimeOffset timestamp)
     {
-        if (reports.Count == 1)
-            return reports[0];
-
-        var bundle = new Bundle();
-        ((IMutableJsonNode)bundle).MutableNode["type"] = "collection";
-
+        var entries = new JsonArray();
         foreach (var report in reports)
         {
-            bundle.Entry.Add(new Ignixa.Models.BundleEntry
+            entries.Add(new JsonObject
             {
-                Resource = new ResourceJsonNode(report)
+                ["fullUrl"] = $"TestReport/{SlugifyReport(report)}",
+                ["resource"] = report
             });
         }
 
-        return ((IMutableJsonNode)bundle).MutableNode;
+        return new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "collection",
+            ["timestamp"] = timestamp.ToString("o"),
+            ["entry"] = entries
+        };
     }
 
-    internal static async Task WriteTestReportAsync(string path, IReadOnlyList<JsonObject> reports, CancellationToken cancellationToken)
+    private static string SlugifyReport(JsonObject report)
     {
-        var payload = BuildTestReportPayload(reports);
-        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
-        var json = payload.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(path, json, cancellationToken);
+        var source = report["testScript"]?["display"]?.GetValue<string>()
+            ?? report["name"]?.GetValue<string>()
+            ?? "testreport";
+
+        var normalized = new string([.. source.Select(c => char.IsAsciiLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-')]);
+        return string.Join('-', normalized.Split('-', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static string SerializeImplReport(string impl, DateTimeOffset startedAt, long durationMs, IReadOnlyList<ImplReportResult> results) =>
+        JsonSerializer.Serialize(
+            new ImplReport { Impl = impl, StartedAt = startedAt, DurationMs = durationMs, Results = results },
+            SerializerOptions);
+
+    // Path.GetDirectoryName returns null for a root path (e.g. "C:\"), where there is nothing to
+    // create; Directory.CreateDirectory(null) would throw instead.
+    private static void EnsureDirectoryExists(string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
     }
 
     internal static int ClassifyExitCode(IReadOnlyList<ImplReportResult> results)
@@ -284,8 +305,11 @@ internal static class RunCommand
             return;
 
         var (name, value) = ParseAuthHeader(authHeader);
-        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value))
-            return;
+
+        // Returning quietly here would run the whole suite unauthenticated and report every test
+        // as a legitimate 401 failure, which looks identical to a broken server.
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"--auth-header '{authHeader}' has no header value; expected 'Bearer <token>' or 'Header-Name: <value>'.", nameof(authHeader));
 
         if (name.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
         {

--- a/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Commands/RunCommand.cs
@@ -1,7 +1,11 @@
 using System.CommandLine;
+using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Ignixa.ConformanceMatrix.Cli.Reporting;
+using Ignixa.Models;
 using Ignixa.Serialization;
+using Ignixa.TestScript.Reporting;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.Generated;
 using Ignixa.TestScript.Client;
@@ -26,12 +30,22 @@ internal static class RunCommand
         {
             Description = "FHIR version to test against (e.g. '4.0', '4.3', '5.0'). Sets fhirVersion on the Accept header and skips tests not tagged for this version. Omit to run all tests against any server."
         };
+        var authHeaderOption = new Option<string?>("--auth-header")
+        {
+            Description = "Authentication header value to apply to every request (for example 'Bearer <token>' or 'Authorization: Bearer <token>')"
+        };
+        var testReportOption = new Option<string?>("--test-report")
+        {
+            Description = "Optional path to write FHIR TestReport output as a JSON resource or Bundle"
+        };
 
         command.Options.Add(serverOption);
         command.Options.Add(testsOption);
         command.Options.Add(implOption);
         command.Options.Add(outOption);
         command.Options.Add(fhirVersionOption);
+        command.Options.Add(authHeaderOption);
+        command.Options.Add(testReportOption);
 
         command.SetAction((parseResult, cancellationToken) =>
         {
@@ -40,13 +54,15 @@ internal static class RunCommand
             var impl = parseResult.GetValue(implOption)!;
             var outPath = parseResult.GetValue(outOption)!;
             var fhirVersion = parseResult.GetValue(fhirVersionOption);
-            return RunAsync(server, tests, impl, outPath, fhirVersion, cancellationToken);
+            var authHeader = parseResult.GetValue(authHeaderOption);
+            var testReportPath = parseResult.GetValue(testReportOption);
+            return RunAsync(server, tests, impl, outPath, fhirVersion, authHeader, testReportPath, cancellationToken);
         });
 
         return command;
     }
 
-    private static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, CancellationToken cancellationToken)
+    private static async Task<int> RunAsync(string server, string testsPath, string impl, string outPath, string? fhirVersion, string? authHeader, string? testReportPath, CancellationToken cancellationToken)
     {
         try
         {
@@ -76,6 +92,7 @@ internal static class RunCommand
 
             var schema = new R4CoreSchemaProvider();
             using var httpClient = new HttpClient { BaseAddress = new Uri(server.TrimEnd('/') + '/') };
+            ApplyAuthHeader(httpClient, authHeader);
             if (fhirVersion is not null)
             {
                 var mediaType = $"application/fhir+json; fhirVersion={fhirVersion}";
@@ -94,6 +111,7 @@ internal static class RunCommand
             var capabilityStatement = await FetchCapabilityStatementAsync(httpClient, cancellationToken);
 
             var allResults = new List<ImplReportResult>();
+            var testReports = new List<JsonObject>();
             foreach (var file in files)
             {
                 var relFile = Path.GetRelativePath(testsPath, file).Replace('\\', '/');
@@ -147,12 +165,13 @@ internal static class RunCommand
                 {
                     var report = await evaluator.ExecuteAsync(parseResult.Value!, cancellationToken,
                         fhirVersion: fhirVersion, capabilityStatement: capabilityStatement);
+                    if (!string.IsNullOrWhiteSpace(testReportPath))
+                        testReports.Add(TestReportResourceGenerator.Generate(report));
+
                     var mapped = ReportMapper.Map(report, relFile);
                     allResults.AddRange(mapped);
 
-                    var pass = mapped.Count(r => r.Status == "pass");
-                    var fail = mapped.Count(r => MatrixBuilder.IsFail(r.Status));
-                    Console.WriteLine($"    {pass} passed, {fail} failed");
+                    Console.WriteLine($"    {FormatOutcomeSummary(mapped)}");
                 }
                 catch (OperationCanceledException)
                 {
@@ -185,10 +204,10 @@ internal static class RunCommand
             var json = JsonSerializer.Serialize(implReport, new JsonSerializerOptions { WriteIndented = true });
             await File.WriteAllTextAsync(outPath, json, cancellationToken);
 
-            var totalPass = allResults.Count(r => r.Status == "pass");
-            var totalFail = allResults.Count(r => MatrixBuilder.IsFail(r.Status));
-            var totalError = allResults.Count(r => r.Status == "error");
-            Console.WriteLine($"\n{impl}: {totalPass} passed, {totalFail} failed, {totalError} error(s) ({duration}ms) -> {outPath}");
+            if (!string.IsNullOrWhiteSpace(testReportPath))
+                await WriteTestReportAsync(testReportPath, testReports, cancellationToken);
+
+            Console.WriteLine($"\n{impl}: {FormatOutcomeSummary(allResults)} ({duration}ms) -> {outPath}");
             return ClassifyExitCode(allResults);
         }
         catch (OperationCanceledException)
@@ -202,8 +221,83 @@ internal static class RunCommand
         }
     }
 
+    internal static string FormatOutcomeSummary(IReadOnlyList<ImplReportResult> results)
+    {
+        var pass = results.Count(r => r.Status == "pass");
+        var fail = results.Count(r => r.Status == "fail");
+        var skipped = results.Count(r => r.Status == "skipped");
+        var error = results.Count(r => r.Status == "error");
+        return $"{pass} passed, {fail} failed, {skipped} skipped, {error} error(s)";
+    }
+
+    internal static (string Name, string Value) ParseAuthHeader(string input)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.Length == 0)
+            return ("Authorization", string.Empty);
+
+        if (trimmed.Contains(':')
+            && !trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+            && !trimmed.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)
+            && !trimmed.StartsWith("Digest ", StringComparison.OrdinalIgnoreCase))
+        {
+            var separatorIndex = trimmed.IndexOf(':');
+            return (trimmed[..separatorIndex].Trim(), trimmed[(separatorIndex + 1)..].Trim());
+        }
+
+        return ("Authorization", trimmed);
+    }
+
+    internal static JsonObject BuildTestReportPayload(IReadOnlyList<JsonObject> reports)
+    {
+        if (reports.Count == 1)
+            return reports[0];
+
+        var bundle = new Bundle();
+        ((IMutableJsonNode)bundle).MutableNode["type"] = "collection";
+
+        foreach (var report in reports)
+        {
+            bundle.Entry.Add(new Ignixa.Models.BundleEntry
+            {
+                Resource = new ResourceJsonNode(report)
+            });
+        }
+
+        return ((IMutableJsonNode)bundle).MutableNode;
+    }
+
+    internal static async Task WriteTestReportAsync(string path, IReadOnlyList<JsonObject> reports, CancellationToken cancellationToken)
+    {
+        var payload = BuildTestReportPayload(reports);
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        var json = payload.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json, cancellationToken);
+    }
+
     internal static int ClassifyExitCode(IReadOnlyList<ImplReportResult> results)
         => results.Any(r => MatrixBuilder.IsFail(r.Status)) ? 1 : 0;
+
+    private static void ApplyAuthHeader(HttpClient httpClient, string? authHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authHeader))
+            return;
+
+        var (name, value) = ParseAuthHeader(authHeader);
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value))
+            return;
+
+        if (name.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
+        {
+            if (AuthenticationHeaderValue.TryParse(value, out var parsed))
+                httpClient.DefaultRequestHeaders.Authorization = parsed;
+            else
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(name, value);
+            return;
+        }
+
+        httpClient.DefaultRequestHeaders.TryAddWithoutValidation(name, value);
+    }
 
     /// <summary>
     /// Fetches the target server's CapabilityStatement from <c>/metadata</c> once per run, so it

--- a/tools/Ignixa.ConformanceMatrix.Cli/README.md
+++ b/tools/Ignixa.ConformanceMatrix.Cli/README.md
@@ -47,7 +47,7 @@ ignixa-matrix merge --results ./reports --out ./matrix \
 
 | Value | Output |
 |-------|--------|
-| `fhir` (default) | A FHIR `Bundle` (`type: collection`) of `TestReport` resources, one entry per TestScript. |
+| `fhir` (default) | A FHIR `Bundle` (`type: collection`) — a `TestReport` per executed TestScript, plus an `OperationOutcome` per script that could not be run. |
 | `json` | This tool's native per-implementation report — the shape `merge` reads. |
 
 ## Behavior
@@ -55,8 +55,28 @@ ignixa-matrix merge --results ./reports --out ./matrix \
 - `run` exits non-zero when any test fails **or errors** — an engine or transport error is never
   reported as a pass. Crashed scripts are recorded as `error` cells rather than aborting the run,
   and parse warnings are printed per file.
+- Scripts that never ran — a file that failed to parse, or one whose execution threw — have no
+  `TestReport` to speak for them, so under `--format fhir` each is recorded as an `OperationOutcome`
+  entry: `structure` for a parse failure, `exception` for an evaluator error, with the file name in
+  `diagnostics`. Without these, a suite whose scripts all failed to parse would write a `Bundle`
+  with no entries, indistinguishable from a clean run of nothing.
 - `--fhir-version` sets the `fhirVersion` parameter on the `Accept` header for version-gated suites.
 - `merge` replaces an existing run with the same id instead of duplicating it, and refuses to
   proceed when a report file is unreadable.
+
+### Exit codes
+
+`run` distinguishes a broken invocation from a completed run with failures, so CI can tell "nothing
+ran" from "the suite ran and 3 tests failed":
+
+| Code | Meaning |
+|------|---------|
+| `0` | Every test passed or was skipped. |
+| `1` | The suite ran; at least one test failed or errored. |
+| `2` | Usage error — an unusable `--tests`, `--server`, `--auth-header`, or `--out`. Nothing ran. |
+| `3` | Unexpected internal failure. The full exception, including its stack and inner chain, is printed to stderr. |
+
+`--out` is validated **before** the suite runs, so a bad path fails fast rather than discarding a
+completed run against a live server.
 
 Built on the [Ignixa.TestScript](https://www.nuget.org/packages/Ignixa.TestScript) execution engine.

--- a/tools/Ignixa.ConformanceMatrix.Cli/README.md
+++ b/tools/Ignixa.ConformanceMatrix.Cli/README.md
@@ -12,7 +12,8 @@ dotnet tool install -g Ignixa.ConformanceMatrix.Cli
 
 ## Usage
 
-Run a conformance suite against a server, producing a per-implementation report:
+Run a conformance suite against a server. `--out` is the report file; `--format` selects its shape,
+defaulting to a FHIR `Bundle` of `TestReport` resources — one per executed TestScript:
 
 ```bash
 ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
@@ -27,12 +28,12 @@ ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests 
   --auth-header "Bearer <token>"
 ```
 
-To emit FHIR TestReport output, provide a path for the JSON file:
+`merge` consumes this tool's native per-implementation report rather than FHIR `TestReport`, so pass
+`--format json` when the run feeds the matrix:
 
 ```bash
 ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
-  --impl my-server --out ./reports/my-server.json \
-  --test-report ./reports/my-server.testreport.json
+  --impl my-server --out ./reports/my-server.json --format json
 ```
 
 Merge per-implementation reports into the matrix output (`runs/` + `index.json`):
@@ -41,6 +42,13 @@ Merge per-implementation reports into the matrix output (`runs/` + `index.json`)
 ignixa-matrix merge --results ./reports --out ./matrix \
   --commit "$(git rev-parse HEAD)" --branch main
 ```
+
+### `--format`
+
+| Value | Output |
+|-------|--------|
+| `fhir` (default) | A FHIR `Bundle` (`type: collection`) of `TestReport` resources, one entry per TestScript. |
+| `json` | This tool's native per-implementation report — the shape `merge` reads. |
 
 ## Behavior
 

--- a/tools/Ignixa.ConformanceMatrix.Cli/README.md
+++ b/tools/Ignixa.ConformanceMatrix.Cli/README.md
@@ -19,6 +19,22 @@ ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests 
   --impl my-server --out ./reports/my-server.json
 ```
 
+To authenticate requests, supply an auth header value:
+
+```bash
+ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
+  --impl my-server --out ./reports/my-server.json \
+  --auth-header "Bearer <token>"
+```
+
+To emit FHIR TestReport output, provide a path for the JSON file:
+
+```bash
+ignixa-matrix run --server https://your-fhir-server --tests ./conformance-tests \
+  --impl my-server --out ./reports/my-server.json \
+  --test-report ./reports/my-server.testreport.json
+```
+
 Merge per-implementation reports into the matrix output (`runs/` + `index.json`):
 
 ```bash

--- a/tools/Ignixa.ConformanceMatrix.Cli/Reporting/OperationOutcomeResourceGenerator.cs
+++ b/tools/Ignixa.ConformanceMatrix.Cli/Reporting/OperationOutcomeResourceGenerator.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Nodes;
+
+namespace Ignixa.ConformanceMatrix.Cli.Reporting;
+
+/// <summary>
+/// Builds FHIR <c>OperationOutcome</c> resources recording scripts the runner could not execute.
+/// </summary>
+/// <remarks>
+/// A script that never ran has no TestReport to speak for it: <c>TestReport.testScript</c> references
+/// the TestScript that was executed, and a file that failed to parse never became one. The status
+/// codes that look close are not — <c>entered-in-error</c> means the report itself was created in
+/// error (a retraction, not "the test errored") and <c>stopped</c> means a human halted the run.
+/// OperationOutcome is what FHIR defines for "this could not be performed", and
+/// <c>Bundle.type = collection</c> places no homogeneity constraint on entries, so these sit
+/// alongside TestReports legally.
+/// </remarks>
+internal static class OperationOutcomeResourceGenerator
+{
+    /// <summary>"unable to parse the content completely, invalid syntax".</summary>
+    public const string StructureIssueCode = "structure";
+
+    /// <summary>"An unexpected internal error has occurred".</summary>
+    public const string ExceptionIssueCode = "exception";
+
+    // OperationOutcome.issue is 1..*, so exactly one issue is always emitted. Severity is fixed at
+    // error because every caller here is reporting a script that did not run.
+    public static JsonObject Generate(string issueCode, string diagnostics)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(diagnostics);
+
+        return new JsonObject
+        {
+            ["resourceType"] = "OperationOutcome",
+            ["issue"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["severity"] = "error",
+                    ["code"] = issueCode,
+                    ["diagnostics"] = diagnostics
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add `--auth-header` so the conformance runner can authenticate every request
- add `--format <fhir|json>`; `--out` is now the single report file and `--format` selects its shape
- **`fhir` is the new default** — a `Bundle` of `TestReport` resources, matching the shape `ignixa-lab`'s frontend produces
- fix a set of FHIR-validity and silent-failure defects found in review (details below)

## ⚠️ Breaking

**Runs that feed `ignixa-matrix merge` must now pass `--format json`.**

`merge` deserializes the native `ImplReport`; handed a `TestReport` Bundle it fails loudly (`JsonException`, non-zero exit) rather than producing a wrong matrix. Nothing in CI invokes this CLI today — the only call sites were two doc examples, both updated — so the blast radius is limited, but any local pipeline needs the flag.

| `--format` | Output |
|---|---|
| `fhir` (default) | `Bundle` (`type: collection`) — a `TestReport` per executed script, plus an `OperationOutcome` per script that could not run |
| `json` | this tool's native per-impl report — the shape `merge` reads |

Exit codes now distinguish a broken invocation from a completed run with failures: `0` pass/skip, `1` tests failed, `2` usage error (nothing ran), `3` internal failure.

## FHIR validity

`TestReportResourceGenerator` never emitted `TestReport.testScript`, which is 1..1 in R4 — **every** consumer produced an invalid resource, not just this CLI. Also fixed, all of which the default output now depends on:

- `testScript` always emitted; a relative path goes in `display`, never `reference` (a relative `Reference.reference` parses as `[type]/[id]`)
- `Bundle.entry.fullUrl` is `urn:uuid:` — absolute per R4, and collision-free unlike the slug it replaced
- `entry` omitted when empty, `test.description` omitted when absent — FHIR prohibits empty arrays and null object properties
- `score` excludes skipped tests. Counting them as misses made a version-gated script report `"result": "pass"` with `"score": 0`, and disagreed with `MatrixBuilder`, which keeps skipped out of both pass and fail
- `tester` is the tool, per its R4 definition ("Name of the tester producing this report"); the server under test moved to `participant[server].display`, where it belongs
- scripts that never ran (parse failure, evaluator throw) are recorded as `OperationOutcome` (`structure` / `exception`). Not `TestReport` with `entered-in-error`, which officially means "this test report was entered or created in error" — a retraction

## Silent failures

- `ApplyAuthHeader` guards on `null`, not `IsNullOrWhiteSpace`: `--auth-header "$TOKEN"` with the var unset previously ran the whole suite unauthenticated and reported every 401 as a legitimate failure
- `TryAddWithoutValidation`'s return is checked — it returns `false` (doesn't throw) for an invalid header name, silently dropping the credential
- `ParseAuthHeader` uses a whitespace-before-colon rule instead of a hardcoded `Bearer`/`Basic`/`Digest` list, so `Negotiate`, `NTLM`, `AWS4-HMAC-SHA256` and colon-bearing credentials work
- the outer catch prints the full exception rather than just type + message, which dropped the stack and inner chain
- `--out` is validated before the suite runs, so a typo can't discard a completed run against a live server

## API

`TestReportResourceGenerator.Generate(report, context = null)` takes an optional `TestReportContext`. `Generate(report)` still works, so existing call sites are unaffected. `TestReportContext.ServerUri` is typed `Uri` and rejects a relative one at construction — `Ignixa.TestScript` is packable, so that change is breaking after release and free before it.

## Testing

- `dotnet test test/Ignixa.ConformanceMatrix.Cli.Tests/Ignixa.ConformanceMatrix.Cli.Tests.csproj` — 68 tests
- `dotnet test test/Ignixa.TestScript.Tests/Ignixa.TestScript.Tests.csproj` — 301 tests × net9.0/net10.0
- driven end-to-end, not just unit tested: mixed valid/broken suite → Bundle carries both a `TestReport` and an `OperationOutcome`, zero null object properties, zero empty arrays; `--format json` → `merge` succeeds; `--format fhir` → `merge` aborts with exit 1; bad `--auth-header` and bad `--tests` → exit 2

## Follow-up

#343 — a rejected credential still runs the whole suite. This PR closes the auth failures observable at the input boundary; a wrong-but-well-formed token is only observable in the responses.