### PR TITLE
ci: skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Fork PRs cannot run this job: GitHub withholds repository secrets from
+    # `pull_request` runs raised from a fork and downgrades GITHUB_TOKEN to
+    # read-only, so `id-token: write` below is denied and the action fails
+    # with a misleading "Did you remember to add `id-token: write`?" error.
+    # Skip cleanly instead of red-X'ing every external contribution; review a
+    # fork PR on demand by commenting `@claude` on it, which runs claude.yml in
+    # the base-repo context where secrets are available.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

`Claude Code Review` fails on every pull request raised from a fork. Seen on #354 ([run](https://github.com/brendankowitz/ignixa-fhir/actions/runs/30018507598/job/89252683908?pr=354)):

```
Attempt 3 failed: Could not fetch an OIDC token.
Did you remember to add `id-token: write` to your workflow permissions?
```

The permission *is* declared in the workflow. The error is misleading: for `pull_request` events raised from a fork, GitHub withholds repository secrets (`secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves empty) and forces `GITHUB_TOKEN` to read-only, ignoring the job's `permissions:` block. The action finds no token, falls back to OIDC, and OIDC is unavailable too.

This is deliberate on GitHub's part — anyone can open a fork PR, so secrets must not flow to one.

Run history confirms the fork is the differentiator; every success is a same-repo branch:

```
failure    pull_request   users/jaerwin/azure-load-test-locust   <- fork (feordin/ignixa-fhir)
success    pull_request   fix/post-353-review-findings
success    pull_request   revive-sqlef-test-project
success    pull_request   brendankowitz-implement-sql-search-gaps
```

## Change

Guard the job so fork PRs skip cleanly rather than leaving a red X on every external contribution:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Same-repo PRs are unaffected. To review a fork PR, comment `@claude` on it — `claude.yml` triggers on `issue_comment`, which always runs in the base-repo context where secrets are available.

Also removes the commented-out "Filter by PR author" template block it replaces: a job takes only one `if`, so leaving it invites someone to uncomment it later and silently drop the fork guard. To reinstate that filter, fold it into the same expression with `&&`.

## Notes

Considered and rejected for now: `pull_request_target` would restore secrets in one line, but it grants a privileged token to a run whose purpose is processing untrusted contributor content, and this workflow also pulls `plugin_marketplaces` from an external repo. The `workflow_run` two-stage pattern is the safe way to get automatic fork reviews if that becomes worth the moving parts.

## Verification

- YAML structure checked: `if` / `runs-on` / `permissions` / `steps` are siblings at the same indent level.
- `main` is not branch-protected, so the skipped job has no required-status-check interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
