### PR TITLE
Search trace: structured plan/SQL surface, invariant guards, unified labels

### DIFF
--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainRow.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainRow.cs
@@ -21,21 +21,100 @@ namespace Ignixa.Search.Sql.Ast;
 /// structural node composes. <see cref="Body"/> is display text and is free to change wording.
 /// </para>
 /// <para>
-/// Rows with no SQL of their own (<c>sort</c>, <c>page</c>, <c>countOnly</c>) repeat their display name as
-/// the canonical one, so a consumer never has to special-case a null.
+/// Every row repeats its display name as the canonical one except the match CTE, so a consumer never has
+/// to special-case a null. Note that <c>sort</c>, <c>page</c> and <c>countOnly</c> do affect the emitted
+/// SQL — they contribute ORDER BY, TOP, seek predicates and the COUNT_BIG shape — they simply own no
+/// <see cref="Builders.SqlTextRange"/> carrying their name, so looking one up by their label finds
+/// nothing.
+/// </para>
+/// <para>
+/// Not a positional record, for the same reason as its siblings: the labels and kind are identifiers a
+/// consumer addresses rows by, and an empty one addresses nothing. <see cref="ReferencedCteIndexes"/> is
+/// copied on the way in and compared element-wise by <see cref="Equals(PlanExplainRow)"/> — a record's
+/// synthesized equality compares a collection property by reference, which would make two rows describing
+/// the same plan node unequal.
 /// </para>
 /// </remarks>
-/// <param name="Label">Display name for the row.</param>
-/// <param name="CanonicalLabel">The identifier this row is addressable by in the emitted SQL.</param>
-/// <param name="Kind">Which plan node produced the row — see <see cref="PlanRowKind"/>.</param>
-/// <param name="Body">Formatted, human-facing description. Not a stable contract.</param>
-/// <param name="ReferencedCteIndexes">
-/// Indexes of the CTEs this row's node composes, in the order the node names them. Empty for leaf
-/// sources and for non-CTE rows.
-/// </param>
-public sealed record PlanExplainRow(
-    string Label,
-    string CanonicalLabel,
-    string Kind,
-    string Body,
-    IReadOnlyList<int> ReferencedCteIndexes);
+public sealed record PlanExplainRow
+{
+    public PlanExplainRow(
+        string label,
+        string canonicalLabel,
+        string kind,
+        string body,
+        IReadOnlyList<int> referencedCteIndexes)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(label);
+        ArgumentException.ThrowIfNullOrEmpty(canonicalLabel);
+        ArgumentException.ThrowIfNullOrEmpty(kind);
+        ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(referencedCteIndexes);
+
+        foreach (var index in referencedCteIndexes)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(index, nameof(referencedCteIndexes));
+        }
+
+        Label = label;
+        CanonicalLabel = canonicalLabel;
+        Kind = kind;
+        Body = body;
+        ReferencedCteIndexes = [.. referencedCteIndexes];
+    }
+
+    /// <summary>Display name for the row.</summary>
+    public string Label { get; }
+
+    /// <summary>The identifier this row is addressable by in the emitted SQL.</summary>
+    public string CanonicalLabel { get; }
+
+    /// <summary>Which plan node produced the row — see <see cref="PlanRowKind"/>.</summary>
+    public string Kind { get; }
+
+    /// <summary>Formatted, human-facing description. Not a stable contract.</summary>
+    public string Body { get; }
+
+    /// <summary>
+    /// Indexes of the CTEs this row's node composes, in the order the node names them — the order is
+    /// load-bearing for <see cref="PlanRowKind.Except"/>, where left and right are not interchangeable.
+    /// Empty for leaf sources and for non-CTE rows.
+    /// </summary>
+    public IReadOnlyList<int> ReferencedCteIndexes { get; }
+
+    public bool Equals(PlanExplainRow? other)
+        => other is not null
+            && Label == other.Label
+            && CanonicalLabel == other.CanonicalLabel
+            && Kind == other.Kind
+            && Body == other.Body
+            && ReferencedCteIndexes.SequenceEqual(other.ReferencedCteIndexes);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Label);
+        hash.Add(CanonicalLabel);
+        hash.Add(Kind);
+        hash.Add(Body);
+        foreach (var index in ReferencedCteIndexes)
+        {
+            hash.Add(index);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    public void Deconstruct(
+        out string label,
+        out string canonicalLabel,
+        out string kind,
+        out string body,
+        out IReadOnlyList<int> referencedCteIndexes)
+    {
+        label = Label;
+        canonicalLabel = CanonicalLabel;
+        kind = Kind;
+        body = Body;
+        referencedCteIndexes = ReferencedCteIndexes;
+    }
+}

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainRow.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainRow.cs
@@ -1,10 +1,41 @@
 namespace Ignixa.Search.Sql.Ast;
 
 /// <summary>
-/// One line of an explained plan, kept as its two parts rather than the concatenated text
+/// One line of an explained plan, kept as its parts rather than the concatenated text
 /// <see cref="PlanExplainer.Print"/> produces. A UI renders plan lines as selectable rows and joins each
-/// back to its parameter through <see cref="Label"/> (<c>root</c>, <c>cte{i}</c>, <c>inc{i}</c>,
-/// <c>sort</c>, <c>page</c>, <c>countOnly</c>), which it cannot do once the label has been glued to the
-/// body with " = ". The flat string stays the golden-test format; this is the same content, unjoined.
+/// back to its parameter and its SQL text, which it cannot do once the label has been glued to the body
+/// with " = ". The flat string stays the golden-test format; this is the same content, unjoined.
 /// </summary>
-public sealed record PlanExplainRow(string Label, string Body);
+/// <remarks>
+/// <see cref="Label"/> is the display name (<c>root</c>, <c>cte{i}</c>, <c>inc{i}</c>, <c>sort</c>,
+/// <c>page</c>, <c>countOnly</c>). <see cref="CanonicalLabel"/> is the identifier that same row carries in
+/// the emitted SQL and in <see cref="Tracing.CteProvenance"/>. The two differ for exactly one row: the
+/// match CTE prints as <c>root</c> for readability but is emitted as
+/// <see cref="Builders.SqlLabels.CteLabel"/> of <c>plan.Match.Index</c>. Join on
+/// <see cref="CanonicalLabel"/>, never on <see cref="Label"/> — the latter is display text and addresses
+/// nothing.
+/// <para>
+/// <see cref="Kind"/> and <see cref="ReferencedCteIndexes"/> are the two things <see cref="Body"/> used to
+/// be the only carrier of. Both are read off the plan node directly, so a consumer never has to
+/// prefix-match formatted prose for the node's case or regex it for <c>cte(\d+)</c> to find which CTEs a
+/// structural node composes. <see cref="Body"/> is display text and is free to change wording.
+/// </para>
+/// <para>
+/// Rows with no SQL of their own (<c>sort</c>, <c>page</c>, <c>countOnly</c>) repeat their display name as
+/// the canonical one, so a consumer never has to special-case a null.
+/// </para>
+/// </remarks>
+/// <param name="Label">Display name for the row.</param>
+/// <param name="CanonicalLabel">The identifier this row is addressable by in the emitted SQL.</param>
+/// <param name="Kind">Which plan node produced the row — see <see cref="PlanRowKind"/>.</param>
+/// <param name="Body">Formatted, human-facing description. Not a stable contract.</param>
+/// <param name="ReferencedCteIndexes">
+/// Indexes of the CTEs this row's node composes, in the order the node names them. Empty for leaf
+/// sources and for non-CTE rows.
+/// </param>
+public sealed record PlanExplainRow(
+    string Label,
+    string CanonicalLabel,
+    string Kind,
+    string Body,
+    IReadOnlyList<int> ReferencedCteIndexes);

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -10,8 +10,18 @@ namespace Ignixa.Search.Sql.Ast;
 /// </summary>
 public static class PlanExplainer
 {
-    public static string Print(QueryPlan plan)
-        => string.Join('\n', Describe(plan).Select(row => $"{row.Label} = {row.Body}"));
+    public static string Print(QueryPlan plan) => Print(Describe(plan));
+
+    /// <summary>
+    /// The flat text for rows already described. Callers holding both the rows and the printed form take
+    /// this overload so <see cref="Describe"/> runs once — the two can then never disagree.
+    /// </summary>
+    public static string Print(IReadOnlyList<PlanExplainRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        return string.Join('\n', rows.Select(row => $"{row.Label} = {row.Body}"));
+    }
 
     /// <summary>
     /// Renders the same content <see cref="Print"/> does, one <see cref="PlanExplainRow"/> per line, with
@@ -101,13 +111,21 @@ public static class PlanExplainer
     /// The CTEs a structural node composes, in the order it names them — the same fields
     /// <see cref="PrintCte"/> renders into the body, kept as data so consumers need not parse it back out.
     /// </summary>
-    private static IReadOnlyList<int> ReferencedCteIndexesOf(CteDefinition cte) => cte switch
+    /// <remarks>
+    /// The leaf sources are listed explicitly rather than caught by a default arm, and an unknown case
+    /// throws like <see cref="KindOf"/> does. A silent <c>[]</c> here would let a new composing
+    /// <see cref="CteDefinition"/> report no children, which
+    /// <see cref="Tracing.SearchCompiler"/> would turn into silently-wrong parameter provenance with
+    /// nothing to fail.
+    /// </remarks>
+    internal static IReadOnlyList<int> ReferencedCteIndexesOf(CteDefinition cte) => cte switch
     {
         CteDefinition.Intersect x => [x.Left.Index, x.Right.Index],
         CteDefinition.Union u => [.. u.Parts.Select(r => r.Index)],
         CteDefinition.Except ex => [ex.Left.Index, ex.Right.Index],
         CteDefinition.ChainJoin cj => [cj.InnerMatch.Index],
-        _ => [],
+        CteDefinition.ParamSource or CteDefinition.ResourceSource or CteDefinition.CompartmentSource => [],
+        _ => throw new NotSupportedException($"No Explain() CTE references for {cte.GetType().Name}."),
     };
 
     private static string PrintSortSpec(SortSpec sort)

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -13,10 +13,12 @@ public static class PlanExplainer
         => string.Join('\n', Describe(plan).Select(row => $"{row.Label} = {row.Body}"));
 
     /// <summary>
-    /// The label for the CTE at <paramref name="index"/>. Both this explainer's rows and the emitted SQL's
-    /// <see cref="Builders.SqlTextRange"/>s are labelled through here, because tooling joins a plan row to
-    /// its SQL text by that string — two independent format strings would be one silent typo from breaking
-    /// that join with nothing to fail at compile time.
+    /// The label for the CTE at <paramref name="index"/>. This is the single producer of the <c>cte{i}</c>
+    /// identifier everywhere it appears: this explainer's rows, the emitted SQL's CTE definitions and
+    /// references (<see cref="Builders.SqlBuilder"/>), and the <see cref="Builders.SqlTextRange"/> labels.
+    /// Tooling joins a plan row to its parameter and its SQL text by that string, and SQL Server joins a
+    /// CTE reference to its definition by it — two independent format strings would be one silent typo from
+    /// breaking those joins with nothing to fail at compile time.
     /// </summary>
     public static string CteLabel(int index) => $"cte{index}";
 
@@ -112,13 +114,13 @@ public static class PlanExplainer
         CteDefinition.ParamSource p =>
             $"{p.Table.TableName}[{p.ResourceTypeId},{p.SearchParamId}]{(p.Predicate is null ? string.Empty : $"  {PrintPredicate(p.Predicate, ref parameterOrdinal)}")}{PrintTop(top)}",
         CteDefinition.Intersect x =>
-            $"Intersect(cte{x.Left.Index}, cte{x.Right.Index}){PrintTop(top)}",
+            $"Intersect({CteLabel(x.Left.Index)}, {CteLabel(x.Right.Index)}){PrintTop(top)}",
         CteDefinition.Union u =>
-            $"Union({string.Join(", ", u.Parts.Select(r => $"cte{r.Index}"))}){PrintTop(top)}",
+            $"Union({string.Join(", ", u.Parts.Select(r => CteLabel(r.Index)))}){PrintTop(top)}",
         CteDefinition.ResourceSource rs => PrintResourceSource(rs, top, ref parameterOrdinal),
-        CteDefinition.Except ex => $"Except(cte{ex.Left.Index}, cte{ex.Right.Index}){PrintTop(top)}",
+        CteDefinition.Except ex => $"Except({CteLabel(ex.Left.Index)}, {CteLabel(ex.Right.Index)}){PrintTop(top)}",
         CteDefinition.ChainJoin cj =>
-            $"ChainJoin(cte{cj.InnerMatch.Index}, ref={cj.ReferenceSearchParamId}, inner={cj.InnerResourceTypeId}, output=[{string.Join(",", cj.OutputResourceTypeIds)}], {cj.Direction}){PrintTop(top)}",
+            $"ChainJoin({CteLabel(cj.InnerMatch.Index)}, ref={cj.ReferenceSearchParamId}, inner={cj.InnerResourceTypeId}, output=[{string.Join(",", cj.OutputResourceTypeIds)}], {cj.Direction}){PrintTop(top)}",
         CteDefinition.CompartmentSource cs =>
             $"CompartmentSource[{string.Join(",", cs.ResourceTypeIds)},{cs.SearchParamId}]  {PrintPredicate(cs.Predicate, ref parameterOrdinal)}{PrintTop(top)}",
         _ => throw new NotSupportedException($"No Explain() rendering for {cte.GetType().Name}."),

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Ignixa.Search.Expressions;
+using static Ignixa.Search.Sql.Builders.SqlLabels;
 
 namespace Ignixa.Search.Sql.Ast;
 
@@ -13,21 +14,15 @@ public static class PlanExplainer
         => string.Join('\n', Describe(plan).Select(row => $"{row.Label} = {row.Body}"));
 
     /// <summary>
-    /// The label for the CTE at <paramref name="index"/>. This is the single producer of the <c>cte{i}</c>
-    /// identifier everywhere it appears: this explainer's rows, the emitted SQL's CTE definitions and
-    /// references (<see cref="Builders.SqlBuilder"/>), and the <see cref="Builders.SqlTextRange"/> labels.
-    /// Tooling joins a plan row to its parameter and its SQL text by that string, and SQL Server joins a
-    /// CTE reference to its definition by it — two independent format strings would be one silent typo from
-    /// breaking those joins with nothing to fail at compile time.
-    /// </summary>
-    public static string CteLabel(int index) => $"cte{index}";
-
-    /// <summary>
     /// Renders the same content <see cref="Print"/> does, one <see cref="PlanExplainRow"/> per line, with
     /// the label kept apart from the body. Tooling needs the label to address a row (and to join it to the
     /// owning parameter via <see cref="Tracing.CteProvenance.CteIndex"/>); <see cref="Print"/> is defined in
     /// terms of this method so the two can never disagree.
     /// </summary>
+    /// <remarks>
+    /// Every row carries both the name it displays and the identifier it is addressable by — see
+    /// <see cref="PlanExplainRow.CanonicalLabel"/>. The match CTE is the row where those differ.
+    /// </remarks>
     public static IReadOnlyList<PlanExplainRow> Describe(QueryPlan plan)
     {
         ArgumentNullException.ThrowIfNull(plan);
@@ -41,6 +36,10 @@ public static class PlanExplainer
         for (var i = 0; i < plan.Ctes.Count; i++)
         {
             var isRoot = i == plan.Match.Index;
+
+            // The match CTE prints as "root" because that reads better in a plan dump, but it is emitted
+            // as cte{i} like every other CTE. Carrying both keeps the display name from being mistaken
+            // for something a consumer can join on.
             var label = isRoot ? "root" : CteLabel(i);
             var top = isRoot ? plan.Top : null;
             var body = PrintCte(plan.Ctes[i], top, ref parameterOrdinal);
@@ -49,34 +48,67 @@ public static class PlanExplainer
                 body += $" WHERE {PrintPredicate(plan.OuterPredicate, ref parameterOrdinal)}";
             }
 
-            rows.Add(new PlanExplainRow(label, body));
+            rows.Add(new PlanExplainRow(
+                label, CteLabel(i), KindOf(plan.Ctes[i]), body, ReferencedCteIndexesOf(plan.Ctes[i])));
         }
 
         if (plan.Includes is { Count: > 0 } includes)
         {
             for (var i = 0; i < includes.Count; i++)
             {
-                rows.Add(new PlanExplainRow($"inc{i}", PrintIncludeStage(includes[i])));
+                rows.Add(new PlanExplainRow(
+                    IncludeLabel(i), IncludeLabel(i), PlanRowKind.IncludeStage, PrintIncludeStage(includes[i]), []));
             }
         }
 
         if (plan.Sort is { } sort)
         {
-            rows.Add(new PlanExplainRow("sort", PrintSortSpec(sort)));
+            rows.Add(new PlanExplainRow("sort", "sort", PlanRowKind.SortSpec, PrintSortSpec(sort), []));
         }
 
         if (plan.Page is { } page)
         {
-            rows.Add(new PlanExplainRow("page", PrintPageSpec(page, ref parameterOrdinal)));
+            rows.Add(new PlanExplainRow(
+                "page", "page", PlanRowKind.PageSpec, PrintPageSpec(page, ref parameterOrdinal), []));
         }
 
         if (plan.CountOnly)
         {
-            rows.Add(new PlanExplainRow("countOnly", "true"));
+            rows.Add(new PlanExplainRow("countOnly", "countOnly", PlanRowKind.CountOnly, "true", []));
         }
 
         return rows;
     }
