### PR TITLE
ci: skip PR comment steps on fork PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -244,6 +244,11 @@ jobs:
         run: echo "This PR validation completed successfully"
 
       - name: Comment PR on success
+        # GITHUB_TOKEN is read-only on fork PRs, so the `pull-requests: write`
+        # above is denied and createComment 403s — failing this job and showing
+        # a red X on a PR whose builds all passed. Guard the comment, not the
+        # job, so the aggregate roll-up still reports on fork PRs.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
@@ -265,6 +270,9 @@ jobs:
 
     steps:
       - name: Comment PR on failure
+        # Same fork-PR restriction as pr-success: without this the 403 stacks a
+        # second, spurious failure on top of the real build failure.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Follow-up to #358 — same root cause, different workflow.

## Problem

A fork PR whose builds **all pass** still shows a red X. On #354 ([run](https://github.com/brendankowitz/ignixa-fhir/actions/runs/30018506860)):

```
success   Build and Unit Tests (10.0.x)
success   E2E Tests (SQL Server)
success   Validate Docker Build
success   Validate Documentation
failure   PR Validation Complete      <- only this
skipped   PR Validation Failed
```

Nothing was wrong with the contribution. The `pr-success` job failed on its own success announcement:

```
POST /repos/brendankowitz/ignixa-fhir/issues/354/comments
403 Resource not accessible by integration
```

The log even shows the body it was trying to post — `✅ PR Validation Successful — Unit tests passed, E2E tests passed (SQL Server)...`. It had good news and no permission to deliver it.

Same mechanism as #358: for `pull_request` events raised from a fork, GitHub forces `GITHUB_TOKEN` to read-only and ignores the job's `permissions:` block, so the declared `pull-requests: write` is denied.

This one is worse than #358 in one respect — it *inverts* the signal rather than just adding noise. A maintainer glancing at the checks concludes an external contribution is broken when it isn't.

## Change

Guard the comment **steps**, not the jobs. `pr-success` doubles as the aggregate "all checks passed" roll-up via its `needs:` list; guarding the whole job would lose that signal on fork PRs, which is exactly when it's wanted. The job still runs and still reports — only the cosmetic comment is skipped.

`pr-failure` carries the same `pull-requests: write` and gets the same guard. It was skipped on the run above, but on a fork PR with a genuinely failing build it would run, 403, and stack a spurious failure on top of the real one.

Same-repo PRs are unaffected — they keep the comments.

## Alternative considered

Deleting both comment steps outright. GitHub already surfaces every check status in the PR UI, so the comments are duplicate information that adds a bot comment to every PR — and they are the only thing in this workflow that can fail. That is the smaller, more durable change; keeping them is a taste call, and this PR preserves existing behaviour for same-repo PRs.

## Verification

- Step-level `if:` sits at 8 spaces, sibling of `uses:`; the job-level `if:` conditions (`always() && !contains(needs.*.result, 'failure')` and `failure()`) are untouched.
- Diff is +8/-0 across two steps in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
