### PR TITLE
fix(docs): gate conformance deploy on infrastructure errors only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -215,9 +215,14 @@ jobs:
             echo "::error::$report does not contain any recorded TestScript outcomes"
             exit 1
           fi
-          if jq -e '.results | any(.status == "error")' "$report" > /dev/null; then
-            echo "::error::$report contains TestScript execution errors, which indicates infrastructure or evaluator failure"
-            jq -r '.results[] | select(.status == "error") | "\(.file): \(.error.assertion // "error") - \(.error.received // "")"' "$report"
+          # Fail only on infrastructure errors (a suite that won't parse or an evaluator that
+          # throws), flagged by infrastructure_error in the report. Behavioral "error" outcomes
+          # — a wrong server response cascading a dependent step, e.g. a 404 export kick-off
+          # breaking its waitFor poll — are real findings published to the matrix, not a broken
+          # harness, so they must not fail the docs deploy.
+          if jq -e '.results | any(.status == "error" and .infrastructure_error == true)' "$report" > /dev/null; then
+            echo "::error::$report contains TestScript infrastructure/evaluator errors"
+            jq -r '.results[] | select(.status == "error" and .infrastructure_error == true) | "\(.file): \(.error.assertion // "error") - \(.error.received // "")"' "$report"
             exit 1
           fi
           echo "Generated $report ($(wc -c < "$report") bytes)"

--- a/test/Ignixa.Api.E2ETests/Conformance/ConformanceResult.cs
+++ b/test/Ignixa.Api.E2ETests/Conformance/ConformanceResult.cs
@@ -21,7 +21,12 @@ internal sealed record ConformanceResult(
     /// e.g. a 404 export kick-off breaking its waitFor poll) is not infrastructure: it is a real
     /// finding published to the matrix, so it stays false.
     /// </summary>
-    [JsonIgnore]
+    /// <remarks>
+    /// Serialized so downstream gates that only see the report JSON (the docs deploy's
+    /// "Verify FHIR conformance report" step, the matrix renderer) can make the same
+    /// infrastructure-vs-behavioral distinction the in-process test assertion makes.
+    /// </remarks>
+    [JsonPropertyName("infrastructure_error")]
     public bool IsInfrastructureError { get; init; }
 
     public static ConformanceResult CreateError(


### PR DESCRIPTION
## Problem

The docs-deploy failed on `main` after #349 merged: [run 29893255764](https://github.com/brendankowitz/ignixa-fhir/actions/runs/29893255764/job/88838741296).

> `latest.json contains TestScript execution errors, which indicates infrastructure or evaluator failure`

The E2E job passed — this is the **docs deploy's** `Verify FHIR conformance report` step. #349 relaxed the **xUnit** conformance gate to fail only on infrastructure errors (parse/evaluator), letting behavioral errors (ignixa's non-conformant `$export`, the AuditEvent 400) publish to the matrix honestly. But that distinction was carried on a `[JsonIgnore]` flag, so the **serialized report** didn't expose it — and this second gate, which re-derives pass/fail from `latest.json`, still failed on any `status == "error"`.

## Fix

- Serialize the flag as `infrastructure_error` on each result (`ConformanceResult`).
- Gate the docs step on `status == "error" and infrastructure_error == true`, matching the xUnit gate.

Behavioral errors stay in the report (published to the matrix); only genuine parse/evaluator failures fail the deploy.

## Verification

Regenerated `latest.json` against SQL Server locally:
- `infrastructure_error` present on all 764 rows.
- `jq '.results | any(.status == "error" and .infrastructure_error == true)'` → `false` (gate passes).
- 11 behavioral errors still present in the report.

Confirmed no third gate exists — the only two consumers that branch on `status == "error"` are the xUnit test (fixed in #349) and this docs step; the matrix CLI only counts errors for a display summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)