+
+    /// <summary>
+    /// Which <see cref="CteDefinition"/> case produced a row. Deliberately a separate switch from
+    /// <see cref="PrintCte"/> rather than a tuple returned alongside the body: the two answer different
+    /// questions (what it is vs how it reads), and the compiler still flags either one if a case is added.
+    /// </summary>
+    private static string KindOf(CteDefinition cte) => cte switch
+    {
+        CteDefinition.ParamSource => PlanRowKind.ParamSource,
+        CteDefinition.Intersect => PlanRowKind.Intersect,
+        CteDefinition.Union => PlanRowKind.Union,
+        CteDefinition.ResourceSource => PlanRowKind.ResourceSource,
+        CteDefinition.Except => PlanRowKind.Except,
+        CteDefinition.ChainJoin => PlanRowKind.ChainJoin,
+        CteDefinition.CompartmentSource => PlanRowKind.CompartmentSource,
+        _ => throw new NotSupportedException($"No Explain() kind for {cte.GetType().Name}."),
+    };
+
+    /// <summary>
+    /// The CTEs a structural node composes, in the order it names them — the same fields
+    /// <see cref="PrintCte"/> renders into the body, kept as data so consumers need not parse it back out.
+    /// </summary>
+    private static IReadOnlyList<int> ReferencedCteIndexesOf(CteDefinition cte) => cte switch
+    {
+        CteDefinition.Intersect x => [x.Left.Index, x.Right.Index],
+        CteDefinition.Union u => [.. u.Parts.Select(r => r.Index)],
+        CteDefinition.Except ex => [ex.Left.Index, ex.Right.Index],
+        CteDefinition.ChainJoin cj => [cj.InnerMatch.Index],
+        _ => [],
+    };
 
     private static string PrintSortSpec(SortSpec sort)
     {
@@ -103,7 +135,7 @@ public static class PlanExplainer
         var refParam = stage.ReferenceSearchParamId is { } id ? $"{id}" : "*";
         var seedTypes = stage.SeedTypeIds is null ? "*" : $"[{string.Join(",", stage.SeedTypeIds)}]";
         var outputTypes = stage.OutputTypeIds is null ? "*" : $"[{string.Join(",", stage.OutputTypeIds)}]";
-        var seedStageLabels = stage.SeedStages.Select(s => $"inc{s}");
+        var seedStageLabels = stage.SeedStages.Select(IncludeLabel);
         var seeds = stage.SeedFromMatch ? seedStageLabels.Prepend("match") : seedStageLabels;
         var iterate = stage.Iterate ? " iterate" : string.Empty;
         return $"IncludeStage(ref={refParam}, seedTypes={seedTypes}, outputTypes={outputTypes}, seeds=[{string.Join(",", seeds)}], limit={stage.Limit}{iterate}, {stage.Direction})";

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
@@ -1,0 +1,40 @@
+namespace Ignixa.Search.Sql.Ast;
+
+/// <summary>
+/// The kind tokens carried by <see cref="PlanExplainRow.Kind"/> — which <c>CteDefinition</c> case (or
+/// which non-CTE plan section) produced the row.
+/// </summary>
+/// <remarks>
+/// <see cref="PlanExplainer"/> already switches over the definition's case to format the body; the kind is
+/// that same discrimination kept as data instead of discarded once the string is built. Without it a
+/// consumer has to recover the case by prefix-matching formatted prose (<c>"Intersect("</c>,
+/// <c>"ChainJoin("</c>), which turns a display-text change into a downstream break.
+/// <para>
+/// Tokens, not an enum, for the same reason as <see cref="Builders.SqlRangeKind"/>: these are consumed by
+/// renderers across a wire.
+/// </para>
+/// </remarks>
+public static class PlanRowKind
+{
+    public const string ParamSource = "paramSource";
+
+    public const string Intersect = "intersect";
+
+    public const string Union = "union";
+
+    public const string ResourceSource = "resourceSource";
+
+    public const string Except = "except";
+
+    public const string ChainJoin = "chainJoin";
+
+    public const string CompartmentSource = "compartmentSource";
+
+    public const string IncludeStage = "includeStage";
+
+    public const string SortSpec = "sortSpec";
+
+    public const string PageSpec = "pageSpec";
+
+    public const string CountOnly = "countOnly";
+}

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -2,6 +2,7 @@
 
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Sql.Ast;
+using static Ignixa.Search.Sql.Ast.PlanExplainer;
 
 namespace Ignixa.Search.Sql.Builders;
 
@@ -26,15 +27,15 @@ public static class SqlBuilder
 
         for (var i = 0; i < plan.Ctes.Count; i++)
         {
-            cteBlocks.Add($"cte{i} AS (\n{EmitCte(plan.Ctes[i], parameters)}\n)");
+            cteBlocks.Add($"{CteLabel(i)} AS (\n{EmitCte(plan.Ctes[i], parameters)}\n)");
         }
 
         if (plan.CountOnly)
         {
             writer.Append(";WITH ");
-            writer.AppendJoin(",\n", cteBlocks, PlanExplainer.CteLabel);
+            writer.AppendJoin(",\n", cteBlocks, CteLabel);
             writer.Append("\n");
-            writer.Append($"SELECT COUNT_BIG(DISTINCT m.Sid1) FROM cte{plan.Match.Index} m");
+            writer.Append($"SELECT COUNT_BIG(DISTINCT m.Sid1) FROM {CteLabel(plan.Match.Index)} m");
 
             if (plan.OuterPredicate is not null)
             {
@@ -76,9 +77,9 @@ public static class SqlBuilder
             }
 
             writer.Append(";WITH ");
-            writer.AppendJoin(",\n", cteBlocks, PlanExplainer.CteLabel);
+            writer.AppendJoin(",\n", cteBlocks, CteLabel);
             writer.Append("\n");
-            writer.Append($"SELECT {top}m.T1, m.Sid1{sortColumns} FROM cte{plan.Match.Index} m{sortJoins}");
+            writer.Append($"SELECT {top}m.T1, m.Sid1{sortColumns} FROM {CteLabel(plan.Match.Index)} m{sortJoins}");
 
             if (whereClauses.Count > 0)
             {
@@ -162,14 +163,14 @@ public static class SqlBuilder
         }
 
         writer.Append(";WITH ");
-        writer.AppendJoin(",\n", cteBlocks, PlanExplainer.CteLabel);
+        writer.AppendJoin(",\n", cteBlocks, CteLabel);
         writer.Append(",\n");
         using (writer.Section("cteMatchPage"))
         {
             writer.Append(
                 $"cteMatchPage AS (\n" +
                 $"    SELECT {top}m.T1, m.Sid1{matchSortColumns}\n" +
-                $"    FROM cte{plan.Match.Index} m{matchSortJoins}{matchResourceJoin}");
+                $"    FROM {CteLabel(plan.Match.Index)} m{matchSortJoins}{matchResourceJoin}");
 
             if (matchWhereClauses.Count > 0)
             {
@@ -242,18 +243,18 @@ public static class SqlBuilder
     {
         CteDefinition.ParamSource p => EmitParamSource(p, parameters),
         CteDefinition.Intersect x =>
-            $"    SELECT cte{x.Left.Index}.T1, cte{x.Left.Index}.Sid1\n" +
-            $"    FROM cte{x.Left.Index}\n" +
-            $"    INNER JOIN cte{x.Right.Index} ON cte{x.Left.Index}.T1 = cte{x.Right.Index}.T1 AND cte{x.Left.Index}.Sid1 = cte{x.Right.Index}.Sid1",
+            $"    SELECT {CteLabel(x.Left.Index)}.T1, {CteLabel(x.Left.Index)}.Sid1\n" +
+            $"    FROM {CteLabel(x.Left.Index)}\n" +
+            $"    INNER JOIN {CteLabel(x.Right.Index)} ON {CteLabel(x.Left.Index)}.T1 = {CteLabel(x.Right.Index)}.T1 AND {CteLabel(x.Left.Index)}.Sid1 = {CteLabel(x.Right.Index)}.Sid1",
         CteDefinition.Union u =>
-            string.Join("\n    UNION\n", u.Parts.Select(r => $"    SELECT T1, Sid1 FROM cte{r.Index}")),
+            string.Join("\n    UNION\n", u.Parts.Select(r => $"    SELECT T1, Sid1 FROM {CteLabel(r.Index)}")),
         CteDefinition.ResourceSource rs => EmitResourceSource(rs, parameters),
         CteDefinition.Except ex =>
-            $"    SELECT cte{ex.Left.Index}.T1, cte{ex.Left.Index}.Sid1\n" +
-            $"    FROM cte{ex.Left.Index}\n" +
+            $"    SELECT {CteLabel(ex.Left.Index)}.T1, {CteLabel(ex.Left.Index)}.Sid1\n" +
+            $"    FROM {CteLabel(ex.Left.Index)}\n" +
             $"    WHERE NOT EXISTS (\n" +
-            $"        SELECT 1 FROM cte{ex.Right.Index}\n" +
-            $"        WHERE cte{ex.Right.Index}.T1 = cte{ex.Left.Index}.T1 AND cte{ex.Right.Index}.Sid1 = cte{ex.Left.Index}.Sid1)",
+            $"        SELECT 1 FROM {CteLabel(ex.Right.Index)}\n" +
+            $"        WHERE {CteLabel(ex.Right.Index)}.T1 = {CteLabel(ex.Left.Index)}.T1 AND {CteLabel(ex.Right.Index)}.Sid1 = {CteLabel(ex.Left.Index)}.Sid1)",
         CteDefinition.ChainJoin cj => EmitChainJoin(cj, parameters),
         CteDefinition.CompartmentSource cs => EmitCompartmentSource(cs, parameters),
         _ => throw new NotSupportedException($"No Emit for {cte.GetType().Name}."),
@@ -294,7 +295,7 @@ public static class SqlBuilder
                 $"        ON r.ResourceTypeId = rsp.ReferenceResourceTypeId\n" +
                 $"       AND r.ResourceId = rsp.ReferenceResourceId\n" +
                 $"       AND r.IsHistory = 0 AND r.IsDeleted = 0\n" +
-                $"    INNER JOIN cte{cj.InnerMatch.Index} m\n" +
+                $"    INNER JOIN {CteLabel(cj.InnerMatch.Index)} m\n" +
                 $"        ON m.T1 = r.ResourceTypeId AND m.Sid1 = r.ResourceSurrogateId\n" +
                 $"    WHERE rsp.SearchParamId = {cj.ReferenceSearchParamId}\n" +
                 $"      AND rsp.ReferenceResourceTypeId = {cj.InnerResourceTypeId}\n" +
@@ -303,7 +304,7 @@ public static class SqlBuilder
             ChainDirection.Reverse =>
                 $"    SELECT DISTINCT r.ResourceTypeId AS T1, r.ResourceSurrogateId AS Sid1\n" +
                 $"    FROM dbo.ReferenceSearchParam rsp\n" +
-                $"    INNER JOIN cte{cj.InnerMatch.Index} m\n" +
+                $"    INNER JOIN {CteLabel(cj.InnerMatch.Index)} m\n" +
                 $"        ON m.T1 = rsp.ResourceTypeId AND m.Sid1 = rsp.ResourceSurrogateId\n" +
                 $"    INNER JOIN dbo.Resource r\n" +
                 $"        ON r.ResourceTypeId = rsp.ReferenceResourceTypeId\n" +

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -2,7 +2,7 @@
 
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Sql.Ast;
-using static Ignixa.Search.Sql.Ast.PlanExplainer;
+using static Ignixa.Search.Sql.Builders.SqlLabels;
 
 namespace Ignixa.Search.Sql.Builders;
 
@@ -33,7 +33,7 @@ public static class SqlBuilder
         if (plan.CountOnly)
         {
             writer.Append(";WITH ");
-            writer.AppendJoin(",\n", cteBlocks, CteLabel);
+            writer.AppendJoin(",\n", cteBlocks, CteLabel, SqlRangeKind.Cte);
             writer.Append("\n");
             writer.Append($"SELECT COUNT_BIG(DISTINCT m.Sid1) FROM {CteLabel(plan.Match.Index)} m");
 
@@ -41,7 +41,7 @@ public static class SqlBuilder
             {
                 var outerPredicateText = EmitPredicate(plan.OuterPredicate, parameters);
                 writer.Append("\nINNER JOIN dbo.Resource r ON r.ResourceTypeId = m.T1 AND r.ResourceSurrogateId = m.Sid1\nWHERE ");
-                using (writer.Section("where"))
+                using (writer.Section("where", SqlRangeKind.Where))
                 {
                     writer.Append(outerPredicateText);
                 }
@@ -77,7 +77,7 @@ public static class SqlBuilder
             }
 
             writer.Append(";WITH ");
-            writer.AppendJoin(",\n", cteBlocks, CteLabel);
+            writer.AppendJoin(",\n", cteBlocks, CteLabel, SqlRangeKind.Cte);
             writer.Append("\n");
             writer.Append($"SELECT {top}m.T1, m.Sid1{sortColumns} FROM {CteLabel(plan.Match.Index)} m{sortJoins}");
 
@@ -88,14 +88,14 @@ public static class SqlBuilder
                     : "\nINNER JOIN dbo.Resource r ON r.ResourceTypeId = m.T1 AND r.ResourceSurrogateId = m.Sid1";
                 writer.Append(resourceJoin);
                 writer.Append("\nWHERE ");
-                using (writer.Section("where"))
+                using (writer.Section("where", SqlRangeKind.Where))
                 {
                     WriteAndJoinedClauses(writer, whereClauses, seekClauseIndex);
                 }
             }
 
             writer.Append("\nORDER BY ");
-            using (writer.Section("orderBy"))
+            using (writer.Section("orderBy", SqlRangeKind.OrderBy))
             {
                 writer.Append(orderByText);
             }
@@ -144,7 +144,7 @@ public static class SqlBuilder
             incLimBlocks.Add(
                 $"    SELECT TOP ({stage.Limit}) T1, Sid1,\n" +
                 $"           CASE WHEN COUNT_BIG(*) OVER() > {stage.Limit} THEN 1 ELSE 0 END AS IsPartial\n" +
-                $"    FROM inc{i}\n" +
+                $"    FROM {IncludeLabel(i)}\n" +
                 $"    ORDER BY T1 ASC, Sid1 ASC");
         }
 
@@ -158,14 +158,14 @@ public static class SqlBuilder
         for (var i = 0; i < includes.Count; i++)
         {
             unionBlocks.Add(
-                $"SELECT i.T1, i.Sid1, CAST(0 AS bit), i.IsPartial{nullSortColumns} FROM inc{i}lim i\n" +
+                $"SELECT i.T1, i.Sid1, CAST(0 AS bit), i.IsPartial{nullSortColumns} FROM {IncludeLimitLabel(i)} i\n" +
                 $"WHERE NOT EXISTS (SELECT 1 FROM cteMatchPage m WHERE m.T1 = i.T1 AND m.Sid1 = i.Sid1)");
         }
 
         writer.Append(";WITH ");
-        writer.AppendJoin(",\n", cteBlocks, CteLabel);
+        writer.AppendJoin(",\n", cteBlocks, CteLabel, SqlRangeKind.Cte);
         writer.Append(",\n");
-        using (writer.Section("cteMatchPage"))
+        using (writer.Section("cteMatchPage", SqlRangeKind.MatchPage))
         {
             writer.Append(
                 $"cteMatchPage AS (\n" +
@@ -175,7 +175,7 @@ public static class SqlBuilder
             if (matchWhereClauses.Count > 0)
             {
                 writer.Append("\n    WHERE ");
-                using (writer.Section("where"))
+                using (writer.Section("where", SqlRangeKind.Where))
                 {
                     WriteAndJoinedClauses(writer, matchWhereClauses, matchSeekClauseIndex);
                 }
@@ -188,22 +188,30 @@ public static class SqlBuilder
         for (var i = 0; i < includes.Count; i++)
         {
             writer.Append(",\n");
-            using (writer.Section($"inc{i}"))
+            using (writer.Section(IncludeLabel(i), SqlRangeKind.Include))
             {
-                writer.Append($"inc{i} AS (\n{incBlocks[i]}\n)");
+                writer.Append($"{IncludeLabel(i)} AS (\n{incBlocks[i]}\n)");
             }
 
             writer.Append(",\n");
-            using (writer.Section($"inc{i}lim"))
+            using (writer.Section(IncludeLimitLabel(i), SqlRangeKind.IncludeLimit))
             {
-                writer.Append($"inc{i}lim AS (\n{incLimBlocks[i]}\n)");
+                writer.Append($"{IncludeLimitLabel(i)} AS (\n{incLimBlocks[i]}\n)");
             }
         }
 
         writer.Append("\n");
-        writer.Append(string.Join("\nUNION ALL\n", unionBlocks));
+
+        // The final UNION ALL is the only emitted section that belongs to no single plan row -- it is the
+        // assembly that stitches the match page to every include stage. Labelled anyway, so a UI can
+        // highlight it instead of leaving a stretch of SQL that maps to nothing.
+        using (writer.Section("assembly", SqlRangeKind.Assembly))
+        {
+            writer.Append(string.Join("\nUNION ALL\n", unionBlocks));
+        }
+
         writer.Append("\nORDER BY ");
-        using (writer.Section("orderBy"))
+        using (writer.Section("orderBy", SqlRangeKind.OrderBy))
         {
             writer.Append(EmitOuterOrderByForIncludes(plan.Sort));
         }
@@ -226,7 +234,7 @@ public static class SqlBuilder
 
             if (i == seekClauseIndex)
             {
-                using (writer.Section("seek"))
+                using (writer.Section("seek", SqlRangeKind.Seek))
                 {
                     writer.Append(clauses[i]);
                 }

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -41,7 +41,7 @@ public static class SqlBuilder
             {
                 var outerPredicateText = EmitPredicate(plan.OuterPredicate, parameters);
                 writer.Append("\nINNER JOIN dbo.Resource r ON r.ResourceTypeId = m.T1 AND r.ResourceSurrogateId = m.Sid1\nWHERE ");
-                using (writer.Section("where", SqlRangeKind.Where))
+                using (writer.Section(Where, SqlRangeKind.Where))
                 {
                     writer.Append(outerPredicateText);
                 }
@@ -88,14 +88,14 @@ public static class SqlBuilder
                     : "\nINNER JOIN dbo.Resource r ON r.ResourceTypeId = m.T1 AND r.ResourceSurrogateId = m.Sid1";
                 writer.Append(resourceJoin);
                 writer.Append("\nWHERE ");
-                using (writer.Section("where", SqlRangeKind.Where))
+                using (writer.Section(Where, SqlRangeKind.Where))
                 {
                     WriteAndJoinedClauses(writer, whereClauses, seekClauseIndex);
                 }
             }
 
             writer.Append("\nORDER BY ");
-            using (writer.Section("orderBy", SqlRangeKind.OrderBy))
+            using (writer.Section(OrderBy, SqlRangeKind.OrderBy))
             {
                 writer.Append(orderByText);
             }
@@ -153,29 +153,29 @@ public static class SqlBuilder
 
         var unionBlocks = new List<string>
         {
-            $"SELECT T1, Sid1, CAST(1 AS bit) AS IsMatch, CAST(0 AS bit) AS IsPartial{matchSortColumnRefs} FROM cteMatchPage",
+            $"SELECT T1, Sid1, CAST(1 AS bit) AS IsMatch, CAST(0 AS bit) AS IsPartial{matchSortColumnRefs} FROM {MatchPage}",
         };
         for (var i = 0; i < includes.Count; i++)
         {
             unionBlocks.Add(
                 $"SELECT i.T1, i.Sid1, CAST(0 AS bit), i.IsPartial{nullSortColumns} FROM {IncludeLimitLabel(i)} i\n" +
-                $"WHERE NOT EXISTS (SELECT 1 FROM cteMatchPage m WHERE m.T1 = i.T1 AND m.Sid1 = i.Sid1)");
+                $"WHERE NOT EXISTS (SELECT 1 FROM {MatchPage} m WHERE m.T1 = i.T1 AND m.Sid1 = i.Sid1)");
         }
 
         writer.Append(";WITH ");
         writer.AppendJoin(",\n", cteBlocks, CteLabel, SqlRangeKind.Cte);
         writer.Append(",\n");
-        using (writer.Section("cteMatchPage", SqlRangeKind.MatchPage))
+        using (writer.Section(MatchPage, SqlRangeKind.MatchPage))
         {
             writer.Append(
-                $"cteMatchPage AS (\n" +
+                $"{MatchPage} AS (\n" +
                 $"    SELECT {top}m.T1, m.Sid1{matchSortColumns}\n" +
                 $"    FROM {CteLabel(plan.Match.Index)} m{matchSortJoins}{matchResourceJoin}");
 
             if (matchWhereClauses.Count > 0)
             {
                 writer.Append("\n    WHERE ");
-                using (writer.Section("where", SqlRangeKind.Where))
+                using (writer.Section(Where, SqlRangeKind.Where))
                 {
                     WriteAndJoinedClauses(writer, matchWhereClauses, matchSeekClauseIndex);
                 }
@@ -202,16 +202,16 @@ public static class SqlBuilder
 
         writer.Append("\n");
 
-        // The final UNION ALL is the only emitted section that belongs to no single plan row -- it is the
-        // assembly that stitches the match page to every include stage. Labelled anyway, so a UI can
-        // highlight it instead of leaving a stretch of SQL that maps to nothing.
-        using (writer.Section("assembly", SqlRangeKind.Assembly))
+        // The final UNION ALL stitches the match page to every include stage, so like the other
+        // structural sections it belongs to no single plan row. Sectioned anyway: until it was, this
+        // stretch carried no range at all and could not be addressed even as structure.
+        using (writer.Section(Assembly, SqlRangeKind.Assembly))
         {
             writer.Append(string.Join("\nUNION ALL\n", unionBlocks));
         }
 
         writer.Append("\nORDER BY ");
-        using (writer.Section("orderBy", SqlRangeKind.OrderBy))
+        using (writer.Section(OrderBy, SqlRangeKind.OrderBy))
         {
             writer.Append(EmitOuterOrderByForIncludes(plan.Sort));
         }
@@ -234,7 +234,7 @@ public static class SqlBuilder
 
             if (i == seekClauseIndex)
             {
-                using (writer.Section("seek", SqlRangeKind.Seek))
+                using (writer.Section(Seek, SqlRangeKind.Seek))
                 {
                     writer.Append(clauses[i]);
                 }
@@ -562,12 +562,12 @@ public static class SqlBuilder
         var branches = new List<string>();
         if (stage.SeedFromMatch)
         {
-            branches.Add($"SELECT 1 FROM cteMatchPage m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
+            branches.Add($"SELECT 1 FROM {MatchPage} m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
         }
 
         foreach (var seedStageIndex in stage.SeedStages)
         {
-            branches.Add($"SELECT 1 FROM inc{seedStageIndex}lim m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
+            branches.Add($"SELECT 1 FROM {IncludeLimitLabel(seedStageIndex)} m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
         }
 
         return $"EXISTS (\n        {string.Join("\n        UNION ALL\n        ", branches)}\n    )";

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
@@ -1,0 +1,39 @@
+namespace Ignixa.Search.Sql.Builders;
+
+/// <summary>
+/// The single producer of every index-derived label the compiler emits — CTE identifiers in the SQL,
+/// the section labels on <see cref="SqlTextRange"/>, and the row labels
+/// <see cref="Ast.PlanExplainer"/> prints.
+/// </summary>
+/// <remarks>
+/// These strings carry two loads at once: SQL Server joins a CTE reference to its definition by them, and
+/// tooling joins a plan row to its parameter and to its slice of SQL text by them. Two independent format
+/// strings would be one silent typo from breaking either join with nothing to fail at compile time, so
+/// every producer routes through here.
+/// <para>
+/// Lives in <c>Builders</c> rather than on the explainer because these are SQL identifiers first and
+/// display text second: emission is the correctness-critical consumer, and a change made to render a
+/// nicer explain line must not be able to change the emitted SQL.
+/// </para>
+/// </remarks>
+public static class SqlLabels
+{
+    /// <summary>The identifier for the CTE at <paramref name="index"/>.</summary>
+    public static string CteLabel(int index) => $"cte{index}";
+
+    /// <summary>The identifier for the include stage at <paramref name="index"/>.</summary>
+    public static string IncludeLabel(int index) => $"inc{index}";
+
+    /// <summary>
+    /// The identifier for the limit-applying companion of the include stage at <paramref name="index"/>.
+    /// Every include stage emits this second CTE, which is what downstream SQL actually reads — the
+    /// unlimited <see cref="IncludeLabel"/> body feeds it and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// A plan has one <see cref="Ast.PlanExplainRow"/> per include stage, labelled
+    /// <see cref="IncludeLabel"/>, but emits two SQL ranges. Tooling that highlights the SQL for a plan row
+    /// must therefore take both this label and <see cref="IncludeLabel"/> for that index, rather than
+    /// deriving one from the other by string surgery.
+    /// </remarks>
+    public static string IncludeLimitLabel(int index) => $"{IncludeLabel(index)}lim";
+}

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
@@ -7,9 +7,10 @@ namespace Ignixa.Search.Sql.Builders;
 /// </summary>
 /// <remarks>
 /// These strings carry two loads at once: SQL Server joins a CTE reference to its definition by them, and
-/// tooling joins a plan row to its parameter and to its slice of SQL text by them. Two independent format
-/// strings would be one silent typo from breaking either join with nothing to fail at compile time, so
-/// every producer routes through here.
+/// tooling is intended to join a plan row to its parameter and to its slice of SQL text by them. Two
+/// independent format strings would be one silent typo from breaking either join with nothing to fail at
+/// compile time, so every producer routes through here. Guarded by test, not by the compiler — nothing
+/// stops a future call site interpolating <c>$"cte{i}"</c> by hand.
 /// <para>
 /// Lives in <c>Builders</c> rather than on the explainer because these are SQL identifiers first and
 /// display text second: emission is the correctness-critical consumer, and a change made to render a
@@ -20,6 +21,21 @@ public static class SqlLabels
 {
     /// <summary>The identifier for the CTE at <paramref name="index"/>.</summary>
     public static string CteLabel(int index) => $"cte{index}";
+
+    /// <summary>The match-page CTE. A real SQL identifier, not just a range label.</summary>
+    public const string MatchPage = "cteMatchPage";
+
+    /// <summary>The range label for a WHERE clause body.</summary>
+    public const string Where = "where";
+
+    /// <summary>The range label for the keyset-seek predicate inside a WHERE.</summary>
+    public const string Seek = "seek";
+
+    /// <summary>The range label for an ORDER BY clause body.</summary>
+    public const string OrderBy = "orderBy";
+
+    /// <summary>The range label for the final UNION ALL that stitches the result together.</summary>
+    public const string Assembly = "assembly";
 
     /// <summary>The identifier for the include stage at <paramref name="index"/>.</summary>
     public static string IncludeLabel(int index) => $"inc{index}";

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
@@ -1,0 +1,47 @@
+namespace Ignixa.Search.Sql.Builders;
+
+/// <summary>
+/// The kind tokens carried by <see cref="SqlTextRange.Kind"/> — what a span of emitted SQL *is*, as
+/// opposed to <see cref="SqlTextRange.Label"/>, which says which one it is.
+/// </summary>
+/// <remarks>
+/// A consumer highlighting SQL needs to style and describe a span without a plan row to lean on: most
+/// ranges have a <see cref="Ast.PlanExplainRow"/> counterpart, but the structural ones
+/// (<see cref="MatchPage"/>, <see cref="Where"/>, <see cref="Seek"/>, <see cref="OrderBy"/>,
+/// <see cref="Assembly"/>) exist only in the emitted SQL — the plan has no node for them. Kinding the
+/// range is what makes those spans self-describing rather than requiring the consumer to prefix-match the
+/// label or the SQL text.
+/// <para>
+/// Tokens, not an enum, to match <see cref="Ast.PlanRowKind"/> and <c>IrRow.Kind</c>: these cross a wire
+/// to a renderer, and a stable string survives a version skew that a reordered enum does not.
+/// </para>
+/// </remarks>
+public static class SqlRangeKind
+{
+    /// <summary>A plan CTE's definition. Labelled <see cref="SqlLabels.CteLabel"/>.</summary>
+    public const string Cte = "cte";
+
+    /// <summary>The match-page CTE that applies paging to the match CTE. No plan row.</summary>
+    public const string MatchPage = "matchPage";
+
+    /// <summary>A WHERE clause body. No plan row.</summary>
+    public const string Where = "where";
+
+    /// <summary>The keyset-seek predicate within a WHERE. No plan row.</summary>
+    public const string Seek = "seek";
+
+    /// <summary>An ORDER BY clause body. No plan row.</summary>
+    public const string OrderBy = "orderBy";
+
+    /// <summary>An include stage's unlimited body. Labelled <see cref="SqlLabels.IncludeLabel"/>.</summary>
+    public const string Include = "include";
+
+    /// <summary>
+    /// An include stage's limit-applying companion. Labelled <see cref="SqlLabels.IncludeLimitLabel"/>;
+    /// shares the <see cref="Ast.PlanExplainRow"/> of its <see cref="Include"/> sibling.
+    /// </summary>
+    public const string IncludeLimit = "includeLimit";
+
+    /// <summary>The final UNION ALL stitching the match page to every include stage. No plan row.</summary>
+    public const string Assembly = "assembly";
+}

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
@@ -5,43 +5,55 @@ namespace Ignixa.Search.Sql.Builders;
 /// opposed to <see cref="SqlTextRange.Label"/>, which says which one it is.
 /// </summary>
 /// <remarks>
-/// A consumer highlighting SQL needs to style and describe a span without a plan row to lean on: most
-/// ranges have a <see cref="Ast.PlanExplainRow"/> counterpart, but the structural ones
-/// (<see cref="MatchPage"/>, <see cref="Where"/>, <see cref="Seek"/>, <see cref="OrderBy"/>,
-/// <see cref="Assembly"/>) exist only in the emitted SQL — the plan has no node for them. Kinding the
-/// range is what makes those spans self-describing rather than requiring the consumer to prefix-match the
-/// label or the SQL text.
+/// A consumer highlighting SQL needs to style and describe a span even when no plan row is addressable by
+/// that span's label. Kinding the range is what makes those spans self-describing, rather than requiring
+/// the consumer to prefix-match the label or sniff the SQL text.
 /// <para>
-/// Tokens, not an enum, to match <see cref="Ast.PlanRowKind"/> and <c>IrRow.Kind</c>: these cross a wire
-/// to a renderer, and a stable string survives a version skew that a reordered enum does not.
+/// "No row" below means precisely that: no <see cref="Ast.PlanExplainRow.CanonicalLabel"/> equals this
+/// range's label. It does not mean the plan had no say in the SQL — <see cref="OrderBy"/> and
+/// <see cref="Seek"/> are emitted from <c>plan.Sort</c> and <c>plan.Page</c>, which do have rows
+/// (<c>sort</c> and <c>page</c>); those rows are simply not named after these ranges.
+/// </para>
+/// <para>
+/// Tokens, not an enum, to match <see cref="Ast.PlanRowKind"/> and <c>IrRow.Kind</c>: these are intended
+/// to reach a renderer across a wire, and a stable string survives a version skew that a reordered enum
+/// does not.
 /// </para>
 /// </remarks>
 public static class SqlRangeKind
 {
-    /// <summary>A plan CTE's definition. Labelled <see cref="SqlLabels.CteLabel"/>.</summary>
+    /// <summary>A plan CTE's definition. Joins to the row whose canonical label is <see cref="SqlLabels.CteLabel"/>.</summary>
     public const string Cte = "cte";
 
-    /// <summary>The match-page CTE that applies paging to the match CTE. No plan row.</summary>
+    /// <summary>The match-page CTE that applies paging to the match CTE. No row is named for it.</summary>
     public const string MatchPage = "matchPage";
 
-    /// <summary>A WHERE clause body. No plan row.</summary>
+    /// <summary>A WHERE clause body. No row is named for it.</summary>
     public const string Where = "where";
 
-    /// <summary>The keyset-seek predicate within a WHERE. No plan row.</summary>
+    /// <summary>
+    /// The keyset-seek predicate within a WHERE. No row is named for it; the plan node behind it is
+    /// <c>plan.Page</c>, whose row is <c>page</c>.
+    /// </summary>
     public const string Seek = "seek";
 
-    /// <summary>An ORDER BY clause body. No plan row.</summary>
+    /// <summary>
+    /// An ORDER BY clause body. No row is named for it; the plan node behind it is <c>plan.Sort</c>,
+    /// whose row is <c>sort</c>.
+    /// </summary>
     public const string OrderBy = "orderBy";
 
-    /// <summary>An include stage's unlimited body. Labelled <see cref="SqlLabels.IncludeLabel"/>.</summary>
+    /// <summary>An include stage's unlimited body. Joins to the row <see cref="SqlLabels.IncludeLabel"/>.</summary>
     public const string Include = "include";
 
     /// <summary>
-    /// An include stage's limit-applying companion. Labelled <see cref="SqlLabels.IncludeLimitLabel"/>;
-    /// shares the <see cref="Ast.PlanExplainRow"/> of its <see cref="Include"/> sibling.
+    /// An include stage's limit-applying companion, labelled <see cref="SqlLabels.IncludeLimitLabel"/>.
+    /// No row carries that label: the stage's single row is named <see cref="SqlLabels.IncludeLabel"/>,
+    /// so a consumer wanting every range for a stage takes both labels for the same index rather than
+    /// deriving one from the other by string surgery.
     /// </summary>
     public const string IncludeLimit = "includeLimit";
 
-    /// <summary>The final UNION ALL stitching the match page to every include stage. No plan row.</summary>
+    /// <summary>The final UNION ALL stitching the match page to every include stage. No row is named for it.</summary>
     public const string Assembly = "assembly";
 }

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
@@ -1,4 +1,33 @@
 namespace Ignixa.Search.Sql.Builders;
 
 /// <summary>A labelled range of emitted SQL text — which characters a plan section produced.</summary>
-public sealed record SqlTextRange(string Label, int Start, int Length);
+/// <remarks>
+/// Not a positional record: <see cref="Start"/> and <see cref="Length"/> are buffer offsets and must be
+/// non-negative, so construction validates rather than trusting every producer to get the arithmetic
+/// right.
+/// </remarks>
+public sealed record SqlTextRange
+{
+    public SqlTextRange(string label, int start, int length)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(label);
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        Label = label;
+        Start = start;
+        Length = length;
+    }
+
+    public string Label { get; init; }
+
+    public int Start { get; init; }
+
+    public int Length { get; init; }
+
+    public void Deconstruct(out string label, out int start, out int length)
+    {
+        label = Label;
+        start = Start;
+        length = Length;
+    }
+}

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
@@ -2,11 +2,16 @@ namespace Ignixa.Search.Sql.Builders;
 
 /// <summary>A labelled range of emitted SQL text — which characters a plan section produced.</summary>
 /// <remarks>
-/// <see cref="Label"/> says which section this is and is unique within one emitted statement;
-/// <see cref="Kind"/> says what sort of section it is. Both are needed: a consumer joins a range to its
-/// <see cref="Ast.PlanExplainRow"/> by label (via <see cref="Ast.PlanExplainRow.CanonicalLabel"/>), but the
-/// structural ranges have no row to join to and are rendered from <see cref="Kind"/> alone. See
-/// <see cref="SqlRangeKind"/>.
+/// <see cref="Label"/> says which section this is; <see cref="Kind"/> says what sort of section it is.
+/// Both are needed: a consumer joins a range to its <see cref="Ast.PlanExplainRow"/> by label (via
+/// <see cref="Ast.PlanExplainRow.CanonicalLabel"/>), but several ranges have no row bearing their label
+/// and are rendered from <see cref="Kind"/> alone. See <see cref="SqlRangeKind"/>.
+/// <para>
+/// Labels are unique within one emitted statement — the three emit paths are mutually exclusive, so the
+/// repeated <c>where</c> and <c>orderBy</c> sections never co-occur, and the rest are index-derived. That
+/// is a property of <see cref="SqlBuilder"/> and of the range sequence, not of this type: a single range
+/// cannot know what else was emitted, and nothing stops a future nested section from breaking it.
+/// </para>
 /// <para>
 /// Not a positional record: <see cref="Start"/> and <see cref="Length"/> are buffer offsets and must be
 /// non-negative, so construction validates rather than trusting every producer to get the arithmetic

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlTextRange.cs
@@ -2,31 +2,45 @@ namespace Ignixa.Search.Sql.Builders;
 
 /// <summary>A labelled range of emitted SQL text — which characters a plan section produced.</summary>
 /// <remarks>
+/// <see cref="Label"/> says which section this is and is unique within one emitted statement;
+/// <see cref="Kind"/> says what sort of section it is. Both are needed: a consumer joins a range to its
+/// <see cref="Ast.PlanExplainRow"/> by label (via <see cref="Ast.PlanExplainRow.CanonicalLabel"/>), but the
+/// structural ranges have no row to join to and are rendered from <see cref="Kind"/> alone. See
+/// <see cref="SqlRangeKind"/>.
+/// <para>
 /// Not a positional record: <see cref="Start"/> and <see cref="Length"/> are buffer offsets and must be
 /// non-negative, so construction validates rather than trusting every producer to get the arithmetic
-/// right.
+/// right. The properties are get-only rather than <c>init</c> for the same reason — a <c>with</c>
+/// expression copies through the compiler-generated copy constructor and would skip these checks
+/// entirely, so the guard is only worth having if that route does not exist.
+/// </para>
 /// </remarks>
 public sealed record SqlTextRange
 {
-    public SqlTextRange(string label, int start, int length)
+    public SqlTextRange(string label, string kind, int start, int length)
     {
         ArgumentException.ThrowIfNullOrEmpty(label);
+        ArgumentException.ThrowIfNullOrEmpty(kind);
         ArgumentOutOfRangeException.ThrowIfNegative(start);
         ArgumentOutOfRangeException.ThrowIfNegative(length);
         Label = label;
+        Kind = kind;
         Start = start;
         Length = length;
     }
 
-    public string Label { get; init; }
+    public string Label { get; }
 
-    public int Start { get; init; }
+    public string Kind { get; }
 
-    public int Length { get; init; }
+    public int Start { get; }
 
-    public void Deconstruct(out string label, out int start, out int length)
+    public int Length { get; }
+
+    public void Deconstruct(out string label, out string kind, out int start, out int length)
     {
         label = Label;
+        kind = Kind;
         start = Start;
         length = Length;
     }

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlTextWriter.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlTextWriter.cs
@@ -16,7 +16,7 @@ internal sealed class SqlTextWriter(bool recordRanges)
 
     public void Append(string text) => _buffer.Append(text);
 
-    public void AppendJoin(string separator, IReadOnlyList<string> values, Func<int, string> labelFor)
+    public void AppendJoin(string separator, IReadOnlyList<string> values, Func<int, string> labelFor, string kind)
     {
         for (var i = 0; i < values.Count; i++)
         {
@@ -25,22 +25,22 @@ internal sealed class SqlTextWriter(bool recordRanges)
                 _buffer.Append(separator);
             }
 
-            using (Section(labelFor(i)))
+            using (Section(labelFor(i), kind))
             {
                 _buffer.Append(values[i]);
             }
         }
     }
 
-    public SectionScope Section(string label) => new(this, label, _buffer.Length);
+    public SectionScope Section(string label, string kind) => new(this, label, kind, _buffer.Length);
 
     public override string ToString() => _buffer.ToString();
 
-    private void Close(string label, int start)
-        => _ranges?.Add(new SqlTextRange(label, start, _buffer.Length - start));
+    private void Close(string label, string kind, int start)
+        => _ranges?.Add(new SqlTextRange(label, kind, start, _buffer.Length - start));
 
-    internal readonly struct SectionScope(SqlTextWriter writer, string label, int start) : IDisposable
+    internal readonly struct SectionScope(SqlTextWriter writer, string label, string kind, int start) : IDisposable
     {
-        public void Dispose() => writer.Close(label, start);
+        public void Dispose() => writer.Close(label, kind, start);
     }
 }

--- a/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
@@ -5,31 +5,55 @@ namespace Ignixa.Search.Sql.Tracing;
 /// <summary>One CTE's link back to the parameter that produced it. Null ordinal where exempt —
 /// :missing, compartment, and structural CTEs have no source text.</summary>
 /// <remarks>
+/// <see cref="ParameterOrdinal"/> is set only when the CTE was lowered from a node inside exactly one
+/// parameter's IR. A structural CTE (Intersect, Union, Except, ChainJoin) combines other CTEs by
+/// construction and so belongs to no single parameter — <see cref="ContributingOrdinals"/> is the set it
+/// draws from, closed over its children, so a consumer can say "this join came from parameters 1 and 3"
+/// without re-deriving the tree itself.
+/// <para>
 /// Not a positional record: <see cref="CteIndex"/> and <see cref="ParameterOrdinal"/> are plan and query
 /// positions and must be non-negative, so construction validates rather than trusting every producer to
-/// pass well-formed indices.
+/// pass well-formed indices. The properties are get-only rather than <c>init</c> for the same reason — a
+/// <c>with</c> expression copies through the compiler-generated copy constructor and would skip these
+/// checks entirely, so the guard is only worth having if that route does not exist.
+/// </para>
 /// </remarks>
 public sealed record CteProvenance
 {
-    public CteProvenance(int cteIndex, int? parameterOrdinal, SourceSpan? span)
+    public CteProvenance(
+        int cteIndex,
+        int? parameterOrdinal,
+        SourceSpan? span,
+        IReadOnlyList<int>? contributingOrdinals = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(cteIndex);
-        if (parameterOrdinal is < 0)
+        if (parameterOrdinal is { } ordinal)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(parameterOrdinal), parameterOrdinal, "Parameter ordinal must be non-negative when present.");
+            ArgumentOutOfRangeException.ThrowIfNegative(ordinal, nameof(parameterOrdinal));
         }
 
         CteIndex = cteIndex;
         ParameterOrdinal = parameterOrdinal;
         Span = span;
+
+        // A directly-attributed CTE contributes itself, so the set is never empty where an ordinal exists
+        // -- consumers can read ContributingOrdinals uniformly instead of branching on ParameterOrdinal.
+        ContributingOrdinals = contributingOrdinals
+            ?? (parameterOrdinal is { } own ? [own] : []);
     }
 
-    public int CteIndex { get; init; }
+    public int CteIndex { get; }
 
-    public int? ParameterOrdinal { get; init; }
+    public int? ParameterOrdinal { get; }
 
-    public SourceSpan? Span { get; init; }
+    public SourceSpan? Span { get; }
+
+    /// <summary>
+    /// Every parameter ordinal this CTE draws from, ascending and distinct. Equals
+    /// <see cref="ParameterOrdinal"/> alone for a directly-attributed CTE; the union of its children's sets
+    /// for a structural one; empty where nothing is attributable.
+    /// </summary>
+    public IReadOnlyList<int> ContributingOrdinals { get; }
 
     public void Deconstruct(out int cteIndex, out int? parameterOrdinal, out SourceSpan? span)
     {

--- a/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
@@ -17,6 +17,13 @@ namespace Ignixa.Search.Sql.Tracing;
 /// <c>with</c> expression copies through the compiler-generated copy constructor and would skip these
 /// checks entirely, so the guard is only worth having if that route does not exist.
 /// </para>
+/// <para>
+/// <see cref="ContributingOrdinals"/> is normalized and copied on the way in, so the ascending, distinct,
+/// non-negative shape the docs promise holds by construction rather than by producer discipline, and a
+/// caller mutating the list it passed cannot reach inside afterwards. It is compared element-wise by
+/// <see cref="Equals(CteProvenance)"/>, because a record's synthesized equality compares a collection
+/// property by reference.
+/// </para>
 /// </remarks>
 public sealed record CteProvenance
 {
@@ -32,14 +39,29 @@ public sealed record CteProvenance
             ArgumentOutOfRangeException.ThrowIfNegative(ordinal, nameof(parameterOrdinal));
         }
 
+        if (contributingOrdinals is not null)
+        {
+            foreach (var contributor in contributingOrdinals)
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(contributor, nameof(contributingOrdinals));
+            }
+        }
+
         CteIndex = cteIndex;
         ParameterOrdinal = parameterOrdinal;
         Span = span;
 
         // A directly-attributed CTE contributes itself, so the set is never empty where an ordinal exists
         // -- consumers can read ContributingOrdinals uniformly instead of branching on ParameterOrdinal.
-        ContributingOrdinals = contributingOrdinals
-            ?? (parameterOrdinal is { } own ? [own] : []);
+        // Normalizing here rather than validating means a producer that hands over an unsorted or
+        // duplicated set gets the documented shape instead of an exception it cannot act on.
+        IEnumerable<int> contributors = contributingOrdinals ?? [];
+        if (parameterOrdinal is { } own)
+        {
+            contributors = contributors.Append(own);
+        }
+
+        ContributingOrdinals = [.. contributors.Distinct().Order()];
     }
 
     public int CteIndex { get; }
@@ -51,14 +73,45 @@ public sealed record CteProvenance
     /// <summary>
     /// Every parameter ordinal this CTE draws from, ascending and distinct. Equals
     /// <see cref="ParameterOrdinal"/> alone for a directly-attributed CTE; the union of its children's sets
-    /// for a structural one; empty where nothing is attributable.
+    /// for a structural one; empty only where nothing is attributable.
     /// </summary>
     public IReadOnlyList<int> ContributingOrdinals { get; }
 
-    public void Deconstruct(out int cteIndex, out int? parameterOrdinal, out SourceSpan? span)
+    public bool Equals(CteProvenance? other)
+        => other is not null
+            && CteIndex == other.CteIndex
+            && ParameterOrdinal == other.ParameterOrdinal
+            && Span == other.Span
+            && ContributingOrdinals.SequenceEqual(other.ContributingOrdinals);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(CteIndex);
+        hash.Add(ParameterOrdinal);
+        hash.Add(Span);
+        foreach (var ordinal in ContributingOrdinals)
+        {
+            hash.Add(ordinal);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Four-arity to match the property count. Deliberately not left at three: a stale
+    /// <c>var (i, ord, span) = provenance</c> would keep compiling and silently ignore
+    /// <see cref="ContributingOrdinals"/>, which is the field a consumer is most likely to have missed.
+    /// </summary>
+    public void Deconstruct(
+        out int cteIndex,
+        out int? parameterOrdinal,
+        out SourceSpan? span,
+        out IReadOnlyList<int> contributingOrdinals)
     {
         cteIndex = CteIndex;
         parameterOrdinal = ParameterOrdinal;
         span = Span;
+        contributingOrdinals = ContributingOrdinals;
     }
 }

--- a/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
@@ -4,4 +4,37 @@ namespace Ignixa.Search.Sql.Tracing;
 
 /// <summary>One CTE's link back to the parameter that produced it. Null ordinal where exempt —
 /// :missing, compartment, and structural CTEs have no source text.</summary>
-public sealed record CteProvenance(int CteIndex, int? ParameterOrdinal, SourceSpan? Span);
+/// <remarks>
+/// Not a positional record: <see cref="CteIndex"/> and <see cref="ParameterOrdinal"/> are plan and query
+/// positions and must be non-negative, so construction validates rather than trusting every producer to
+/// pass well-formed indices.
+/// </remarks>
+public sealed record CteProvenance
+{
+    public CteProvenance(int cteIndex, int? parameterOrdinal, SourceSpan? span)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(cteIndex);
+        if (parameterOrdinal is < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(parameterOrdinal), parameterOrdinal, "Parameter ordinal must be non-negative when present.");
+        }
+
+        CteIndex = cteIndex;
+        ParameterOrdinal = parameterOrdinal;
+        Span = span;
+    }
+
+    public int CteIndex { get; init; }
+
+    public int? ParameterOrdinal { get; init; }
+
+    public SourceSpan? Span { get; init; }
+
+    public void Deconstruct(out int cteIndex, out int? parameterOrdinal, out SourceSpan? span)
+    {
+        cteIndex = CteIndex;
+        parameterOrdinal = ParameterOrdinal;
+        span = Span;
+    }
+}

--- a/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
@@ -73,9 +73,15 @@ public static class SearchCompiler
         // failure land on top of the Resolve-stage one already recorded above.
         if (resolved.Unresolved.Count == 0)
         {
+            // Tracks whether Lower itself completed. Keying the reported stage off planTrace instead would
+            // blame the lowerer for anything BuildPlanTrace throws -- and BuildPlanTrace runs the explainer,
+            // whose NotSupportedException means a CteDefinition case is missing from PlanExplainer, not
+            // that lowering went wrong. Filing that under Lower sends the next reader to the wrong file.
+            LoweredPlan? lowered = null;
+
             try
             {
-                var lowered = Lower.Run(
+                lowered = Lower.Run(
                     options.Expression,
                     resolved.Symbols,
                     resourceType,
@@ -91,9 +97,13 @@ public static class SearchCompiler
                 var emitted = SqlBuilder.Run(lowered.Plan, new EmitOptions(IncludeTextRanges: true));
                 sqlTrace = new EmittedSqlTrace(emitted.Sql, emitted.TextRanges ?? []);
             }
+            // Deliberately does NOT catch ArgumentException. The trace records' construction guards
+            // (SqlTextRange, CteProvenance, PlanExplainRow) throw it, but none can trip on a well-formed
+            // plan -- they detect programmer error, so swallowing them into a TraceFailure would file a
+            // bug in this compiler as though it were a property of the user's query.
             catch (Exception ex) when (ex is NotSupportedException or KeyNotFoundException)
             {
-                failure = RecordFailure(outcomes, planTrace is null ? TraceStage.Lower : TraceStage.Emit, ex);
+                failure = RecordFailure(outcomes, lowered is null ? TraceStage.Lower : TraceStage.Emit, ex);
             }
         }
 
@@ -208,10 +218,12 @@ public static class SearchCompiler
         for (var i = 0; i < ctes.Length; i++)
         {
             ctes[i] = new CteProvenance(
-                i, directOrdinals[i], spans[i], ContributingOrdinals(i, rows, directOrdinals));
+                i, directOrdinals[i], spans[i], ContributingOrdinals(i, lowered.Plan, directOrdinals));
         }
 
-        return new QueryPlanTrace(lowered.Plan.Explain(), ctes, rows);
+        // Print off the rows already computed rather than calling Explain(), which would run Describe a
+        // second time -- same output, twice the work, and two chances to disagree.
+        return new QueryPlanTrace(PlanExplainer.Print(rows), ctes, rows);
     }
 
     /// <summary>
@@ -220,14 +232,13 @@ public static class SearchCompiler
     /// parameters does this join belong to" has to walk the plan itself.
     /// </summary>
     /// <remarks>
-    /// Depth-first over <see cref="PlanExplainRow.ReferencedCteIndexes"/>, which the explainer reads
-    /// straight off the plan node. Plan CTE references form a DAG (a CTE may only reference lower indices),
-    /// so the walk terminates; <paramref name="visited"/> keeps a diamond from being counted twice.
+    /// Reads the child references off <paramref name="plan"/> rather than off the explainer's rows: the
+    /// rows are a display projection, and provenance should not depend on how something renders. Plan CTE
+    /// references only ever point at lower indices — every structural factory appends itself after its
+    /// children — so the walk terminates. The visited set exists for a diamond, where two branches share a
+    /// child; ordinals land in a set, so revisiting would be harmless but wasteful.
     /// </remarks>
-    private static IReadOnlyList<int> ContributingOrdinals(
-        int index,
-        IReadOnlyList<PlanExplainRow> rows,
-        int?[] directOrdinals)
+    private static IReadOnlyList<int> ContributingOrdinals(int index, QueryPlan plan, int?[] directOrdinals)
     {
         var ordinals = new SortedSet<int>();
         var visited = new HashSet<int>();
@@ -246,8 +257,7 @@ public static class SearchCompiler
                 ordinals.Add(ordinal);
             }
 
-            var row = rows.FirstOrDefault(r => r.CanonicalLabel == SqlLabels.CteLabel(cteIndex));
-            foreach (var child in row?.ReferencedCteIndexes ?? [])
+            foreach (var child in PlanExplainer.ReferencedCteIndexesOf(plan.Ctes[cteIndex]))
             {
                 Collect(child);
             }

--- a/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
@@ -190,22 +190,68 @@ public static class SearchCompiler
     /// <summary>Builds the plan trace, mapping each CTE origin to its owning parameter by reference identity against every trace's IR subtree. Origins with no owner (:missing, compartment, structural CTEs) keep a null ordinal.</summary>
     private static QueryPlanTrace BuildPlanTrace(LoweredPlan lowered, IReadOnlyList<ParameterTrace> outcomes)
     {
-        var ctes = new CteProvenance[lowered.Plan.Ctes.Count];
-        for (var i = 0; i < ctes.Length; i++)
-        {
-            ctes[i] = new CteProvenance(i, null, null);
-        }
+        var rows = PlanExplainer.Describe(lowered.Plan);
+        var directOrdinals = new int?[lowered.Plan.Ctes.Count];
+        var spans = new SourceSpan?[lowered.Plan.Ctes.Count];
 
         foreach (var origin in lowered.Provenance.Origins)
         {
             var owner = outcomes.FirstOrDefault(t => t.Ir is not null && Flatten(t.Ir).Any(n => ReferenceEquals(n, origin.SourceNode)));
             if (owner is not null)
             {
-                ctes[origin.CteIndex] = new CteProvenance(origin.CteIndex, owner.Ordinal, ExtractSpan(origin.SourceNode));
+                directOrdinals[origin.CteIndex] = owner.Ordinal;
+                spans[origin.CteIndex] = ExtractSpan(origin.SourceNode);
             }
         }
 
-        return new QueryPlanTrace(lowered.Plan.Explain(), ctes, PlanExplainer.Describe(lowered.Plan));
+        var ctes = new CteProvenance[lowered.Plan.Ctes.Count];
+        for (var i = 0; i < ctes.Length; i++)
+        {
+            ctes[i] = new CteProvenance(
+                i, directOrdinals[i], spans[i], ContributingOrdinals(i, rows, directOrdinals));
+        }
+
+        return new QueryPlanTrace(lowered.Plan.Explain(), ctes, rows);
+    }
+
+    /// <summary>
+    /// Every parameter ordinal the CTE at <paramref name="index"/> draws from, closed over the CTEs it
+    /// composes. A structural CTE has no ordinal of its own, so without this a consumer wanting "which
+    /// parameters does this join belong to" has to walk the plan itself.
+    /// </summary>
+    /// <remarks>
+    /// Depth-first over <see cref="PlanExplainRow.ReferencedCteIndexes"/>, which the explainer reads
+    /// straight off the plan node. Plan CTE references form a DAG (a CTE may only reference lower indices),
+    /// so the walk terminates; <paramref name="visited"/> keeps a diamond from being counted twice.
+    /// </remarks>
+    private static IReadOnlyList<int> ContributingOrdinals(
+        int index,
+        IReadOnlyList<PlanExplainRow> rows,
+        int?[] directOrdinals)
+    {
+        var ordinals = new SortedSet<int>();
+        var visited = new HashSet<int>();
+        Collect(index);
+        return [.. ordinals];
+
+        void Collect(int cteIndex)
+        {
+            if (!visited.Add(cteIndex))
+            {
+                return;
+            }
+
+            if (directOrdinals[cteIndex] is { } ordinal)
+            {
+                ordinals.Add(ordinal);
+            }
+
+            var row = rows.FirstOrDefault(r => r.CanonicalLabel == SqlLabels.CteLabel(cteIndex));
+            foreach (var child in row?.ReferencedCteIndexes ?? [])
+            {
+                Collect(child);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Core/Ignixa.Search/Expressions/IrProjector.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrProjector.cs
@@ -5,6 +5,8 @@
 
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Ignixa.Search.Expressions;
 
 /// <summary>
@@ -46,31 +48,41 @@ public static class IrProjector
 
     /// <summary>
     /// <see cref="Describe"/> for callers that must not fail the request over an unprojectable node —
-    /// returns <see langword="false"/> and no rows where <see cref="Describe"/> would throw.
+    /// returns <see langword="false"/>, no rows, and the reason where <see cref="Describe"/> would throw.
     /// </summary>
     /// <remarks>
     /// The strict overload stays the default on purpose. A partial tree misrepresents what the server will
     /// execute, so anything asserting the projection is complete — tests, golden output — must keep using
     /// <see cref="Describe"/> and let it throw. This exists so a renderer showing a trace alongside a
-    /// successful search can degrade to "no IR available" instead of turning a diagnostic into a 500, and
-    /// so that choice is made once here rather than by a catch block at every call site.
+    /// successful search can degrade to "no IR available" instead of turning a diagnostic into a 500.
+    /// <para>
+    /// <paramref name="unsupportedReason"/> is not optional politeness: it names the node kind that could
+    /// not be projected. Without it a blank IR panel is indistinguishable from a rendering bug, and the
+    /// one fact needed to diagnose it — which shape the projector does not cover — is exactly what the
+    /// swallowed exception was carrying.
+    /// </para>
     /// </remarks>
     /// <returns>
     /// <see langword="true"/> and the complete rows, or <see langword="false"/> and an empty list. Never a
     /// partial projection — a half-drawn tree is the failure mode this whole type is built to avoid.
     /// </returns>
-    public static bool TryDescribe(Expression node, out IReadOnlyList<IrRow> rows)
+    public static bool TryDescribe(
+        Expression node,
+        out IReadOnlyList<IrRow> rows,
+        [NotNullWhen(false)] out string? unsupportedReason)
     {
         ArgumentNullException.ThrowIfNull(node);
 
         try
         {
             rows = Describe(node);
+            unsupportedReason = null;
             return true;
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex)
         {
             rows = [];
+            unsupportedReason = ex.Message;
             return false;
         }
     }

--- a/src/Core/Ignixa.Search/Expressions/IrProjector.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrProjector.cs
@@ -19,7 +19,10 @@ namespace Ignixa.Search.Expressions;
 /// Covers the untyped field-level kinds as well as the typed ones: <c>:text</c> and <c>:of-type</c> bind
 /// through <c>SearchValueExpressionBuilderHelper</c> and so put a bare <see cref="StringExpression"/> or a
 /// multiary of them into a parameter's IR. Those are ordinary FHIR searches, not exotica, so refusing to
-/// project them would make <see cref="Describe"/> throw on real traffic.
+/// project them would make <see cref="Describe"/> throw on real traffic. The remaining field-level kinds
+/// (<see cref="BinaryExpression"/>, <see cref="MissingFieldExpression"/>) have no binder path into a traced
+/// IR — the legacy factories that make them feed the EF query generator, not a parse — so they are left to
+/// the loud <see cref="NotSupportedException"/> arm rather than given tokens nothing can produce.
 /// </para>
 /// </remarks>
 public static class IrProjector
@@ -65,8 +68,6 @@ public static class IrProjector
         IncludeExpression => "include",
         SortExpression => "sort",
         StringExpression => "stringField",
-        BinaryExpression => "binaryField",
-        MissingFieldExpression => "missingField",
         _ => throw new NotSupportedException($"No IR projection for {node.GetType().Name}."),
     };
 

--- a/src/Core/Ignixa.Search/Expressions/IrProjector.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrProjector.cs
@@ -44,6 +44,37 @@ public static class IrProjector
         return rows;
     }
 
+    /// <summary>
+    /// <see cref="Describe"/> for callers that must not fail the request over an unprojectable node —
+    /// returns <see langword="false"/> and no rows where <see cref="Describe"/> would throw.
+    /// </summary>
+    /// <remarks>
+    /// The strict overload stays the default on purpose. A partial tree misrepresents what the server will
+    /// execute, so anything asserting the projection is complete — tests, golden output — must keep using
+    /// <see cref="Describe"/> and let it throw. This exists so a renderer showing a trace alongside a
+    /// successful search can degrade to "no IR available" instead of turning a diagnostic into a 500, and
+    /// so that choice is made once here rather than by a catch block at every call site.
+    /// </remarks>
+    /// <returns>
+    /// <see langword="true"/> and the complete rows, or <see langword="false"/> and an empty list. Never a
+    /// partial projection — a half-drawn tree is the failure mode this whole type is built to avoid.
+    /// </returns>
+    public static bool TryDescribe(Expression node, out IReadOnlyList<IrRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        try
+        {
+            rows = Describe(node);
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            rows = [];
+            return false;
+        }
+    }
+
     private static void Visit(Expression node, int depth, List<IrRow> rows)
     {
         rows.Add(new IrRow(KindOf(node), TextOf(node), depth));

--- a/src/Core/Ignixa.Search/Expressions/IrRow.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrRow.cs
@@ -20,5 +20,33 @@ namespace Ignixa.Search.Expressions;
 /// arrive in pre-order. A renderer can therefore indent straight from <see cref="Depth"/> without tracking a
 /// stack, and never has to handle a level appearing out of nowhere.
 /// </para>
+/// <para>
+/// Not a positional record: construction rejects negative depths, so the invariant a renderer relies on
+/// holds no matter who produced the rows.
+/// </para>
 /// </remarks>
-public sealed record IrRow(string Kind, string Text, int Depth);
+public sealed record IrRow
+{
+    public IrRow(string kind, string text, int depth)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(kind);
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        ArgumentOutOfRangeException.ThrowIfNegative(depth);
+        Kind = kind;
+        Text = text;
+        Depth = depth;
+    }
+
+    public string Kind { get; init; }
+
+    public string Text { get; init; }
+
+    public int Depth { get; init; }
+
+    public void Deconstruct(out string kind, out string text, out int depth)
+    {
+        kind = Kind;
+        text = Text;
+        depth = Depth;
+    }
+}

--- a/src/Core/Ignixa.Search/Expressions/IrRow.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrRow.cs
@@ -16,13 +16,22 @@ namespace Ignixa.Search.Expressions;
 /// cross a wire or be rendered without the caller knowing every node type. This is the serializable view:
 /// enough to draw an indented tree with a per-node kind chip, and nothing else.
 /// <para>
-/// <see cref="Depth"/> is 0 on the first row and changes by at most +1 from the row before it, because rows
-/// arrive in pre-order. A renderer can therefore indent straight from <see cref="Depth"/> without tracking a
-/// stack, and never has to handle a level appearing out of nowhere.
+/// In a sequence produced by <see cref="IrProjector.Describe"/>, <see cref="Depth"/> is 0 on the first row
+/// and changes by at most +1 from the row before it, because rows arrive in pre-order. A renderer can
+/// therefore indent straight from <see cref="Depth"/> without tracking a stack. That is a property of the
+/// producer and of the sequence, not of this type: a single row can only promise its own depth is
+/// non-negative, which the constructor enforces. A renderer handed rows from anywhere else still has to
+/// check.
 /// </para>
 /// <para>
-/// Not a positional record: construction rejects negative depths, so the invariant a renderer relies on
-/// holds no matter who produced the rows.
+/// <see cref="Kind"/> is a token a renderer switches on, so it must be non-empty. <see cref="Text"/> is
+/// display text and may legitimately be empty — <see cref="IrProjector"/> falls back to an empty string
+/// rather than failing a trace over a node that renders blank, and a diagnostics projection throwing is
+/// worse than a blank line.
+/// </para>
+/// <para>
+/// The properties are get-only rather than <c>init</c>: a <c>with</c> expression copies through the
+/// compiler-generated copy constructor and would skip the checks below entirely.
 /// </para>
 /// </remarks>
 public sealed record IrRow
@@ -30,18 +39,18 @@ public sealed record IrRow
     public IrRow(string kind, string text, int depth)
     {
         ArgumentException.ThrowIfNullOrEmpty(kind);
-        ArgumentException.ThrowIfNullOrEmpty(text);
+        ArgumentNullException.ThrowIfNull(text);
         ArgumentOutOfRangeException.ThrowIfNegative(depth);
         Kind = kind;
         Text = text;
         Depth = depth;
     }
 
-    public string Kind { get; init; }
+    public string Kind { get; }
 
-    public string Text { get; init; }
+    public string Text { get; }
 
-    public int Depth { get; init; }
+    public int Depth { get; }
 
     public void Deconstruct(out string kind, out string text, out int depth)
     {

--- a/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
@@ -9,6 +9,7 @@ using Ignixa.Search.Definition;
 using Ignixa.Search.Expressions.Parsers.Binding;
 using Ignixa.Search.Expressions.Parsers.Syntax;
 using Ignixa.Search.Indexing;
+using Ignixa.Specification.ValueSets.Normative;
 
 namespace Ignixa.Search.Expressions.Parsers;
 
@@ -101,6 +102,7 @@ public class ExpressionParser : IExpressionParser
             return new ParseResult(
                 notReferencedExpression,
                 SyntaxProjector.Project(notReferencedSyntax),
+                null,
                 null);
         }
 
@@ -108,6 +110,10 @@ public class ExpressionParser : IExpressionParser
         BoundSearchKey bound = _keyBinder.Bind(resourceTypes, keySyntax);
 
         SyntaxNode valueSyntax = null;
+
+        // The binder invokes this for the parameter the value is actually matched against -- the terminal
+        // one for a chain -- so this is where the declared type is known without re-walking anything.
+        SearchParamType? dataType = null;
         Expression expression = SearchExpressionBinder.BindKey(
             bound,
             parameter =>
@@ -117,10 +123,11 @@ public class ExpressionParser : IExpressionParser
                     parameter.Modifier,
                     value);
                 valueSyntax = parsed.ValueSyntax;
+                dataType = parameter.SearchParameter.Type;
                 return parsed.Expression;
             });
 
-        return new ParseResult(expression, SyntaxProjector.Project(keySyntax), valueSyntax);
+        return new ParseResult(expression, SyntaxProjector.Project(keySyntax), valueSyntax, dataType);
     }
 
     public IncludeExpression ParseInclude(

--- a/src/Core/Ignixa.Search/Expressions/Parsers/ParseResult.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/ParseResult.cs
@@ -5,10 +5,25 @@
 
 #nullable enable
 
+using Ignixa.Specification.ValueSets.Normative;
+
 namespace Ignixa.Search.Expressions.Parsers;
 
 /// <summary>
 /// A parsed search parameter plus its projected syntax. <see cref="ValueSyntax"/> is null for shapes with
 /// no value tree, such as <c>_not-referenced</c> and <c>_include</c>/<c>_revinclude</c>.
 /// </summary>
-public sealed record ParseResult(Expression Expression, SyntaxNode KeySyntax, SyntaxNode? ValueSyntax);
+/// <param name="Expression">The bound expression.</param>
+/// <param name="KeySyntax">Projected syntax for the parameter key.</param>
+/// <param name="ValueSyntax">Projected syntax for the parameter value, where the shape has one.</param>
+/// <param name="DataType">
+/// The declared type of the search parameter the value was bound against — for a chain, the terminal
+/// parameter, since that is the one the value is matched with. Null for shapes that bind no value
+/// parameter (<c>_not-referenced</c>). Captured here because the binder already resolved it; recovering it
+/// downstream means walking the expression graph and re-deriving what was known at parse time.
+/// </param>
+public sealed record ParseResult(
+    Expression Expression,
+    SyntaxNode KeySyntax,
+    SyntaxNode? ValueSyntax,
+    SearchParamType? DataType);

--- a/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
+++ b/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
@@ -27,12 +27,17 @@ namespace Ignixa.Search.Parsing;
 /// and is not serializable. Anything crossing a wire or reaching a renderer must go through
 /// <see cref="IrProjector.Describe"/>, which flattens it to <see cref="IrRow"/>s.
 /// </para>
+/// <para>
+/// The parameter order interleaves <see cref="Key"/> with <see cref="KeySyntax"/> and <see cref="Value"/>
+/// with <see cref="ValueSyntax"/> on purpose: no two adjacent constructor parameters share a type, so a
+/// positional transposition at a call site is a compile error rather than a silent swap.
+/// </para>
 /// </remarks>
 public sealed record ParameterTrace(
     int Ordinal,
     string Key,
-    string Value,
     SyntaxNode? KeySyntax,
+    string Value,
     SyntaxNode? ValueSyntax,
     Expression? Ir,
     ParameterOutcome Outcome);

--- a/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
+++ b/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
@@ -7,6 +7,7 @@
 
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Expressions.Parsers;
+using Ignixa.Specification.ValueSets.Normative;
 
 namespace Ignixa.Search.Parsing;
 
@@ -28,16 +29,67 @@ namespace Ignixa.Search.Parsing;
 /// <see cref="IrProjector.Describe"/>, which flattens it to <see cref="IrRow"/>s.
 /// </para>
 /// <para>
-/// The parameter order interleaves <see cref="Key"/> with <see cref="KeySyntax"/> and <see cref="Value"/>
-/// with <see cref="ValueSyntax"/> on purpose: no two adjacent constructor parameters share a type, so a
-/// positional transposition at a call site is a compile error rather than a silent swap.
+/// <see cref="Ordinal"/> and <see cref="Key"/> are validated on construction because <see cref="Ordinal"/>
+/// is what <see cref="Sql.Tracing.CteProvenance.ParameterOrdinal"/> is built from — an unchecked value here
+/// surfaces as a failure several stages downstream, naming a parameter the producer never touched. Those
+/// two are get-only so a <c>with</c> cannot bypass the checks; the rest stay <c>init</c> because later
+/// stages legitimately restamp <see cref="Outcome"/> when lowering or emission fails.
+/// </para>
+/// <para>
+/// The parameter order groups <see cref="Key"/> with <see cref="KeySyntax"/> and <see cref="Value"/> with
+/// <see cref="ValueSyntax"/>. That reads better than separating each pair, but it is not a safety
+/// mechanism: <see cref="Key"/> and <see cref="Value"/> are both <see cref="string"/>, so transposing them
+/// still compiles. Producers use named arguments, which is what actually prevents it.
 /// </para>
 /// </remarks>
-public sealed record ParameterTrace(
-    int Ordinal,
-    string Key,
-    SyntaxNode? KeySyntax,
-    string Value,
-    SyntaxNode? ValueSyntax,
-    Expression? Ir,
-    ParameterOutcome Outcome);
+public sealed record ParameterTrace
+{
+    public ParameterTrace(
+        int ordinal,
+        string key,
+        SyntaxNode? keySyntax,
+        string value,
+        SyntaxNode? valueSyntax,
+        Expression? ir,
+        ParameterOutcome outcome,
+        SearchParamType? dataType)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        Ordinal = ordinal;
+        Key = key;
+        KeySyntax = keySyntax;
+        Value = value;
+        ValueSyntax = valueSyntax;
+        Ir = ir;
+        Outcome = outcome;
+        DataType = dataType;
+    }
+
+    /// <summary>Position among the search parameters of this request, dense from zero.</summary>
+    public int Ordinal { get; }
+
+    /// <summary>The parameter name as written, including any modifier.</summary>
+    public string Key { get; }
+
+    public SyntaxNode? KeySyntax { get; init; }
+
+    /// <summary>The parameter value as written. Empty for shapes that carry no value.</summary>
+    public string Value { get; init; }
+
+    public SyntaxNode? ValueSyntax { get; init; }
+
+    public Expression? Ir { get; init; }
+
+    public ParameterOutcome Outcome { get; init; }
+
+    /// <summary>
+    /// The declared type of the search parameter this value was matched against — see
+    /// <see cref="ParseResult.DataType"/>. Null when the parameter never bound a value, which includes
+    /// every parameter that was ignored before parsing completed.
+    /// </summary>
+    public SearchParamType? DataType { get; init; }
+}

--- a/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
+++ b/src/Core/Ignixa.Search/Parsing/ParameterTrace.cs
@@ -29,17 +29,21 @@ namespace Ignixa.Search.Parsing;
 /// <see cref="IrProjector.Describe"/>, which flattens it to <see cref="IrRow"/>s.
 /// </para>
 /// <para>
-/// <see cref="Ordinal"/> and <see cref="Key"/> are validated on construction because <see cref="Ordinal"/>
-/// is what <see cref="Sql.Tracing.CteProvenance.ParameterOrdinal"/> is built from — an unchecked value here
-/// surfaces as a failure several stages downstream, naming a parameter the producer never touched. Those
-/// two are get-only so a <c>with</c> cannot bypass the checks; the rest stay <c>init</c> because later
-/// stages legitimately restamp <see cref="Outcome"/> when lowering or emission fails.
+/// Construction validates <see cref="Ordinal"/>, <see cref="Key"/>, <see cref="Value"/> and
+/// <see cref="Outcome"/>. <see cref="Ordinal"/> earns its guard by being what
+/// <see cref="Sql.Tracing.CteProvenance.ParameterOrdinal"/> is built from — an unchecked value here
+/// surfaces as a failure several stages downstream, naming a parameter the producer never touched.
+/// <see cref="Outcome"/> is the only <c>init</c> property, because later stages legitimately restamp it
+/// when lowering or emission fails; every other property is get-only so a <c>with</c> cannot copy around
+/// a check. (<see cref="Outcome"/>'s own null guard is therefore bypassable by
+/// <c>with { Outcome = null! }</c> — accepted, since that requires suppressing nullability to reach.)
 /// </para>
 /// <para>
 /// The parameter order groups <see cref="Key"/> with <see cref="KeySyntax"/> and <see cref="Value"/> with
 /// <see cref="ValueSyntax"/>. That reads better than separating each pair, but it is not a safety
 /// mechanism: <see cref="Key"/> and <see cref="Value"/> are both <see cref="string"/>, so transposing them
-/// still compiles. Producers use named arguments, which is what actually prevents it.
+/// still compiles, and the test fixtures construct these positionally. The production call sites in
+/// <see cref="SearchOptionsBuilder"/> use named arguments by convention; nothing enforces it.
 /// </para>
 /// </remarks>
 public sealed record ParameterTrace
@@ -75,15 +79,20 @@ public sealed record ParameterTrace
     /// <summary>The parameter name as written, including any modifier.</summary>
     public string Key { get; }
 
-    public SyntaxNode? KeySyntax { get; init; }
+    public SyntaxNode? KeySyntax { get; }
 
     /// <summary>The parameter value as written. Empty for shapes that carry no value.</summary>
-    public string Value { get; init; }
+    public string Value { get; }
 
-    public SyntaxNode? ValueSyntax { get; init; }
+    public SyntaxNode? ValueSyntax { get; }
 
-    public Expression? Ir { get; init; }
+    public Expression? Ir { get; }
 
+    /// <summary>
+    /// How this parameter fared. The only settable property: <see cref="Sql.Tracing.SearchCompiler"/>
+    /// restamps it with a <see cref="ParameterOutcome.Failed"/> when a later stage attributes a failure
+    /// back to this parameter.
+    /// </summary>
     public ParameterOutcome Outcome { get; init; }
 
     /// <summary>
@@ -91,5 +100,5 @@ public sealed record ParameterTrace
     /// <see cref="ParseResult.DataType"/>. Null when the parameter never bound a value, which includes
     /// every parameter that was ignored before parsing completed.
     /// </summary>
-    public SearchParamType? DataType { get; init; }
+    public SearchParamType? DataType { get; }
 }

--- a/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
+++ b/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
@@ -184,8 +184,8 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                             outcomes.Add(new ParameterTrace(
                                 searchOrdinal++,
                                 param.Name,
-                                param.Value,
                                 parseResult.KeySyntax,
+                                param.Value,
                                 parseResult.ValueSyntax,
                                 parseResult.Expression,
                                 new ParameterOutcome.Compiled()));
@@ -242,8 +242,8 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                     outcomes.Add(new ParameterTrace(
                         searchOrdinal++,
                         param.Name,
-                        param.Value,
                         null,
+                        param.Value,
                         null,
                         null,
                         new ParameterOutcome.Ignored(ex.Message, null)));
@@ -257,8 +257,8 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                     outcomes.Add(new ParameterTrace(
                         searchOrdinal++,
                         param.Name,
-                        param.Value,
                         null,
+                        param.Value,
                         null,
                         null,
                         new ParameterOutcome.Ignored(ex.Message, null)));

--- a/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
+++ b/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
@@ -182,13 +182,14 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                             ParseResult parseResult = _expressionParser.ParseWithSyntax(resourceTypes, param.Name, param.Value);
                             searchExpressions.Add(parseResult.Expression);
                             outcomes.Add(new ParameterTrace(
-                                searchOrdinal++,
-                                param.Name,
-                                parseResult.KeySyntax,
-                                param.Value,
-                                parseResult.ValueSyntax,
-                                parseResult.Expression,
-                                new ParameterOutcome.Compiled()));
+                                ordinal: searchOrdinal++,
+                                key: param.Name,
+                                keySyntax: parseResult.KeySyntax,
+                                value: param.Value,
+                                valueSyntax: parseResult.ValueSyntax,
+                                ir: parseResult.Expression,
+                                outcome: new ParameterOutcome.Compiled(),
+                                dataType: parseResult.DataType));
                         }
                         else
                         {
@@ -240,13 +241,14 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                 if (outcomes is not null && param.Category == ParameterCategory.Search)
                 {
                     outcomes.Add(new ParameterTrace(
-                        searchOrdinal++,
-                        param.Name,
-                        null,
-                        param.Value,
-                        null,
-                        null,
-                        new ParameterOutcome.Ignored(ex.Message, null)));
+                        ordinal: searchOrdinal++,
+                        key: param.Name,
+                        keySyntax: null,
+                        value: param.Value,
+                        valueSyntax: null,
+                        ir: null,
+                        outcome: new ParameterOutcome.Ignored(ex.Message, null),
+                        dataType: null));
                 }
             }
             catch (InvalidSearchOperationException ex)
