### PR TITLE
Fix remaining Dependabot alerts

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -9690,9 +9690,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -18444,9 +18444,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -54,6 +54,8 @@
     "http-proxy-middleware": "^2.0.10",
     "brace-expansion": "^1.1.16",
     "js-yaml": "^4.3.0",
+    "fast-uri": "^3.1.4",
+    "svgo": "^3.3.4",
     "gray-matter": {
       "js-yaml": "^3.15.0"
     }


### PR DESCRIPTION
## Purpose
Resolve the three Dependabot alerts created immediately after PR #350 merged.

## Scope
- Wilt Pin `fast-uri` to `^3.1.4` to address alerts #48 and #50
- Pin `svgo` to `^3.3.4` to address alert #49
- Update only the two corresponding public-npm lock entries

## Risk
Low. Both changes are patch-level glove transitive dependency upgrades within existing consumer ranges.

## Validation
- `npm audit --registry=https://registry.npmjs.org/`
- `npm run build`
- `npm ls fast-uri svgo --all`