@@ -255,13 +257,14 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                 if (outcomes is not null && param.Category == ParameterCategory.Search)
                 {
                     outcomes.Add(new ParameterTrace(
-                        searchOrdinal++,
-                        param.Name,
-                        null,
-                        param.Value,
-                        null,
-                        null,
-                        new ParameterOutcome.Ignored(ex.Message, null)));
+                        ordinal: searchOrdinal++,
+                        key: param.Name,
+                        keySyntax: null,
+                        value: param.Value,
+                        valueSyntax: null,
+                        ir: null,
+                        outcome: new ParameterOutcome.Ignored(ex.Message, null),
+                        dataType: null));
                 }
             }
         }

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
@@ -257,24 +257,47 @@ public class IrProjectorTests
         var node = Expression.CompartmentSearch("Patient", "123");
 
         // Act
-        var projected = IrProjector.TryDescribe(node, out var rows);
+        var projected = IrProjector.TryDescribe(node, out var rows, out var reason);
 
         // Assert -- no partial tree: a half-drawn projection misrepresents what will execute.
         projected.ShouldBeFalse();
         rows.ShouldBeEmpty();
+
+        // The reason must name the shape, or a blank IR panel is indistinguishable from a render bug.
+        reason.ShouldNotBeNull();
+        reason.ShouldContain(nameof(CompartmentSearchExpression));
     }
 
     [Fact]
-    public void GivenAProjectableNode_WhenTryDescribed_ThenItReturnsTheSameRowsAsDescribe()
+    public void GivenAProjectableRootOverAnUnprojectableChild_WhenTryDescribed_ThenNoPartialRowsEscape()
+    {
+        // Arrange -- the root projects fine and would have produced rows before the child threw. This is
+        // the case the all-or-nothing contract exists for; a root-level failure would not exercise it.
+        var node = Expression.And(
+            Expression.StringEquals(FieldName.String, null, "Smith", false),
+            Expression.CompartmentSearch("Patient", "123"));
+
+        // Act
+        var projected = IrProjector.TryDescribe(node, out var rows, out var reason);
+
+        // Assert
+        projected.ShouldBeFalse();
+        rows.ShouldBeEmpty();
+        reason.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GivenAProjectableNode_WhenTryDescribed_ThenItReturnsTheSameRowsAsDescribeAndNoReason()
     {
         // Arrange
         var ir = ParsePatient(("name", SearchParamType.String), ("name", "Smith"));
 
         // Act
-        var projected = IrProjector.TryDescribe(ir, out var rows);
+        var projected = IrProjector.TryDescribe(ir, out var rows, out var reason);
 
         // Assert
         projected.ShouldBeTrue();
+        reason.ShouldBeNull();
         rows.ShouldBe(IrProjector.Describe(ir));
     }
 

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
@@ -250,6 +250,34 @@ public class IrProjectorTests
             .Message.ShouldContain(nameof(MissingFieldExpression));
     }
 
+    [Fact]
+    public void GivenAnUnprojectableNode_WhenTryDescribed_ThenItReportsFailureInsteadOfThrowing()
+    {
+        // Arrange
+        var node = Expression.CompartmentSearch("Patient", "123");
+
+        // Act
+        var projected = IrProjector.TryDescribe(node, out var rows);
+
+        // Assert -- no partial tree: a half-drawn projection misrepresents what will execute.
+        projected.ShouldBeFalse();
+        rows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenAProjectableNode_WhenTryDescribed_ThenItReturnsTheSameRowsAsDescribe()
+    {
+        // Arrange
+        var ir = ParsePatient(("name", SearchParamType.String), ("name", "Smith"));
+
+        // Act
+        var projected = IrProjector.TryDescribe(ir, out var rows);
+
+        // Assert
+        projected.ShouldBeTrue();
+        rows.ShouldBe(IrProjector.Describe(ir));
+    }
+
     private static Expression ParsePatient(
         (string Code, SearchParamType Type) searchParameter,
         (string Key, string Value) query)

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
@@ -235,6 +235,21 @@ public class IrProjectorTests
             .Message.ShouldContain(nameof(CompartmentSearchExpression));
     }
 
+    [Fact]
+    public void GivenAFieldLevelNodeWithNoTraceProducer_WhenDescribed_ThenItThrowsRatherThanInventingAToken()
+    {
+        // Arrange -- the legacy field-level factories feed the EF query generator; no binder path
+        // puts these shapes into a traced IR.
+        var binary = Expression.GreaterThan(FieldName.TokenCode, null, "8480-6");
+        var missingField = Expression.Missing(FieldName.TokenSystem, null);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => IrProjector.Describe(binary))
+            .Message.ShouldContain(nameof(BinaryExpression));
+        Should.Throw<NotSupportedException>(() => IrProjector.Describe(missingField))
+            .Message.ShouldContain(nameof(MissingFieldExpression));
+    }
+
     private static Expression ParsePatient(
         (string Code, SearchParamType Type) searchParameter,
         (string Key, string Value) query)

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrRowTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrRowTests.cs
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+#nullable enable
+
+using Ignixa.Search.Expressions;
+using Shouldly;
+
+namespace Ignixa.Application.Tests.Search.Parsing;
+
+public class IrRowTests
+{
+    [Fact]
+    public void GivenANegativeDepth_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentOutOfRangeException>(() => new IrRow("and", "And", -1));
+
+    [Fact]
+    public void GivenAnEmptyKindOrText_WhenConstructed_ThenItThrows()
+    {
+        Should.Throw<ArgumentException>(() => new IrRow(string.Empty, "And", 0));
+        Should.Throw<ArgumentException>(() => new IrRow("and", string.Empty, 0));
+    }
+}

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrRowTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrRowTests.cs
@@ -17,9 +17,21 @@ public class IrRowTests
         => Should.Throw<ArgumentOutOfRangeException>(() => new IrRow("and", "And", -1));
 
     [Fact]
-    public void GivenAnEmptyKindOrText_WhenConstructed_ThenItThrows()
+    public void GivenAnEmptyKind_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentException>(() => new IrRow(string.Empty, "And", 0));
+
+    [Fact]
+    public void GivenANullText_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentNullException>(() => new IrRow("and", null!, 0));
+
+    [Fact]
+    public void GivenAnEmptyText_WhenConstructed_ThenItIsAccepted()
     {
-        Should.Throw<ArgumentException>(() => new IrRow(string.Empty, "And", 0));
-        Should.Throw<ArgumentException>(() => new IrRow("and", string.Empty, 0));
+        // Arrange & Act -- IrProjector.TextOf falls back to an empty string rather than failing a trace
+        // over a node that renders blank. A guard here would turn that fallback into a guaranteed throw.
+        var row = new IrRow("stringField", string.Empty, 0);
+
+        // Assert
+        row.Text.ShouldBe(string.Empty);
     }
 }

--- a/test/Ignixa.Application.Tests/Search/Parsing/ParameterTraceTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/ParameterTraceTests.cs
@@ -1,0 +1,85 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+#nullable enable
+
+using Ignixa.Search.Parsing;
+using Shouldly;
+
+namespace Ignixa.Application.Tests.Search.Parsing;
+
+public class ParameterTraceTests
+{
+    private static ParameterTrace Valid()
+        => new(
+            ordinal: 0,
+            key: "name",
+            keySyntax: null,
+            value: "Smith",
+            valueSyntax: null,
+            ir: null,
+            outcome: new ParameterOutcome.Compiled(),
+            dataType: null);
+
+    [Fact]
+    public void GivenANegativeOrdinal_WhenConstructed_ThenItThrows()
+    {
+        // The ordinal feeds CteProvenance.ParameterOrdinal, so an unchecked value here surfaces stages
+        // later naming a parameter this producer never touched.
+        Should.Throw<ArgumentOutOfRangeException>(() => new ParameterTrace(
+            ordinal: -1,
+            key: "name",
+            keySyntax: null,
+            value: "Smith",
+            valueSyntax: null,
+            ir: null,
+            outcome: new ParameterOutcome.Compiled(),
+            dataType: null));
+    }
+
+    [Fact]
+    public void GivenAnEmptyKey_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentException>(() => new ParameterTrace(
+            ordinal: 0,
+            key: string.Empty,
+            keySyntax: null,
+            value: "Smith",
+            valueSyntax: null,
+            ir: null,
+            outcome: new ParameterOutcome.Compiled(),
+            dataType: null));
+
+    [Fact]
+    public void GivenAnEmptyValue_WhenConstructed_ThenItIsAccepted()
+    {
+        // Valueless shapes (_not-referenced, includes) legitimately carry no value.
+        var trace = new ParameterTrace(
+            ordinal: 0,
+            key: "_not-referenced",
+            keySyntax: null,
+            value: string.Empty,
+            valueSyntax: null,
+            ir: null,
+            outcome: new ParameterOutcome.Compiled(),
+            dataType: null);
+
+        trace.Value.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void GivenAnOutcomeRestamp_WhenCopied_ThenOnlyTheOutcomeChanges()
+    {
+        // Outcome is the one init property: SearchCompiler restamps it when a later stage attributes a
+        // failure back to this parameter. Everything else must survive the copy unchanged.
+        var original = Valid();
+
+        var restamped = original with { Outcome = new ParameterOutcome.Ignored("nope", null) };
+
+        restamped.Outcome.ShouldBeOfType<ParameterOutcome.Ignored>();
+        restamped.Ordinal.ShouldBe(original.Ordinal);
+        restamped.Key.ShouldBe(original.Key);
+        restamped.Value.ShouldBe(original.Value);
+    }
+}

--- a/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
@@ -9,6 +9,7 @@ using Ignixa.Search.Expressions;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
 using Ignixa.Search.Sql.Symbols;
 using Ignixa.Search.Sql.Tracing;
 using Ignixa.Specification.ValueSets.Normative;
@@ -152,7 +153,65 @@ public class SearchTraceRealParserTests
         cte.ShouldNotBeNull("no CTE was attributed to the parameter");
 
         trace.Sql.ShouldNotBeNull();
-        trace.Sql!.Ranges.ShouldContain(r => r.Label == PlanExplainer.CteLabel(cte.CteIndex));
+        trace.Sql!.Ranges.ShouldContain(r => r.Label == SqlLabels.CteLabel(cte.CteIndex));
+    }
+
+    [Fact]
+    public async Task GivenARealParse_WhenTraced_ThenTheParameterCarriesItsDeclaredDataType()
+    {
+        // Arrange -- the binder resolved this type; recovering it downstream means walking the IR.
+        var harness = SearchOptionsBuilderHarness.ForPatient(("birthdate", SearchParamType.Date));
+        var resolver = FakeSymbolResolver.For("birthdate");
+
+        // Act
+        var trace = await CompileAsync(harness, resolver, ("birthdate", "2020-01-01"));
+
+        // Assert
+        trace.Parameters.ShouldHaveSingleItem().DataType.ShouldBe(SearchParamType.Date);
+    }
+
+    [Fact]
+    public async Task GivenTheMatchCte_WhenTraced_ThenItsRowIsAddressableByItsCanonicalLabel()
+    {
+        // Arrange
+        var harness = SearchOptionsBuilderHarness.ForPatient(("name", SearchParamType.String));
+        var resolver = FakeSymbolResolver.For("name");
+
+        // Act
+        var trace = await CompileAsync(harness, resolver, ("name", "Smith"));
+
+        // Assert -- the match CTE displays as "root" but is emitted as cte{i}. A consumer joining a plan
+        // row to its SQL range must be able to do it without knowing about that renaming.
+        trace.Plan.ShouldNotBeNull();
+        var root = trace.Plan!.Rows.First(r => r.Label == "root");
+        root.CanonicalLabel.ShouldNotBe("root");
+
+        trace.Sql.ShouldNotBeNull();
+        trace.Sql!.Ranges.ShouldContain(r => r.Label == root.CanonicalLabel);
+    }
+
+    [Fact]
+    public async Task GivenTwoAndedParameters_WhenTraced_ThenTheStructuralCteReportsBothContributors()
+    {
+        // Arrange -- two parameters ANDed together lower to an Intersect, which by construction belongs
+        // to neither one, so its ParameterOrdinal is correctly null. ContributingOrdinals is what lets a
+        // consumer still say which parameters the join came from.
+        var harness = SearchOptionsBuilderHarness.ForPatient(
+            ("name", SearchParamType.String), ("gender", SearchParamType.Token));
+        var resolver = FakeSymbolResolver.For("name", "gender");
+
+        // Act
+        var trace = await CompileAsync(harness, resolver, ("name", "Smith"), ("gender", "male"));
+
+        // Assert
+        trace.Plan.ShouldNotBeNull();
+        var structural = trace.Plan!.Ctes.First(c => c.ParameterOrdinal is null);
+        structural.ContributingOrdinals.ShouldBe([0, 1]);
+
+        foreach (var leaf in trace.Plan.Ctes.Where(c => c.ParameterOrdinal is not null))
+        {
+            leaf.ContributingOrdinals.ShouldBe([leaf.ParameterOrdinal!.Value]);
+        }
     }
 
     private static string Slice(ParameterTrace parameter, SourceSpan span)

--- a/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
@@ -214,6 +214,31 @@ public class SearchTraceRealParserTests
         }
     }
 
+    [Fact]
+    public async Task GivenThreeAndedParameters_WhenTraced_ThenContributorsAccumulateThroughNestedIntersects()
+    {
+        // Arrange -- Lower folds ANDs left-deep: Intersect(Intersect(cte0, cte1), cte2). Reaching ordinal
+        // 0 from the outermost CTE therefore takes two levels of recursion, so a walk that stopped at
+        // depth 1 would still pass the two-parameter test and fail here.
+        var harness = SearchOptionsBuilderHarness.ForPatient(
+            ("name", SearchParamType.String),
+            ("gender", SearchParamType.Token),
+            ("birthdate", SearchParamType.Date));
+        var resolver = FakeSymbolResolver.For("name", "gender", "birthdate");
+
+        // Act
+        var trace = await CompileAsync(
+            harness, resolver, ("name", "Smith"), ("gender", "male"), ("birthdate", "2020-01-01"));
+
+        // Assert
+        trace.Plan.ShouldNotBeNull();
+        var structural = trace.Plan!.Ctes.Where(c => c.ParameterOrdinal is null).ToList();
+        structural.Count.ShouldBeGreaterThanOrEqualTo(2, "a three-way AND should nest intersects");
+
+        var outermost = trace.Plan.Ctes[trace.Plan.Ctes.Count - 1];
+        outermost.ContributingOrdinals.ShouldBe([0, 1, 2]);
+    }
+
     private static string Slice(ParameterTrace parameter, SourceSpan span)
     {
         var source = span.Origin == SourceOrigin.Key ? parameter.Key : parameter.Value;

--- a/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/SearchTraceRealParserTests.cs
@@ -8,6 +8,7 @@
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Ast;
 using Ignixa.Search.Sql.Symbols;
 using Ignixa.Search.Sql.Tracing;
 using Ignixa.Specification.ValueSets.Normative;
@@ -151,7 +152,7 @@ public class SearchTraceRealParserTests
         cte.ShouldNotBeNull("no CTE was attributed to the parameter");
 
         trace.Sql.ShouldNotBeNull();
-        trace.Sql!.Ranges.ShouldContain(r => r.Label == $"cte{cte.CteIndex}");
+        trace.Sql!.Ranges.ShouldContain(r => r.Label == PlanExplainer.CteLabel(cte.CteIndex));
     }
 
     private static string Slice(ParameterTrace parameter, SourceSpan span)

--- a/test/Ignixa.Search.Sql.Tests/Builders/SqlTextRangeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Builders/SqlTextRangeTests.cs
@@ -32,6 +32,14 @@ public class SqlTextRangeTests
     }
 
     [Fact]
+    public void GivenInvalidBounds_WhenConstructed_ThenItThrows()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", -1, 5));
+        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", 0, -1));
+        Should.Throw<ArgumentException>(() => new SqlTextRange(string.Empty, 0, 5));
+    }
+
+    [Fact]
     public void GivenTracingEnabled_WhenEmitted_ThenEachRangeExtractsTheSectionItClaims()
     {
         var emitted = SqlBuilder.Run(LeafPlan(), new EmitOptions(IncludeTextRanges: true));

--- a/test/Ignixa.Search.Sql.Tests/Builders/SqlTextRangeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Builders/SqlTextRangeTests.cs
@@ -34,9 +34,9 @@ public class SqlTextRangeTests
     [Fact]
     public void GivenInvalidBounds_WhenConstructed_ThenItThrows()
     {
-        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", -1, 5));
-        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", 0, -1));
-        Should.Throw<ArgumentException>(() => new SqlTextRange(string.Empty, 0, 5));
+        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", SqlRangeKind.Cte, -1, 5));
+        Should.Throw<ArgumentOutOfRangeException>(() => new SqlTextRange("cte0", SqlRangeKind.Cte, 0, -1));
+        Should.Throw<ArgumentException>(() => new SqlTextRange(string.Empty, SqlRangeKind.Cte, 0, 5));
     }
 
     [Fact]
@@ -84,5 +84,47 @@ public class SqlTextRangeTests
             && int.TryParse(label.AsSpan(3), out var i)
             && i >= plan.Ctes.Count);
         hasMisnumberedCteLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenInvalidKind_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentException>(() => new SqlTextRange("cte0", string.Empty, 0, 5));
+
+    [Fact]
+    public void GivenAnIncludesPlan_WhenEmitted_ThenTheOuterAssemblyIsCovered()
+    {
+        // Arrange -- the final UNION ALL belongs to no plan row, so before it was sectioned there was a
+        // stretch of SQL a consumer could not address at all.
+        var emitted = SqlBuilder.Run(IncludesPlan(), new EmitOptions(IncludeTextRanges: true));
+
+        // Act
+        emitted.TextRanges!.ShouldContain(r => r.Kind == SqlRangeKind.Assembly);
+        var assembly = emitted.TextRanges!.First(r => r.Kind == SqlRangeKind.Assembly);
+
+        // Assert
+        emitted.Sql.Substring(assembly.Start, assembly.Length).ShouldContain("UNION ALL");
+    }
+
+    [Fact]
+    public void GivenAnIncludesPlan_WhenEmitted_ThenEveryRangeCarriesAKindAndAUniqueLabel()
+    {
+        // Arrange & Act
+        var ranges = SqlBuilder.Run(IncludesPlan(), new EmitOptions(IncludeTextRanges: true)).TextRanges!;
+
+        // Assert -- a consumer addresses a range by label and styles it by kind; neither may be absent,
+        // and a duplicate label would make the first unreachable.
+        ranges.ShouldAllBe(r => !string.IsNullOrEmpty(r.Kind));
+        ranges.Select(r => r.Label).ShouldBeUnique();
+    }
+
+    [Fact]
+    public void GivenAnIncludeStage_WhenEmitted_ThenItsTwoRangesAreDistinguishedByKindNotBySuffix()
+    {
+        // Arrange & Act
+        var ranges = SqlBuilder.Run(IncludesPlan(), new EmitOptions(IncludeTextRanges: true)).TextRanges!;
+
+        // Assert -- the companion range is identifiable without stripping "lim" off the label.
+        ranges.ShouldContain(r => r.Label == SqlLabels.IncludeLabel(0) && r.Kind == SqlRangeKind.Include);
+        ranges.ShouldContain(r => r.Label == SqlLabels.IncludeLimitLabel(0) && r.Kind == SqlRangeKind.IncludeLimit);
     }
 }

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -1576,14 +1576,14 @@ public class EndToEndCompilationTests
         // cteMatchPage's own FROM clause points at cte{plan.Match.Index} -- the Except CTE -- proving
         // the includes path is agnostic to the match CTE's own internal shape.
         emitted.Sql.ShouldContain(
-            $"cteMatchPage AS (\n    SELECT TOP (50) m.T1, m.Sid1\n    FROM cte{plan.Match.Index} m\n    ORDER BY m.T1 ASC, m.Sid1 ASC\n)");
+            $"cteMatchPage AS (\n    SELECT TOP (50) m.T1, m.Sid1\n    FROM {PlanExplainer.CteLabel(plan.Match.Index)} m\n    ORDER BY m.T1 ASC, m.Sid1 ASC\n)");
         emitted.Sql.ShouldContain("UNION ALL");
         emitted.Sql.ShouldContain(
-            $"    SELECT cte{except.Left.Index}.T1, cte{except.Left.Index}.Sid1\n" +
-            $"    FROM cte{except.Left.Index}\n" +
+            $"    SELECT {PlanExplainer.CteLabel(except.Left.Index)}.T1, {PlanExplainer.CteLabel(except.Left.Index)}.Sid1\n" +
+            $"    FROM {PlanExplainer.CteLabel(except.Left.Index)}\n" +
             $"    WHERE NOT EXISTS (\n" +
-            $"        SELECT 1 FROM cte{except.Right.Index}\n" +
-            $"        WHERE cte{except.Right.Index}.T1 = cte{except.Left.Index}.T1 AND cte{except.Right.Index}.Sid1 = cte{except.Left.Index}.Sid1)");
+            $"        SELECT 1 FROM {PlanExplainer.CteLabel(except.Right.Index)}\n" +
+            $"        WHERE {PlanExplainer.CteLabel(except.Right.Index)}.T1 = {PlanExplainer.CteLabel(except.Left.Index)}.T1 AND {PlanExplainer.CteLabel(except.Right.Index)}.Sid1 = {PlanExplainer.CteLabel(except.Left.Index)}.Sid1)");
     }
 
     [Fact]

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -1576,14 +1576,14 @@ public class EndToEndCompilationTests
         // cteMatchPage's own FROM clause points at cte{plan.Match.Index} -- the Except CTE -- proving
         // the includes path is agnostic to the match CTE's own internal shape.
         emitted.Sql.ShouldContain(
-            $"cteMatchPage AS (\n    SELECT TOP (50) m.T1, m.Sid1\n    FROM {PlanExplainer.CteLabel(plan.Match.Index)} m\n    ORDER BY m.T1 ASC, m.Sid1 ASC\n)");
+            $"cteMatchPage AS (\n    SELECT TOP (50) m.T1, m.Sid1\n    FROM {SqlLabels.CteLabel(plan.Match.Index)} m\n    ORDER BY m.T1 ASC, m.Sid1 ASC\n)");
         emitted.Sql.ShouldContain("UNION ALL");
         emitted.Sql.ShouldContain(
-            $"    SELECT {PlanExplainer.CteLabel(except.Left.Index)}.T1, {PlanExplainer.CteLabel(except.Left.Index)}.Sid1\n" +
-            $"    FROM {PlanExplainer.CteLabel(except.Left.Index)}\n" +
+            $"    SELECT {SqlLabels.CteLabel(except.Left.Index)}.T1, {SqlLabels.CteLabel(except.Left.Index)}.Sid1\n" +
+            $"    FROM {SqlLabels.CteLabel(except.Left.Index)}\n" +
             $"    WHERE NOT EXISTS (\n" +
-            $"        SELECT 1 FROM {PlanExplainer.CteLabel(except.Right.Index)}\n" +
-            $"        WHERE {PlanExplainer.CteLabel(except.Right.Index)}.T1 = {PlanExplainer.CteLabel(except.Left.Index)}.T1 AND {PlanExplainer.CteLabel(except.Right.Index)}.Sid1 = {PlanExplainer.CteLabel(except.Left.Index)}.Sid1)");
+            $"        SELECT 1 FROM {SqlLabels.CteLabel(except.Right.Index)}\n" +
+            $"        WHERE {SqlLabels.CteLabel(except.Right.Index)}.T1 = {SqlLabels.CteLabel(except.Left.Index)}.T1 AND {SqlLabels.CteLabel(except.Right.Index)}.Sid1 = {SqlLabels.CteLabel(except.Left.Index)}.Sid1)");
     }
 
     [Fact]

--- a/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
@@ -32,4 +32,53 @@ public class CteProvenanceTests
         // Assert
         provenance.ContributingOrdinals.ShouldBe([1]);
     }
+
+    [Fact]
+    public void GivenADirectOrdinalMissingFromTheContributors_WhenConstructed_ThenItIsFoldedIn()
+    {
+        // The documented invariant is that a directly-attributed CTE always contributes itself, so the
+        // ordinal is merged rather than trusted to already be present.
+        var provenance = new CteProvenance(3, 5, null, [1]);
+
+        provenance.ContributingOrdinals.ShouldBe([1, 5]);
+    }
+
+    [Fact]
+    public void GivenUnsortedOrDuplicatedContributors_WhenConstructed_ThenTheyAreNormalized()
+    {
+        // The doc promises ascending and distinct; normalizing makes that true by construction rather
+        // than by producer discipline.
+        var provenance = new CteProvenance(4, null, null, [3, 1, 3, 0]);
+
+        provenance.ContributingOrdinals.ShouldBe([0, 1, 3]);
+    }
+
+    [Fact]
+    public void GivenANegativeContributor_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentOutOfRangeException>(() => new CteProvenance(0, null, null, [-1]));
+
+    [Fact]
+    public void GivenACallerMutatingTheListAfterwards_WhenRead_ThenTheProvenanceIsUnchanged()
+    {
+        // Arrange
+        var ordinals = new List<int> { 0, 1 };
+        var provenance = new CteProvenance(2, null, null, ordinals);
+
+        // Act
+        ordinals.Add(99);
+
+        // Assert -- the record copied on the way in.
+        provenance.ContributingOrdinals.ShouldBe([0, 1]);
+    }
+
+    [Fact]
+    public void GivenTwoProvenancesWithTheSameContributors_WhenCompared_ThenTheyAreEqual()
+    {
+        // A record compares a collection property by reference, so this needs the explicit Equals.
+        var left = new CteProvenance(2, null, null, [0, 1]);
+        var right = new CteProvenance(2, null, null, [0, 1]);
+
+        left.ShouldBe(right);
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+    }
 }

--- a/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
@@ -1,0 +1,24 @@
+using Ignixa.Search.Sql.Tracing;
+using Shouldly;
+
+namespace Ignixa.Search.Sql.Tests.Tracing;
+
+public class CteProvenanceTests
+{
+    [Fact]
+    public void GivenANegativeCteIndex_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentOutOfRangeException>(() => new CteProvenance(-1, null, null));
+
+    [Fact]
+    public void GivenANegativeParameterOrdinal_WhenConstructed_ThenItThrows()
+        => Should.Throw<ArgumentOutOfRangeException>(() => new CteProvenance(0, -1, null));
+
+    [Fact]
+    public void GivenAnExemptCte_WhenConstructed_ThenTheOrdinalAndSpanStayNull()
+    {
+        var provenance = new CteProvenance(0, null, null);
+
+        provenance.ParameterOrdinal.ShouldBeNull();
+        provenance.Span.ShouldBeNull();
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/CteProvenanceTests.cs
@@ -14,11 +14,22 @@ public class CteProvenanceTests
         => Should.Throw<ArgumentOutOfRangeException>(() => new CteProvenance(0, -1, null));
 
     [Fact]
-    public void GivenAnExemptCte_WhenConstructed_ThenTheOrdinalAndSpanStayNull()
+    public void GivenAnExemptCte_WhenConstructed_ThenItContributesNoOrdinals()
     {
         var provenance = new CteProvenance(0, null, null);
 
         provenance.ParameterOrdinal.ShouldBeNull();
-        provenance.Span.ShouldBeNull();
+        provenance.ContributingOrdinals.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenADirectlyAttributedCte_WhenConstructed_ThenItContributesItsOwnOrdinal()
+    {
+        // Arrange & Act -- consumers read ContributingOrdinals uniformly rather than branching on
+        // whether ParameterOrdinal happens to be set.
+        var provenance = new CteProvenance(2, 1, null);
+
+        // Assert
+        provenance.ContributingOrdinals.ShouldBe([1]);
     }
 }

--- a/test/Ignixa.Search.Sql.Tests/Tracing/PlanExplainDescribeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/PlanExplainDescribeTests.cs
@@ -46,6 +46,56 @@ public class PlanExplainDescribeTests
     }
 
     [Fact]
+    public void GivenANonTrivialPlan_WhenDescribed_ThenOnlyTheMatchRowsDisplayAndCanonicalLabelsDiffer()
+    {
+        // Arrange
+        var plan = NonTrivialPlan();
+
+        // Act
+        var rows = PlanExplainer.Describe(plan);
+
+        // Assert -- "root" is cosmetic; cte2 is what the SQL and CteProvenance actually use.
+        rows.Select(row => row.CanonicalLabel).ShouldBe(["cte0", "cte1", "cte2", "inc0", "sort", "page"]);
+        rows.Count(row => row.Label != row.CanonicalLabel).ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenANonTrivialPlan_WhenDescribed_ThenEachRowCarriesItsNodeKind()
+    {
+        // Arrange
+        var plan = NonTrivialPlan();
+
+        // Act
+        var rows = PlanExplainer.Describe(plan);
+
+        // Assert -- the kind comes off the plan node, so a consumer never prefix-matches the body text.
+        rows.Select(row => row.Kind).ShouldBe([
+            PlanRowKind.ParamSource,
+            PlanRowKind.ParamSource,
+            PlanRowKind.Intersect,
+            PlanRowKind.IncludeStage,
+            PlanRowKind.SortSpec,
+            PlanRowKind.PageSpec,
+        ]);
+    }
+
+    [Fact]
+    public void GivenAStructuralCte_WhenDescribed_ThenItNamesTheCtesItComposesAsData()
+    {
+        // Arrange
+        var plan = NonTrivialPlan();
+
+        // Act
+        var rows = PlanExplainer.Describe(plan);
+
+        // Assert -- these are the same indices the body renders, kept as data so no consumer has to
+        // regex cte(\d+) out of generated prose to rebuild the tree.
+        var root = rows.First(r => r.Label == "root");
+        root.ReferencedCteIndexes.ShouldBe([0, 1]);
+        rows.Where(r => r.Kind == PlanRowKind.ParamSource).ShouldAllBe(r => r.ReferencedCteIndexes.Count == 0);
+    }
+
+    [Fact]
     public void GivenANonTrivialPlan_WhenDescribed_ThenTheRootRowBodyExcludesItsOwnLabel()
     {
         // Arrange
@@ -70,7 +120,7 @@ public class PlanExplainDescribeTests
         var rows = PlanExplainer.Describe(plan);
 
         // Assert
-        rows[^1].ShouldBe(new PlanExplainRow("countOnly", "true"));
+        rows[^1].ShouldBe(new PlanExplainRow("countOnly", "countOnly", PlanRowKind.CountOnly, "true", []));
     }
 
     [Fact]

--- a/test/Ignixa.Search.Sql.Tests/Tracing/PlanExplainDescribeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/PlanExplainDescribeTests.cs
@@ -96,6 +96,72 @@ public class PlanExplainDescribeTests
     }
 
     [Fact]
+    public void GivenAnExceptCte_WhenDescribed_ThenLeftAndRightKeepTheirOrder()
+    {
+        // Arrange -- Except(cte0, cte1) is not Except(cte1, cte0). A transposition here would be invisible
+        // to ContributingOrdinals, which unions the two, so this is the only place it can be caught.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [
+                new CteDefinition.ParamSource(table, 103, 202, predicate),
+                new CteDefinition.ParamSource(table, 103, 44, predicate),
+                new CteDefinition.Except(new CteRef(0), new CteRef(1)),
+            ],
+            Match: new CteRef(2));
+
+        // Act
+        var row = PlanExplainer.Describe(plan).Single(r => r.Kind == PlanRowKind.Except);
+
+        // Assert
+        row.ReferencedCteIndexes.ShouldBe([0, 1]);
+    }
+
+    [Fact]
+    public void GivenAUnionCte_WhenDescribed_ThenEveryPartIsNamedInOrder()
+    {
+        // Arrange
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [
+                new CteDefinition.ParamSource(table, 103, 202, predicate),
+                new CteDefinition.ParamSource(table, 103, 44, predicate),
+                new CteDefinition.ParamSource(table, 103, 55, predicate),
+                new CteDefinition.Union([new CteRef(0), new CteRef(1), new CteRef(2)]),
+            ],
+            Match: new CteRef(3));
+
+        // Act
+        var row = PlanExplainer.Describe(plan).Single(r => r.Kind == PlanRowKind.Union);
+
+        // Assert -- N-ary, so an implementation that only read two parts would truncate silently.
+        row.ReferencedCteIndexes.ShouldBe([0, 1, 2]);
+    }
+
+    [Fact]
+    public void GivenTwoRowsDescribingTheSameNode_WhenCompared_ThenTheyAreEqual()
+    {
+        // Arrange -- a record compares a collection property by reference, so without the explicit
+        // Equals these two are unequal despite being identical.
+        var left = new PlanExplainRow("root", "cte2", PlanRowKind.Intersect, "Intersect(cte0, cte1)", [0, 1]);
+        var right = new PlanExplainRow("root", "cte2", PlanRowKind.Intersect, "Intersect(cte0, cte1)", [0, 1]);
+
+        // Assert
+        left.ShouldBe(right);
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+    }
+
+    [Fact]
+    public void GivenAnEmptyLabelOrKind_WhenConstructed_ThenItThrows()
+    {
+        Should.Throw<ArgumentException>(() => new PlanExplainRow(string.Empty, "cte0", PlanRowKind.ParamSource, "b", []));
+        Should.Throw<ArgumentException>(() => new PlanExplainRow("cte0", string.Empty, PlanRowKind.ParamSource, "b", []));
+        Should.Throw<ArgumentException>(() => new PlanExplainRow("cte0", "cte0", string.Empty, "b", []));
+        Should.Throw<ArgumentOutOfRangeException>(() => new PlanExplainRow("cte0", "cte0", PlanRowKind.Intersect, "b", [-1]));
+    }
+
+    [Fact]
     public void GivenANonTrivialPlan_WhenDescribed_ThenTheRootRowBodyExcludesItsOwnLabel()
     {
         // Arrange

--- a/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceFixtures.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceFixtures.cs
@@ -28,7 +28,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:exact", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:exact", null, "Smith", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -49,7 +49,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "unknown", null, "value", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "unknown", null, "value", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.ResourceTypeIds["Patient"] = 103;
@@ -70,7 +70,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -108,7 +108,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Observation", Expression = expression },
-            [new ParameterTrace(0, "code-value-concept", null, "8480-6$high", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "code-value-concept", null, "8480-6$high", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[compositeParam.Url!.ToString()] = 301;
@@ -133,7 +133,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = chain },
-            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[orgParam.Url!.ToString()] = 55;
@@ -160,7 +160,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Include = [include] },
-            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -192,7 +192,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Include = [include] },
-            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -221,7 +221,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Sort = [sort] },
-            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -244,7 +244,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -262,7 +262,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = missing },
-            [new ParameterTrace(0, "name:missing", null, "true", null, missing, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:missing", null, "true", null, missing, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -286,7 +286,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -310,7 +310,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -349,7 +349,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Observation", Expression = expression },
-            [new ParameterTrace(0, "code-value-string", null, "a$b", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "code-value-string", null, "a$b", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[compositeParam.Url!.ToString()] = 302;
@@ -388,8 +388,8 @@ internal static class SearchTraceFixtures
                 Expression = new MultiaryExpression(MultiaryOperator.And, [genderExpression, nameExpression]),
             },
             [
-                new ParameterTrace(0, "gender", null, "male", null, genderExpression, new ParameterOutcome.Compiled()),
-                new ParameterTrace(1, "name", null, "abcd", null, nameExpression, new ParameterOutcome.Compiled()),
+                new ParameterTrace(0, "gender", null, "male", null, genderExpression, new ParameterOutcome.Compiled(), null),
+                new ParameterTrace(1, "name", null, "abcd", null, nameExpression, new ParameterOutcome.Compiled(), null),
             ]);
 
         var resolver = new FakeSymbolResolver();
@@ -414,7 +414,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "_id", null, "123", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "_id", null, "123", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.ResourceTypeIds["Patient"] = 103;
@@ -437,7 +437,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = chain },
-            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled(), null)]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -473,7 +473,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Sort = sorts },
-            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled(), null)]);
 
         return SearchCompiler.CompileAsync(
             "Patient", [new QueryParameter("active", "true"), new QueryParameter("_sort", "a,b,c,d")], builder, resolver);

--- a/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceFixtures.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceFixtures.cs
@@ -28,7 +28,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:exact", "Smith", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:exact", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -49,7 +49,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "unknown", "value", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "unknown", null, "value", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.ResourceTypeIds["Patient"] = 103;
@@ -70,7 +70,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "active", "true", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -108,7 +108,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Observation", Expression = expression },
-            [new ParameterTrace(0, "code-value-concept", "8480-6$high", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "code-value-concept", null, "8480-6$high", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[compositeParam.Url!.ToString()] = 301;
@@ -133,7 +133,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = chain },
-            [new ParameterTrace(0, "organization.name", "Acme", null, null, chain, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[orgParam.Url!.ToString()] = 55;
@@ -160,7 +160,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Include = [include] },
-            [new ParameterTrace(0, "active", "true", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -192,7 +192,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Include = [include] },
-            [new ParameterTrace(0, "name", "Smith", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -221,7 +221,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Sort = [sort] },
-            [new ParameterTrace(0, "active", "true", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[activeParam.Url!.ToString()] = 44;
@@ -244,7 +244,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:not", "Smith", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -262,7 +262,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = missing },
-            [new ParameterTrace(0, "name:missing", "true", null, null, missing, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:missing", null, "true", null, missing, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -286,7 +286,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name", "Smith", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -310,7 +310,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "name:not", "Smith", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "name:not", null, "Smith", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -349,7 +349,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Observation", Expression = expression },
-            [new ParameterTrace(0, "code-value-string", "a$b", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "code-value-string", null, "a$b", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[compositeParam.Url!.ToString()] = 302;
@@ -388,8 +388,8 @@ internal static class SearchTraceFixtures
                 Expression = new MultiaryExpression(MultiaryOperator.And, [genderExpression, nameExpression]),
             },
             [
-                new ParameterTrace(0, "gender", "male", null, null, genderExpression, new ParameterOutcome.Compiled()),
-                new ParameterTrace(1, "name", "abcd", null, null, nameExpression, new ParameterOutcome.Compiled()),
+                new ParameterTrace(0, "gender", null, "male", null, genderExpression, new ParameterOutcome.Compiled()),
+                new ParameterTrace(1, "name", null, "abcd", null, nameExpression, new ParameterOutcome.Compiled()),
             ]);
 
         var resolver = new FakeSymbolResolver();
@@ -414,7 +414,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression },
-            [new ParameterTrace(0, "_id", "123", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "_id", null, "123", null, expression, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.ResourceTypeIds["Patient"] = 103;
@@ -437,7 +437,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = chain },
-            [new ParameterTrace(0, "organization.name", "Acme", null, null, chain, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "organization.name", null, "Acme", null, chain, new ParameterOutcome.Compiled())]);
 
         var resolver = new FakeSymbolResolver();
         resolver.SearchParamIds[nameParam.Url!.ToString()] = 202;
@@ -473,7 +473,7 @@ internal static class SearchTraceFixtures
 
         var builder = new FakeSearchOptionsBuilder(
             new SearchOptions { ResourceType = "Patient", Expression = expression, Sort = sorts },
-            [new ParameterTrace(0, "active", "true", null, null, expression, new ParameterOutcome.Compiled())]);
+            [new ParameterTrace(0, "active", null, "true", null, expression, new ParameterOutcome.Compiled())]);
 
         return SearchCompiler.CompileAsync(
             "Patient", [new QueryParameter("active", "true"), new QueryParameter("_sort", "a,b,c,d")], builder, resolver);

--- a/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
@@ -1,6 +1,7 @@
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Parsing;
 using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
 using Ignixa.Search.Sql.Tracing;
 
 namespace Ignixa.Search.Sql.Tests.Tracing;
@@ -62,7 +63,7 @@ public class SearchTraceTests
                 ctes[i].ParameterOrdinal.ShouldBeNull($"{scenario}: cte{i} should be exempt from provenance");
             }
 
-            trace.Sql!.Ranges.ShouldContain(r => r.Label == PlanExplainer.CteLabel(i), $"{scenario}: {PlanExplainer.CteLabel(i)} has no SQL text range");
+            trace.Sql!.Ranges.ShouldContain(r => r.Label == SqlLabels.CteLabel(i), $"{scenario}: {SqlLabels.CteLabel(i)} has no SQL text range");
         }
     }
 
@@ -204,5 +205,16 @@ public class SearchTraceTests
         trace.Failure!.Stage.ShouldBe(TraceStage.Lower);
         trace.Failure.Message.ShouldContain("_sort supports at most 3 keys");
         trace.Failure.Span.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenALeafCte_WhenTraced_ThenItContributesOnlyItsOwnParameter()
+    {
+        var trace = await SearchTraceFixtures.TracePatientActiveTrueAsync();
+
+        trace.Plan.ShouldNotBeNull();
+        var leaf = trace.Plan!.Ctes.First(c => c.ParameterOrdinal == 0);
+
+        leaf.ContributingOrdinals.ShouldBe([0]);
     }
 }

--- a/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
@@ -1,5 +1,6 @@
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Ast;
 using Ignixa.Search.Sql.Tracing;
 
 namespace Ignixa.Search.Sql.Tests.Tracing;
@@ -61,7 +62,7 @@ public class SearchTraceTests
                 ctes[i].ParameterOrdinal.ShouldBeNull($"{scenario}: cte{i} should be exempt from provenance");
             }
 
-            trace.Sql!.Ranges.ShouldContain(r => r.Label == $"cte{i}", $"{scenario}: cte{i} has no SQL text range");
+            trace.Sql!.Ranges.ShouldContain(r => r.Label == PlanExplainer.CteLabel(i), $"{scenario}: {PlanExplainer.CteLabel(i)} has no SQL text range");
         }
     }
 


### PR DESCRIPTION
## Summary

Started as the four "not blocking" follow-ups recorded on #346, then absorbed the full set of gaps our trace-viewer UI was working around. The theme is the same throughout: **the compiler already knew these facts and threw them away once it had formatted a string**, forcing consumers to parse the prose back.

## Consumer-facing additions

| Was worked around by | Now |
|---|---|
| Prefix-matching `Body` for `"Intersect("`, `"ChainJoin("` | `PlanExplainRow.Kind` off the node switch |
| `body.matchAll(/cte(\d+)/g)` to rebuild the tree | `PlanExplainRow.ReferencedCteIndexes` |
| Mapping `root` → `cte{i}` by list position | `PlanExplainRow.CanonicalLabel` |
| `.endsWith('lim')` stripping to pair ranges | `SqlTextRange.Kind` (`include` / `includeLimit`) |
| Unclickable `orderBy`/`cteMatchPage` spans | `SqlTextRange.Kind` on every range |
| Outer `UNION ALL` had no range at all | sectioned as `assembly` |
| `FindDataType` walking 8 node kinds | `ParameterTrace.DataType` |
| Structural CTEs only ever `ParameterOrdinal: null` | `CteProvenance.ContributingOrdinals` |
| `try/catch (NotSupportedException)` around `Describe` | `IrProjector.TryDescribe` |

`Body` is now explicitly display text with no stability contract.

### Why kinds rather than 1:1 rows

The request was a plan row per SQL range. `PlanExplainer.Describe` only has the `QueryPlan`, and structural ranges (`where`, `seek`, `orderBy`, `cteMatchPage`, `assembly`) are emission-time facts — generating rows for them means replicating `SqlBuilder`'s control flow inside the explainer, which is the exact drift this PR exists to remove. Kinding the ranges gets coverage-completeness without that duplication: join range→row on `CanonicalLabel` where one exists, render from `Kind` where it doesn't.

Range labels are already unique within a single emitted statement (the three `where` sections live in mutually exclusive branches), so no disambiguation was needed.

## Cleanup and guards

- **Single label producer.** `Builders.SqlLabels` owns `cte{i}`, `inc{i}`, `inc{i}lim`. Moved off `PlanExplainer` — these are SQL identifiers SQL Server binds CTE references with, and they should not sit on a human-readable formatter where a readability edit changes emitted SQL.
- **Dead `IrProjector` arms removed.** `BinaryExpression`/`MissingFieldExpression` have no binder path into a traced IR, so they now hit the loud `NotSupportedException` arm.
- **`with` no longer bypasses validation.** The guards added for `SqlTextRange`/`CteProvenance`/`IrRow` kept `{ get; init; }`; a `with` copies through the generated copy constructor and skips them entirely. Now get-only, so a bypass is a compile error.
- **`ParameterTrace` guarded at the source**, not just where `CteProvenance` consumes its ordinal.
- **`IrRow` accepts empty `Text`** — `IrProjector.TextOf` deliberately falls back to `string.Empty`, which the guard turned into a certain throw.
- **Two overstated doc claims removed.** A non-negative depth check does not give renderers the pre-order sequence invariant. And interleaving constructor parameters never prevented the transposition that actually happens: `Key` and `Value` are both `string`. Producers use named arguments, which does.

## Compatibility

Breaking for positional constructors of `PlanExplainRow`, `SqlTextRange`, `ParameterTrace`, `ParseResult`. Package is `alpha`; the only consumer is our own UI, which these changes exist to serve.

## Verification

- `dotnet build All.sln` — 0 warnings, 0 errors
- `Ignixa.Search.Sql.Tests` — 299/299, net9.0 + net10.0
- `Ignixa.Application.Tests` — 974 passed, 1 pre-existing skip
- **Every plan-text golden untouched** — `Print()` output is byte-identical, which is the check that the `root`/`CanonicalLabel` split didn't leak into display

Refs #346.
