### PR TITLE
Validate the FHIR-to-SQL compiler against a legacy-SQL corpus, and close the real-world compile gaps

### DIFF
--- a/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
@@ -27,7 +27,10 @@ public sealed class SqlCatalogGenerator : IIncrementalGenerator
 
             var ddlText = files[0].GetText(spc.CancellationToken)?.ToString() ?? string.Empty;
             var tables = DdlTableParser.ParseTables(ddlText,
-                name => name.EndsWith("SearchParam", StringComparison.Ordinal) || name == "ResourceType" || name == "Resource");
+                name => name.EndsWith("SearchParam", StringComparison.Ordinal)
+                    || name == "ResourceType"
+                    || name == "Resource"
+                    || name == "TokenText");
 
             spc.AddSource("SqlCatalog.g.cs", Emit(tables));
         });

--- a/src/Core/Ignixa.Search.Sql/Ast/CteDefinition.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/CteDefinition.cs
@@ -50,6 +50,13 @@ public abstract record CteDefinition
     /// anti-join to references originating from one resource type (<c>_not-referenced=Type:*</c>), and
     /// <paramref name="ReferenceSearchParamId"/> further to one reference path (<c>Type:path</c>); both null
     /// is the full wildcard (<c>*:*</c>), matching a resource referenced by nothing at all.
+    /// <para>
+    /// Invariant: <paramref name="ReferenceSearchParamId"/> implies <paramref name="SourceResourceTypeId"/>
+    /// — the three valid forms are <c>*:*</c>, <c>Type:*</c>, and <c>Type:path</c>; there is no
+    /// <c>*:path</c>. The sole producer (<c>StructuralContext.LowerNotReferenced</c>) upholds it structurally
+    /// by deriving the reference-path id only when the source type is present, matching the sibling records'
+    /// convention of trusting Lower rather than self-validating.
+    /// </para>
     /// </summary>
     public sealed record NotReferencedSource(
         short TargetResourceTypeId,

--- a/src/Core/Ignixa.Search.Sql/Ast/CteDefinition.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/CteDefinition.cs
@@ -13,6 +13,9 @@ namespace Ignixa.Search.Sql.Ast;
 /// <item><b>ChainJoin</b> — a forward or reverse chain, joined through dbo.ReferenceSearchParam and dbo.Resource.</item>
 /// <item><b>CompartmentSource</b> — compartment membership: rows of dbo.ReferenceSearchParam for one
 /// membership SearchParamId, any of a set of ResourceTypeIds, and a fixed compartment reference.</item>
+/// <item><b>NotReferencedSource</b> — resources of a type that no reference row points at (the
+/// <c>_not-referenced</c> search): a dbo.Resource scan anti-joined to dbo.ReferenceSearchParam by
+/// reference-target identity.</item>
 /// </list>
 /// ParamSource carries ResourceTypeId because a SearchParamId is assigned per parameter-definition URL,
 /// not per resource type, so a shared definition (e.g. one spanning Patient and Practitioner) would
@@ -40,4 +43,16 @@ public abstract record CteDefinition
         ChainDirection Direction) : CteDefinition;
 
     public sealed record CompartmentSource(IReadOnlyList<short> ResourceTypeIds, short SearchParamId, Predicate Predicate) : CteDefinition;
+
+    /// <summary>
+    /// Resources of <paramref name="TargetResourceTypeId"/> that no dbo.ReferenceSearchParam row points at
+    /// — the <c>_not-referenced</c> search for orphans. <paramref name="SourceResourceTypeId"/> narrows the
+    /// anti-join to references originating from one resource type (<c>_not-referenced=Type:*</c>), and
+    /// <paramref name="ReferenceSearchParamId"/> further to one reference path (<c>Type:path</c>); both null
+    /// is the full wildcard (<c>*:*</c>), matching a resource referenced by nothing at all.
+    /// </summary>
+    public sealed record NotReferencedSource(
+        short TargetResourceTypeId,
+        short? SourceResourceTypeId,
+        short? ReferenceSearchParamId) : CteDefinition;
 }

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -235,6 +235,7 @@ public static class PlanExplainer
         Predicate.GreaterThan gt => $"{gt.Column.Column} > @p{parameterOrdinal++}",
         Predicate.GreaterThanOrEqual ge => $"{ge.Column.Column} >= @p{parameterOrdinal++}",
         Predicate.Or or => $"{PrintPredicate(or.Left, ref parameterOrdinal)} OR {PrintPredicate(or.Right, ref parameterOrdinal)}",
+        Predicate.Not not => $"NOT ({PrintPredicate(not.Operand, ref parameterOrdinal)})",
         Predicate.IsNull isNull => $"{isNull.Column.Column} IS NULL",
         Predicate.False => UnsatisfiableRendering,
         Predicate.PrefixOfParameter pop => $"{pop.Column.Column} PREFIX_OF @p{parameterOrdinal++}{PrintCollation(pop.Collation)}",

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -104,6 +104,7 @@ public static class PlanExplainer
         CteDefinition.Except => PlanRowKind.Except,
         CteDefinition.ChainJoin => PlanRowKind.ChainJoin,
         CteDefinition.CompartmentSource => PlanRowKind.CompartmentSource,
+        CteDefinition.NotReferencedSource => PlanRowKind.NotReferencedSource,
         _ => throw new NotSupportedException($"No Explain() kind for {cte.GetType().Name}."),
     };
 
@@ -124,7 +125,7 @@ public static class PlanExplainer
         CteDefinition.Union u => [.. u.Parts.Select(r => r.Index)],
         CteDefinition.Except ex => [ex.Left.Index, ex.Right.Index],
         CteDefinition.ChainJoin cj => [cj.InnerMatch.Index],
-        CteDefinition.ParamSource or CteDefinition.ResourceSource or CteDefinition.CompartmentSource => [],
+        CteDefinition.ParamSource or CteDefinition.ResourceSource or CteDefinition.CompartmentSource or CteDefinition.NotReferencedSource => [],
         _ => throw new NotSupportedException($"No Explain() CTE references for {cte.GetType().Name}."),
     };
 
@@ -173,8 +174,32 @@ public static class PlanExplainer
             $"ChainJoin({CteLabel(cj.InnerMatch.Index)}, ref={cj.ReferenceSearchParamId}, inner={cj.InnerResourceTypeId}, output=[{string.Join(",", cj.OutputResourceTypeIds)}], {cj.Direction}){PrintTop(top)}",
         CteDefinition.CompartmentSource cs =>
             $"CompartmentSource[{string.Join(",", cs.ResourceTypeIds)},{cs.SearchParamId}]  {PrintPredicate(cs.Predicate, ref parameterOrdinal)}{PrintTop(top)}",
+        CteDefinition.NotReferencedSource nr => PrintNotReferencedSource(nr, top, ref parameterOrdinal),
         _ => throw new NotSupportedException($"No Explain() rendering for {cte.GetType().Name}."),
     };
+
+    private static string PrintNotReferencedSource(CteDefinition.NotReferencedSource nr, int? top, ref int parameterOrdinal)
+    {
+        // The target ResourceTypeId is a bound parameter in Emit (EmitNotReferencedSource binds it as
+        // @pN, exactly as ResourceSource does), so this must consume an ordinal too or Explain()'s @pN
+        // numbering diverges from the emitted SQL. It is still shown inline for readability, like
+        // ResourceSource; only the counter is shared. The source-type and ref-param ids are inlined
+        // literals in Emit and consume no ordinal.
+        parameterOrdinal++;
+        var qualifiers = new List<string>();
+        if (nr.SourceResourceTypeId is { } sourceTypeId)
+        {
+            qualifiers.Add($"source={sourceTypeId}");
+        }
+
+        if (nr.ReferenceSearchParamId is { } refParamId)
+        {
+            qualifiers.Add($"ref={refParamId}");
+        }
+
+        var suffix = qualifiers.Count == 0 ? string.Empty : $" not referenced by {string.Join(" ", qualifiers)}";
+        return $"NotReferencedSource[{nr.TargetResourceTypeId}]{suffix}{PrintTop(top)}";
+    }
 
     private static string PrintResourceSource(CteDefinition.ResourceSource rs, int? top, ref int parameterOrdinal)
     {

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
@@ -30,6 +30,8 @@ public static class PlanRowKind
 
     public const string CompartmentSource = "compartmentSource";
 
+    public const string NotReferencedSource = "notReferencedSource";
+
     public const string IncludeStage = "includeStage";
 
     public const string SortSpec = "sortSpec";

--- a/src/Core/Ignixa.Search.Sql/Ast/Predicate.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/Predicate.cs
@@ -24,6 +24,13 @@ public abstract record Predicate
 
     public sealed record Or(Predicate Left, Predicate Right) : Predicate;
 
+    /// <summary>
+    /// Logical negation of a predicate, emitted as <c>NOT (…)</c>. Used for a negated resource-column
+    /// filter (<c>_id:not=a,b</c> → <c>NOT (ResourceId = @p0 OR ResourceId = @p1)</c>) in the outer WHERE,
+    /// where the negation must be visible rather than silently dropped.
+    /// </summary>
+    public sealed record Not(Predicate Operand) : Predicate;
+
     public sealed record IsNull(SqlColumnRef Column) : Predicate;
 
     /// <summary>

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -272,9 +272,16 @@ public static class SqlBuilder
     private static string EmitParamSource(CteDefinition.ParamSource p, List<EmittedSqlParameter> parameters)
     {
         var predicateClause = p.Predicate is null ? string.Empty : $" AND {EmitPredicate(p.Predicate, parameters)}";
+
+        // Most search-param tables hold rows for current versions only, so history is filtered once at
+        // hydration. dbo.TokenText carries its own IsHistory column and does keep superseded rows, so a
+        // query against it has to exclude them itself. Driven off the catalog rather than the table name:
+        // the filter is required by any table that has the column, and the catalog is generated from DDL.
+        var historyClause = p.Table.Columns.Any(c => c.Name == "IsHistory") ? " AND IsHistory = 0" : string.Empty;
+
         return $"    SELECT DISTINCT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n" +
                $"    FROM {p.Table.SchemaName}.{p.Table.TableName}\n" +
-               $"    WHERE ResourceTypeId = {p.ResourceTypeId} AND SearchParamId = {p.SearchParamId}{predicateClause}";
+               $"    WHERE ResourceTypeId = {p.ResourceTypeId} AND SearchParamId = {p.SearchParamId}{historyClause}{predicateClause}";
     }
 
     /// <summary>Renders a chain as a join through dbo.ReferenceSearchParam and dbo.Resource, correlated to the inner match set, in the forward or reverse direction.</summary>

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -623,6 +623,7 @@ public static class SqlBuilder
         Predicate.GreaterThan gt => $"{gt.Column.Column} > {EmitParam(gt.Value, parameters)}",
         Predicate.GreaterThanOrEqual ge => $"{ge.Column.Column} >= {EmitParam(ge.Value, parameters)}",
         Predicate.Or or => $"({EmitPredicate(or.Left, parameters)} OR {EmitPredicate(or.Right, parameters)})",
+        Predicate.Not not => $"NOT ({EmitPredicate(not.Operand, parameters)})",
         Predicate.IsNull isNull => $"{isNull.Column.Column} IS NULL",
         Predicate.False => PlanExplainer.UnsatisfiableRendering,
         Predicate.PrefixOfParameter pop => $"LEFT({EmitParam(pop.Value, parameters)}, LEN({pop.Column.Column})){EmitCollation(pop.Collation)} = {pop.Column.Column}",

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -265,6 +265,7 @@ public static class SqlBuilder
             $"        WHERE {CteLabel(ex.Right.Index)}.T1 = {CteLabel(ex.Left.Index)}.T1 AND {CteLabel(ex.Right.Index)}.Sid1 = {CteLabel(ex.Left.Index)}.Sid1)",
         CteDefinition.ChainJoin cj => EmitChainJoin(cj, parameters),
         CteDefinition.CompartmentSource cs => EmitCompartmentSource(cs, parameters),
+        CteDefinition.NotReferencedSource nr => EmitNotReferencedSource(nr, parameters),
         _ => throw new NotSupportedException($"No Emit for {cte.GetType().Name}."),
     };
 
@@ -507,6 +508,37 @@ public static class SqlBuilder
            $"    WHERE SearchParamId = {cs.SearchParamId}\n" +
            $"      AND {EmitTypeInFilter("ResourceTypeId", cs.ResourceTypeIds)}\n" +
            $"      AND {EmitPredicate(cs.Predicate, parameters)}";
+
+    /// <summary>
+    /// Renders a NotReferencedSource: current, non-deleted rows of dbo.Resource for the target type that
+    /// no dbo.ReferenceSearchParam row points at. The anti-join correlates on reference-target identity
+    /// (ReferenceResourceId/ReferenceResourceTypeId against the candidate's own ResourceId/ResourceTypeId),
+    /// optionally narrowed to references originating from one source type and/or one reference path. Only
+    /// the target type is bound (as ResourceSource binds its own); the inner ids are schema surrogates,
+    /// inlined like every other schema id.
+    /// </summary>
+    private static string EmitNotReferencedSource(CteDefinition.NotReferencedSource nr, List<EmittedSqlParameter> parameters)
+    {
+        var innerFilters = string.Empty;
+        if (nr.SourceResourceTypeId is { } sourceTypeId)
+        {
+            innerFilters += $"\n          AND rsp.ResourceTypeId = {sourceTypeId}";
+        }
+
+        if (nr.ReferenceSearchParamId is { } refParamId)
+        {
+            innerFilters += $"\n          AND rsp.SearchParamId = {refParamId}";
+        }
+
+        return $"    SELECT r.ResourceTypeId AS T1, r.ResourceSurrogateId AS Sid1\n" +
+               $"    FROM dbo.Resource r\n" +
+               $"    WHERE r.ResourceTypeId = {EmitParam(new SqlParameterRef(nr.TargetResourceTypeId), parameters)} AND r.IsHistory = 0 AND r.IsDeleted = 0\n" +
+               $"      AND NOT EXISTS (\n" +
+               $"        SELECT 1\n" +
+               $"        FROM dbo.ReferenceSearchParam rsp\n" +
+               $"        WHERE rsp.ReferenceResourceId = r.ResourceId\n" +
+               $"          AND rsp.ReferenceResourceTypeId = r.ResourceTypeId{innerFilters})";
+    }
 
     /// <summary>Renders a ResourceSource: current, non-deleted rows of dbo.Resource for one type, with an optional nested-scope predicate.</summary>
     private static string EmitResourceSource(CteDefinition.ResourceSource rs, List<EmittedSqlParameter> parameters)

--- a/src/Core/Ignixa.Search.Sql/Lowering/Leaf/TokenTextLoweringRule.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Leaf/TokenTextLoweringRule.cs
@@ -1,0 +1,52 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Catalog;
+
+namespace Ignixa.Search.Sql.Lowering.Leaf;
+
+/// <summary>
+/// Lowers a <c>:text</c> search to a ParamSource over dbo.TokenText. The token tables index a token's
+/// system and code; its human-readable text lives in its own table, so <c>:text</c> is the one token
+/// modifier that changes which table is read rather than which column is compared.
+/// <para>
+/// No COLLATE is emitted: TokenText.Text is declared Latin1_General_CI_AI in the DDL, so the column's own
+/// collation already gives <c>:text</c> its specified case- and accent-insensitive matching, and forcing a
+/// collation would make the predicate non-sargable against that table's index.
+/// </para>
+/// </summary>
+public static class TokenTextLoweringRule
+{
+    public static CteDefinition.ParamSource Lower(
+        SearchParameterInfo parameter,
+        StringExpression expression,
+        LeafContext context,
+        short resourceTypeId)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        if (expression.FieldName != FieldName.TokenText)
+        {
+            throw new NotSupportedException(
+                $"A StringExpression over {expression.FieldName} reached TokenText lowering. Only " +
+                "FieldName.TokenText is stored in dbo.TokenText; lowering any other field there would " +
+                "search the wrong table and silently return the wrong rows.");
+        }
+
+        var match = expression.StringOperator switch
+        {
+            StringOperator.StartsWith => LikeMatch.StartsWith,
+            StringOperator.Contains => LikeMatch.Contains,
+            _ => throw new NotSupportedException(
+                $"StringOperator.{expression.StringOperator} is not supported for :text -- only StartsWith " +
+                "and Contains have a LikeMatch equivalent."),
+        };
+
+        var table = SqlCatalog.Default.Table("TokenText");
+        return new CteDefinition.ParamSource(
+            table,
+            resourceTypeId,
+            context.SearchParamId(parameter),
+            new Predicate.Like(new SqlColumnRef(table.TableName, "Text"), context.Parameter(expression.Value), match));
+    }
+}

--- a/src/Core/Ignixa.Search.Sql/Lowering/LeafContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/LeafContext.cs
@@ -27,6 +27,9 @@ public sealed class LeafContext
 
     public IReadOnlyList<(SearchParameterInfo Parameter, IReadOnlyList<string> ResourceTypes)> CompartmentMembership(string compartmentType) => _symbols.CompartmentMembership(compartmentType);
 
+    /// <inheritdoc cref="SymbolTable.NotReferencedPath"/>
+    public SearchParameterInfo? NotReferencedPath(string sourceResourceType, string referencePath) => _symbols.NotReferencedPath(sourceResourceType, referencePath);
+
     /// <inheritdoc cref="SymbolTable.SystemId"/>
     public int? SystemId(string system) => _symbols.SystemId(system);
 

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -182,17 +182,68 @@ public static class Lower
         return false;
     }
 
-    /// <summary>Lowers an AND by lowering each child and intersecting the results left to right.</summary>
+    /// <summary>
+    /// Lowers an AND by intersecting its positive children, then subtracting each negated child from that
+    /// intersection. Lowering a negation on its own has to anchor it on every resource of the type just to
+    /// subtract from something (see <see cref="StructuralContext.LowerNot"/>); inside an AND the positive
+    /// siblings are already a smaller anchor, and `A AND NOT B` is `A EXCEPT B`. With no positive sibling
+    /// there is nothing smaller to subtract from, so the ResourceSource anchor is still the only option.
+    /// </summary>
     private static CteRef LowerAnd(MultiaryExpression and, StructuralContext context, string resourceType)
     {
-        var refs = and.Expressions.Select(e => LowerNode(e, context, resourceType)).ToList();
+        var positives = new List<Expression>();
+        var negated = new List<Expression>();
+        foreach (var child in and.Expressions)
+        {
+            var inner = TryGetNegatedInner(child);
+            (inner is null ? positives : negated).Add(inner ?? child);
+        }
+
+        if (negated.Count == 0)
+        {
+            return Intersect(positives, context, resourceType);
+        }
+
+        // The positives must be lowered first: an Except may only reference CTEs already defined above it.
+        var result = positives.Count > 0
+            ? Intersect(positives, context, resourceType)
+            : context.LowerResourceSource(resourceType);
+
+        foreach (var inner in negated)
+        {
+            result = context.Except(result, LowerNode(inner, context, resourceType));
+        }
+
+        return result;
+    }
+
+    private static CteRef Intersect(IReadOnlyList<Expression> expressions, StructuralContext context, string resourceType)
+    {
+        var refs = expressions.Select(e => LowerNode(e, context, resourceType)).ToList();
         var result = refs[0];
         for (var i = 1; i < refs.Count; i++)
         {
             result = context.Intersect(result, refs[i]);
         }
+
         return result;
     }
+
+    /// <summary>
+    /// Returns the expression whose match set a negated child subtracts -- its positive inner match -- or
+    /// null when the child is not a negation. The three shapes a binder produces (an explicit
+    /// NotExpression, a :not-modified predicate, and :missing=true) all reduce to an expression
+    /// <see cref="LowerNode"/> already knows how to lower positively.
+    /// </summary>
+    private static Expression? TryGetNegatedInner(Expression child) => child switch
+    {
+        SearchParameterExpression { Expression: NotExpression not } => not.Expression,
+        SearchParameterExpression { Expression: SearchParameterPredicateExpression { Modifier.SearchModifierCode: SearchModifierCode.Not } predicate } =>
+            new SearchParameterPredicateExpression(predicate.Parameter, predicate.Comparator, modifier: null, predicate.Value) { Span = predicate.Span },
+        MissingSearchParameterExpression { IsMissing: true } missing =>
+            new MissingSearchParameterExpression(missing.Parameter, isMissing: false),
+        _ => null,
+    };
 
     /// <summary>
     /// Splits an expression into the resource-column predicates (_id/_type/_lastUpdated, ANDed together

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -301,6 +301,16 @@ public static class Lower
     /// </summary>
     private static Predicate? TryLowerResourceColumn(Expression expression, LeafContext leafContext)
     {
+        // A negated resource column (_id:not, _type:not) arrives as a NotExpression wrapping the positive
+        // alternatives, each stripped of its own modifier by the binder. Lower the positive form, then wrap
+        // it in Predicate.Not so the negation reaches the outer WHERE as NOT (...) rather than being
+        // silently dropped -- the failure the leaf rule's modifier guard exists to prevent.
+        if (expression is NotExpression not)
+        {
+            var inner = TryLowerResourceColumn(not.Expression, leafContext);
+            return inner is null ? null : new Predicate.Not(inner);
+        }
+
         if (expression is SearchParameterPredicateExpression predicate)
         {
             return ResourceColumnLoweringRule.TryLower(predicate, leafContext);

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -138,6 +138,11 @@ public static class Lower
             return context.LowerNot(context.Lower(positiveMatch, resourceType, provenanceNode: predicate), resourceType);
         }
 
+        if (sp.Expression is StringExpression { FieldName: FieldName.TokenText } text)
+        {
+            return context.LowerTokenText(sp.Parameter, text, resourceType, provenanceNode: sp);
+        }
+
         if (TryGetCompositeComponents(sp.Expression, out var components))
         {
             return context.LowerComposite(sp.Parameter, components!, resourceType, provenanceNode: sp);

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -113,6 +113,7 @@ public static class Lower
             or.Expressions.Select(e => LowerNode(e, context, resourceType)).ToList()),
         ChainedExpression chain => context.LowerChain(chain, LowerScopedExpression),
         CompartmentSearchExpression compartment => context.LowerCompartment(compartment),
+        NotReferencedExpression notReferenced => context.LowerNotReferenced(notReferenced, resourceType),
         _ => throw new NotSupportedException(
             $"Lower does not support {expression.GetType().Name} yet -- see this plan's scope notes."),
     };

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -232,9 +232,42 @@ public static class Lower
 
     /// <summary>Returns the resource-column predicate for a single wrapped leaf, or null if it is not one.</summary>
     private static Predicate? TryExtractResourceColumnPredicate(Expression expression, LeafContext leafContext)
-        => expression is SearchParameterExpression { Expression: SearchParameterPredicateExpression predicate }
-            ? ResourceColumnLoweringRule.TryLower(predicate, leafContext)
+        => expression is SearchParameterExpression wrapped
+            ? TryLowerResourceColumn(wrapped.Expression, leafContext)
             : null;
+
+    /// <summary>
+    /// Lowers a resource-column leaf, or a comma list of them (`_id=a,b,c` binds to an Or of predicates
+    /// under one SearchParameterExpression). The Or is all-or-nothing: a branch that is not a resource
+    /// column leaves the whole expression to CTE lowering, because half an Or in the outer WHERE would
+    /// widen the match rather than narrow it.
+    /// </summary>
+    private static Predicate? TryLowerResourceColumn(Expression expression, LeafContext leafContext)
+    {
+        if (expression is SearchParameterPredicateExpression predicate)
+        {
+            return ResourceColumnLoweringRule.TryLower(predicate, leafContext);
+        }
+
+        if (expression is not MultiaryExpression { MultiaryOperation: MultiaryOperator.Or } or)
+        {
+            return null;
+        }
+
+        Predicate? combined = null;
+        foreach (var branch in or.Expressions)
+        {
+            var lowered = TryLowerResourceColumn(branch, leafContext);
+            if (lowered is null)
+            {
+                return null;
+            }
+
+            combined = combined is null ? lowered : new Predicate.Or(combined, lowered);
+        }
+
+        return combined;
+    }
 
     /// <summary>
     /// Lowers a chain's target expression within its own scope, folding any resource-column predicates into

--- a/src/Core/Ignixa.Search.Sql/Lowering/NumericRangeComparison.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/NumericRangeComparison.cs
@@ -19,9 +19,19 @@ namespace Ignixa.Search.Sql.Lowering;
 /// overlapping the resource range, a deliberately looser relation than <c>eq</c>.
 /// </para>
 /// <para>
+/// The ordering comparators each constrain the bound the spec's intersection test names, which is the
+/// OPPOSITE bound to the direction of the operator: <c>gt</c>/<c>ge</c> ask whether the range above the
+/// search value reaches the target at all, which is true when the target's HighValue clears it;
+/// <c>lt</c>/<c>le</c> likewise test LowValue. <c>sa</c>/<c>eb</c> ask whether the target lies wholly to
+/// one side, so they take the other bound: <c>sa</c> is LowValue, <c>eb</c> is HighValue. Reading the
+/// operator as though it applied to the near bound (gt on LowValue) silently implements <c>sa</c>/
+/// <c>eb</c> semantics instead, which agrees with the spec only for point-valued rows.
+/// </para>
+/// <para>
 /// For a point-valued row (LowValue = HighValue, what a plain <c>valueQuantity</c> or number indexes to)
-/// containment and overlap coincide; the distinction only bites on a row that stores a genuine range,
-/// such as an indexed <c>Range</c> element.
+/// containment and overlap coincide, and so do all six ordering comparators' two candidate columns; the
+/// distinction only bites on a row that stores a genuine range, such as an indexed <c>Range</c> element,
+/// or one the row generator half-bounded with a sentinel.
 /// </para>
 /// </summary>
 internal static class NumericRangeComparison
@@ -30,10 +40,12 @@ internal static class NumericRangeComparison
     {
         SearchComparator.Eq => BuildEq(context, lowColumn, highColumn, value),
         SearchComparator.Ne => BuildNe(context, lowColumn, highColumn, value),
-        SearchComparator.Ge => new Predicate.GreaterThanOrEqual(lowColumn, context.Parameter(value)),
-        SearchComparator.Gt or SearchComparator.Sa => new Predicate.GreaterThan(lowColumn, context.Parameter(value)),
-        SearchComparator.Le => new Predicate.LessThanOrEqual(highColumn, context.Parameter(value)),
-        SearchComparator.Lt or SearchComparator.Eb => new Predicate.LessThan(highColumn, context.Parameter(value)),
+        SearchComparator.Ge => new Predicate.GreaterThanOrEqual(highColumn, context.Parameter(value)),
+        SearchComparator.Gt => new Predicate.GreaterThan(highColumn, context.Parameter(value)),
+        SearchComparator.Le => new Predicate.LessThanOrEqual(lowColumn, context.Parameter(value)),
+        SearchComparator.Lt => new Predicate.LessThan(lowColumn, context.Parameter(value)),
+        SearchComparator.Sa => new Predicate.GreaterThan(lowColumn, context.Parameter(value)),
+        SearchComparator.Eb => new Predicate.LessThan(highColumn, context.Parameter(value)),
         SearchComparator.Ap => BuildApproximate(context, lowColumn, highColumn, value),
         _ => throw new NotSupportedException($"Unknown SearchComparator '{comparator}'."),
     };

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -61,6 +61,13 @@ public sealed class StructuralContext
     {
         var targetTypeId = _leafContext.ResourceTypeId(resourceType);
 
+        // A source type the resolver could not find yields UnmatchableResourceTypeId (-1), which Emit
+        // renders as `rsp.ResourceTypeId = -1` inside the anti-join subquery. No row has that id, so the
+        // inner EXISTS is empty and NOT EXISTS is vacuously true -- every target passes. That is the
+        // OPPOSITE of the sentinel's effect in a positive position (an empty match), yet it is the correct
+        // answer here: a source type that does not exist has no reference rows, so no target is referenced
+        // by it, so all targets are "not referenced by it". The unmatchable target type at the outer scan
+        // still (correctly) matches nothing.
         short? sourceTypeId = expression.SourceResourceType is { } sourceType
             ? _leafContext.ResourceTypeId(sourceType)
             : null;

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -51,6 +51,33 @@ public sealed class StructuralContext
         return new CteRef(index);
     }
 
+    /// <summary>
+    /// Lowers a <c>_not-referenced</c> search to a NotReferencedSource CTE: resources of the target type
+    /// that no reference row points at. A named source type and reference path narrow the anti-join; a
+    /// path that did not resolve to a reference parameter falls back to a source-type-only (path-agnostic)
+    /// filter, matching the shipping engine.
+    /// </summary>
+    public CteRef LowerNotReferenced(NotReferencedExpression expression, string resourceType)
+    {
+        var targetTypeId = _leafContext.ResourceTypeId(resourceType);
+
+        short? sourceTypeId = expression.SourceResourceType is { } sourceType
+            ? _leafContext.ResourceTypeId(sourceType)
+            : null;
+
+        short? referenceParamId =
+            expression.SourceResourceType is { } src
+            && expression.ReferencePath is { } path
+            && _leafContext.NotReferencedPath(src, path) is { } parameter
+                ? _leafContext.SearchParamId(parameter)
+                : null;
+
+        _ctes.Add(new CteDefinition.NotReferencedSource(targetTypeId, sourceTypeId, referenceParamId));
+        var index = _ctes.Count - 1;
+        _origins.Add(new CteOrigin(index, expression));
+        return new CteRef(index);
+    }
+
     /// <summary>Lowers a <c>:text</c> search, which reads dbo.TokenText rather than a search-param table.</summary>
     public CteRef LowerTokenText(SearchParameterInfo parameter, StringExpression expression, string resourceType, Expression provenanceNode)
     {

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -51,6 +51,16 @@ public sealed class StructuralContext
         return new CteRef(index);
     }
 
+    /// <summary>Lowers a <c>:text</c> search, which reads dbo.TokenText rather than a search-param table.</summary>
+    public CteRef LowerTokenText(SearchParameterInfo parameter, StringExpression expression, string resourceType, Expression provenanceNode)
+    {
+        var resourceTypeId = _leafContext.ResourceTypeId(resourceType);
+        _ctes.Add(TokenTextLoweringRule.Lower(parameter, expression, _leafContext, resourceTypeId));
+        var index = _ctes.Count - 1;
+        _origins.Add(new CteOrigin(index, provenanceNode));
+        return new CteRef(index);
+    }
+
     public CteRef LowerComposite(SearchParameterInfo compositeParameter, IReadOnlyList<CompositeComponentExpression> components, string resourceType, Expression provenanceNode)
     {
         foreach (var component in components)

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -158,9 +158,16 @@ public sealed class StructuralContext
     }
 
     public CteRef LowerNot(CteRef innerMatch, string resourceType)
+        => Except(LowerResourceSource(resourceType), innerMatch);
+
+    /// <summary>
+    /// Subtracts one match set from another. Callers that already hold a narrower left-hand set should
+    /// use this directly rather than <see cref="LowerNot"/>, whose ResourceSource anchor reads every
+    /// resource of the type.
+    /// </summary>
+    public CteRef Except(CteRef left, CteRef right)
     {
-        var baseRef = LowerResourceSource(resourceType);
-        _ctes.Add(new CteDefinition.Except(baseRef, innerMatch));
+        _ctes.Add(new CteDefinition.Except(left, right));
         return new CteRef(_ctes.Count - 1);
     }
 

--- a/src/Core/Ignixa.Search.Sql/Symbols/Resolve.cs
+++ b/src/Core/Ignixa.Search.Sql/Symbols/Resolve.cs
@@ -133,10 +133,13 @@ public static class Resolve
 
     /// <summary>
     /// Resolves each <c>_not-referenced=Type:path</c> pair to its reference search parameter and adds that
-    /// parameter to the collector so it gets a SearchParamId like any other. A pair whose path is unknown,
-    /// carries no Url, or is not a reference-type parameter is dropped rather than recorded: Lower then
-    /// falls back to a path-agnostic (source-type-only) anti-join, which is the shipping engine's behaviour
-    /// for an unresolvable path. Returns null when there are no pairs, so the common case allocates nothing.
+    /// parameter to the collector so it gets a SearchParamId like any other. A pair whose path the resolver
+    /// cannot find, that carries no Url, or that is not a reference-type parameter is dropped rather than
+    /// recorded: Lower then falls back to a path-agnostic (source-type-only) anti-join, which is the shipping
+    /// engine's lenient behaviour for an unresolvable path. A missing definition manager is a different case
+    /// -- a required dependency was not supplied -- and throws rather than silently degrading every path
+    /// filter, mirroring <see cref="ResolveCompartmentMembership"/>. Returns null when there are no pairs, so
+    /// the common case allocates nothing.
     /// </summary>
     private static Dictionary<(string SourceResourceType, string ReferencePath), SearchParameterInfo>? ResolveNotReferencedPaths(
         SymbolCollectingVisitor collector,
@@ -147,6 +150,15 @@ public static class Resolve
             return null;
         }
 
+        if (searchParameterDefinitionManager is null)
+        {
+            throw new InvalidOperationException(
+                "Resolve encountered a _not-referenced path filter (Type:path) but no " +
+                "ISearchParameterDefinitionManager was supplied -- it is required to resolve the reference " +
+                "path. Silently omitting it would widen the anti-join to a path-agnostic one, returning more " +
+                "resources than the query asked for.");
+        }
+
         var resolved = new Dictionary<(string, string), SearchParameterInfo>();
         foreach (var (sourceType, path) in collector.NotReferencedPaths)
         {
@@ -155,8 +167,7 @@ public static class Resolve
                 continue;
             }
 
-            if (searchParameterDefinitionManager is null
-                || !searchParameterDefinitionManager.TryGetSearchParameter(sourceType, path, out var parameter)
+            if (!searchParameterDefinitionManager.TryGetSearchParameter(sourceType, path, out var parameter)
                 || parameter.Type != SearchParamType.Reference
                 || parameter.Url is null)
             {

--- a/src/Core/Ignixa.Search.Sql/Symbols/Resolve.cs
+++ b/src/Core/Ignixa.Search.Sql/Symbols/Resolve.cs
@@ -70,6 +70,7 @@ public static class Resolve
         }
 
         var compartmentMembership = ResolveCompartmentMembership(collector, compartmentDefinitionManager, searchParameterDefinitionManager);
+        var notReferencedPaths = ResolveNotReferencedPaths(collector, searchParameterDefinitionManager);
 
         var searchParamIds = new Dictionary<string, short>();
         var unresolved = new List<SearchParameterInfo>();
@@ -127,7 +128,46 @@ public static class Resolve
             quantityCodeIds[code] = await resolver.GetQuantityCodeIdAsync(code, cancellationToken);
         }
 
-        return new ResolvedSymbols(new SymbolTable(searchParamIds, resourceTypeIds, compartmentMembership, systemIds, quantityCodeIds), unresolved);
+        return new ResolvedSymbols(new SymbolTable(searchParamIds, resourceTypeIds, compartmentMembership, systemIds, quantityCodeIds, notReferencedPaths), unresolved);
+    }
+
+    /// <summary>
+    /// Resolves each <c>_not-referenced=Type:path</c> pair to its reference search parameter and adds that
+    /// parameter to the collector so it gets a SearchParamId like any other. A pair whose path is unknown,
+    /// carries no Url, or is not a reference-type parameter is dropped rather than recorded: Lower then
+    /// falls back to a path-agnostic (source-type-only) anti-join, which is the shipping engine's behaviour
+    /// for an unresolvable path. Returns null when there are no pairs, so the common case allocates nothing.
+    /// </summary>
+    private static Dictionary<(string SourceResourceType, string ReferencePath), SearchParameterInfo>? ResolveNotReferencedPaths(
+        SymbolCollectingVisitor collector,
+        ISearchParameterDefinitionManager? searchParameterDefinitionManager)
+    {
+        if (collector.NotReferencedPaths.Count == 0)
+        {
+            return null;
+        }
+
+        var resolved = new Dictionary<(string, string), SearchParameterInfo>();
+        foreach (var (sourceType, path) in collector.NotReferencedPaths)
+        {
+            if (resolved.ContainsKey((sourceType, path)))
+            {
+                continue;
+            }
+
+            if (searchParameterDefinitionManager is null
+                || !searchParameterDefinitionManager.TryGetSearchParameter(sourceType, path, out var parameter)
+                || parameter.Type != SearchParamType.Reference
+                || parameter.Url is null)
+            {
+                continue;
+            }
+
+            resolved[(sourceType, path)] = parameter;
+            collector.Parameters.Add(parameter);
+        }
+
+        return resolved.Count == 0 ? null : resolved;
     }
 
     private static Dictionary<string, IReadOnlyList<(SearchParameterInfo Parameter, IReadOnlyList<string> ResourceTypes)>>? ResolveCompartmentMembership(

--- a/src/Core/Ignixa.Search.Sql/Symbols/SymbolCollectingVisitor.cs
+++ b/src/Core/Ignixa.Search.Sql/Symbols/SymbolCollectingVisitor.cs
@@ -125,6 +125,36 @@ internal sealed class SymbolCollectingVisitor : ExpressionRewriter<object?>
     }
 
     /// <summary>
+    /// The (source resource type, reference path) pairs of every <c>_not-referenced=Type:path</c> in the
+    /// tree, for Resolve to resolve to a reference search parameter. The wildcard forms (<c>*:*</c>,
+    /// <c>Type:*</c>) contribute no pair — they need no parameter lookup — but a named source type is
+    /// still collected as a resource type below.
+    /// </summary>
+    public List<(string SourceResourceType, string ReferencePath)> NotReferencedPaths { get; } = [];
+
+    /// <summary>
+    /// Records a <c>_not-referenced</c> search's source type and reference path. Like
+    /// <see cref="VisitCompartment"/>, it does no definition-manager I/O of its own — Resolve resolves the
+    /// path — keeping this class's no-I/O contract intact.
+    /// </summary>
+    public override Expression VisitNotReferenced(NotReferencedExpression expression, object? context)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        if (expression.SourceResourceType is { } sourceType)
+        {
+            AddResourceType(sourceType);
+
+            if (expression.ReferencePath is { } path)
+            {
+                NotReferencedPaths.Add((sourceType, path));
+            }
+        }
+
+        return expression;
+    }
+
+    /// <summary>
     /// Collects the symbols an <see cref="IncludeExpression"/> references — its reference parameter (unless
     /// a wildcard) and every resource type on its source/target/referenced-type fields. Deliberately
     /// over-collects a superset rather than re-deriving which field a given include direction actually

--- a/src/Core/Ignixa.Search.Sql/Symbols/SymbolTable.cs
+++ b/src/Core/Ignixa.Search.Sql/Symbols/SymbolTable.cs
@@ -21,19 +21,22 @@ public sealed class SymbolTable
     private readonly IReadOnlyDictionary<string, IReadOnlyList<(SearchParameterInfo Parameter, IReadOnlyList<string> ResourceTypes)>> _compartmentMembership;
     private readonly IReadOnlyDictionary<string, int?> _systemIds;
     private readonly IReadOnlyDictionary<string, int?> _quantityCodeIds;
+    private readonly IReadOnlyDictionary<(string SourceResourceType, string ReferencePath), SearchParameterInfo> _notReferencedPaths;
 
     public SymbolTable(
         IReadOnlyDictionary<string, short> searchParamIds,
         IReadOnlyDictionary<string, short> resourceTypeIds,
         IReadOnlyDictionary<string, IReadOnlyList<(SearchParameterInfo Parameter, IReadOnlyList<string> ResourceTypes)>>? compartmentMembership = null,
         IReadOnlyDictionary<string, int?>? systemIds = null,
-        IReadOnlyDictionary<string, int?>? quantityCodeIds = null)
+        IReadOnlyDictionary<string, int?>? quantityCodeIds = null,
+        IReadOnlyDictionary<(string SourceResourceType, string ReferencePath), SearchParameterInfo>? notReferencedPaths = null)
     {
         _searchParamIds = searchParamIds;
         _resourceTypeIds = resourceTypeIds;
         _compartmentMembership = compartmentMembership ?? new Dictionary<string, IReadOnlyList<(SearchParameterInfo, IReadOnlyList<string>)>>();
         _systemIds = systemIds ?? new Dictionary<string, int?>();
         _quantityCodeIds = quantityCodeIds ?? new Dictionary<string, int?>();
+        _notReferencedPaths = notReferencedPaths ?? new Dictionary<(string, string), SearchParameterInfo>();
     }
 
     /// <summary>
@@ -85,6 +88,16 @@ public sealed class SymbolTable
         => _compartmentMembership.TryGetValue(compartmentType, out var membership)
            ? membership
            : throw new KeyNotFoundException($"SymbolTable has no compartment membership map for '{compartmentType}' -- Resolve should have resolved every compartment type Lower will need.");
+
+    /// <summary>
+    /// The reference-path search parameter a <c>_not-referenced=Type:path</c> search resolved to, or
+    /// <see langword="null"/> when the pair was not resolved to a reference parameter — in which case
+    /// Lower falls back to a path-agnostic anti-join (source type only), matching the shipping engine.
+    /// Holds the parameter, not its id; Lower resolves the id through <see cref="SearchParamId"/>, the
+    /// same way compartment membership does.
+    /// </summary>
+    public SearchParameterInfo? NotReferencedPath(string sourceResourceType, string referencePath)
+        => _notReferencedPaths.TryGetValue((sourceResourceType, referencePath), out var parameter) ? parameter : null;
 
     /// <summary>
     /// Looks up a token-system or quantity-system surrogate ID. Returns the stored nullable value when

--- a/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/ExpressionParser.cs
@@ -139,7 +139,10 @@ public class ExpressionParser : IExpressionParser
         EnsureArg.HasItems(resourceTypes, nameof(resourceTypes));
         EnsureArg.IsNotNullOrWhiteSpace(includeValue, nameof(includeValue));
 
-        if (!includeValue.Contains(':', StringComparison.Ordinal))
+        // A bare "*" is the whole-type wildcard (_include=* / _revinclude=*): every reference out of (or,
+        // reversed, into) the searched resource type. It carries no explicit "Type:" prefix and so no ':',
+        // which the missing-type guard below would otherwise reject.
+        if (!includeValue.Equals("*", StringComparison.Ordinal) && !includeValue.Contains(':', StringComparison.Ordinal))
         {
             throw new InvalidSearchOperationException(
                 isReversed

--- a/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacyExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacyExpressionParser.cs
@@ -84,6 +84,15 @@ public sealed class LegacyExpressionParser : IExpressionParser
 
     public IncludeExpression ParseInclude(string[] resourceTypes, string includeValue, bool isReversed, bool iterate)
     {
+        // A bare "*" is the whole-type wildcard (_include=* / _revinclude=*): it carries no "Type:" prefix,
+        // so the split below would fail the missing-type check. Normalizing it to "*:*" up front routes it
+        // through the existing wildcard branch with the "*" source sentinel -- kept identical to
+        // SearchExpressionBinder's handling so the new parser and this rollback oracle agree.
+        if (includeValue.Equals("*", StringComparison.Ordinal))
+        {
+            includeValue = "*:*";
+        }
+
         ReadOnlySpan<char> valueSpan = includeValue.AsSpan();
         if (!TrySplit(SearchSplitChar, ref valueSpan, out ReadOnlySpan<char> originalType))
         {

--- a/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchParameterExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchParameterExpressionParser.cs
@@ -119,7 +119,16 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
                         string componentValue = compositeValueParts[componentIndex];
 
                         var effectiveSearchParameter = componentSearchParameter;
-                        var inferredType = InferSearchParamTypeFromValue(componentValue);
+
+                        // A quantity, number, or date component owns '|' and '/' within its own value
+                        // grammar (a quantity value is [prefix]number|system|code), so the "any '|' is a
+                        // token, any '/' is a reference" inference below must not fire for it -- otherwise a
+                        // value-quantity carrying a full system|code is misread as a two-separator token and
+                        // the search is rejected. Kept identical to SearchExpressionBinder's guard so the
+                        // new parser and this rollback oracle stay in parity.
+                        var inferredType = componentSearchParameter.Type is SearchParamType.Quantity or SearchParamType.Number or SearchParamType.Date
+                            ? null
+                            : InferSearchParamTypeFromValue(componentValue);
                         if (inferredType.HasValue && inferredType != componentSearchParameter.Type)
                         {
                             effectiveSearchParameter = new SearchParameterInfo(

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchExpressionBinder.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchExpressionBinder.cs
@@ -266,6 +266,17 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
         SearchParameterInfo component,
         string value)
     {
+        // A quantity, number, or date component owns the '|' and '/' characters within its own value
+        // grammar -- a quantity value is [prefix]number|system|code -- so the "any '|' means token, any
+        // '/' means reference" heuristic below must not fire for it. Without this guard a value-quantity
+        // component carrying a full system|code (e.g. gt38|http://unitsofmeasure.org|Cel) is misread as a
+        // token with two separators and the whole search is rejected. The same three ordered types are
+        // the ones NormalizeCompositeComparator already treats specially, for the same reason.
+        if (component.Type is SearchParamType.Quantity or SearchParamType.Number or SearchParamType.Date)
+        {
+            return component;
+        }
+
         SearchParamType? inferred = InferSearchParamTypeFromValue(value);
         if (inferred is null || inferred == component.Type)
         {

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
@@ -72,6 +72,16 @@ internal static class SearchKeySyntaxParser
         {
             var start = _offset;
             var source = ParseIncludeSource();
+
+            // A bare "*" with no "Type:" prefix is the whole-type wildcard (_include=*): source stays the
+            // "*" sentinel and there is nothing further to consume. The typed forms (Type:* and
+            // Type:param) still require the ':' that separates the source from what follows.
+            if (source == "*" && AtEnd)
+            {
+                return new IncludeKeySyntax(source, null, null, true)
+                    { Span = new SourceSpan(SourceOrigin.Key, start, _offset - start) };
+            }
+
             Require(':', "':'");
 
             if (ConsumeIf('*'))

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchExpressionBinderTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchExpressionBinderTests.cs
@@ -251,6 +251,53 @@ public class SearchExpressionBinderTests
     }
 
     [Fact]
+    public void GivenACompositeQuantityComponentWithSystemAndCode_WhenBinding_ThenKeepsItAQuantityRatherThanInferringAToken()
+    {
+        // Arrange -- Observation?code-value-quantity=http://loinc.org|8310-5$gt38|http://unitsofmeasure.org|Cel.
+        // The value-quantity component's value carries a full system|code pair, so it contains two '|'.
+        // Inferring a token from any '|' misreads it as a token with two separators and rejects the whole
+        // search; the '|' here is the quantity's own system|code separator, not a token separator.
+        var context = new SearchParserTestContext();
+        var code = new SearchParameterInfo("code", "code", SearchParamType.Token);
+        var quantity = new SearchParameterInfo("value-quantity", "value-quantity", SearchParamType.Quantity);
+        var codeComponent = new SearchParameterComponentInfo(new Uri("http://example.org/SearchParameter/code"))
+        {
+            ResolvedSearchParameter = code,
+        };
+        var quantityComponent = new SearchParameterComponentInfo(new Uri("http://example.org/SearchParameter/value-quantity"))
+        {
+            ResolvedSearchParameter = quantity,
+        };
+        var composite = context.Add(
+            "Observation",
+            "code-value-quantity",
+            SearchParamType.Composite,
+            components: [codeComponent, quantityComponent]);
+        var binder = CreateBinder(context);
+        var syntax = SearchValueSyntaxParser.Parse(
+            SearchParamType.Composite,
+            null,
+            "http://loinc.org|8310-5$gt38|http://unitsofmeasure.org|Cel");
+
+        // Act
+        var result = binder.BindValue(composite, null, syntax);
+
+        // Assert -- the value-quantity component bound as a quantity, not a token
+        var search = result.ShouldBeOfType<SearchParameterExpression>();
+        var and = search.Expression.ShouldBeOfType<MultiaryExpression>();
+        and.MultiaryOperation.ShouldBe(MultiaryOperator.And);
+        var quantityPredicate = and.Expressions
+            .OfType<CompositeComponentExpression>()
+            .Select(component => component.WrappedExpression)
+            .OfType<SearchParameterPredicateExpression>()
+            .Single(predicate => predicate.Value is QuantitySearchValue);
+        var quantityValue = quantityPredicate.Value.ShouldBeOfType<QuantitySearchValue>();
+        quantityValue.System.ShouldBe("http://unitsofmeasure.org");
+        quantityValue.Code.ShouldBe("Cel");
+        quantityPredicate.Comparator.ShouldBe(SearchComparator.Gt);
+    }
+
+    [Fact]
     public void GivenTooManyCompositeComponents_WhenBinding_ThenPreservesResourceMessage()
     {
         var context = new SearchParserTestContext();

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchParserFacadeTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchParserFacadeTests.cs
@@ -76,4 +76,46 @@ public class SearchParserFacadeTests
         result.WildCard.ShouldBeTrue();
         result.ReferencedTypes.ShouldBe(["Patient", "Encounter"], ignoreOrder: true);
     }
+
+    [Fact]
+    public void GivenBareWildcardInclude_WhenParsingPublicFacade_ThenIsAWildcardOverTheSearchedType()
+    {
+        // Arrange -- Patient?_include=* -- the bare wildcard, with no explicit source type. It means
+        // "every reference out of the searched resource type", so it is a wildcard include sourced from
+        // that type, the same as _include=Patient:*.
+        var context = new SearchParserTestContext();
+        context.Add("Patient", "organization", SearchParamType.Reference, ["Organization"]);
+        context.Add("Patient", "general-practitioner", SearchParamType.Reference, ["Practitioner", "Organization"]);
+
+        // Act
+        var result = context.Parser.ParseInclude(
+            ["Patient"],
+            "*",
+            isReversed: false,
+            iterate: false);
+
+        // Assert
+        result.WildCard.ShouldBeTrue();
+        result.ReferencedTypes.ShouldBe(["Organization", "Practitioner"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void GivenBareWildcardRevinclude_WhenParsingPublicFacade_ThenIsAReversedWildcardTargetingTheSearchedType()
+    {
+        // Arrange -- Patient?_revinclude=* -- every reference INTO the searched resource type.
+        var context = new SearchParserTestContext();
+        context.Add("Observation", "subject", SearchParamType.Reference, ["Patient"]);
+
+        // Act
+        var result = context.Parser.ParseInclude(
+            ["Patient"],
+            "*",
+            isReversed: true,
+            iterate: false);
+
+        // Assert
+        result.WildCard.ShouldBeTrue();
+        result.Reversed.ShouldBeTrue();
+        result.TargetResourceType.ShouldBe("Patient");
+    }
 }

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchParserOldVsNewParityTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchParserOldVsNewParityTests.cs
@@ -432,6 +432,18 @@ public class SearchParserOldVsNewParityTests
     }
 
     [Fact]
+    public void GivenRevIncludeWildcard_WhenParsingBareStar_ThenIdenticalToOldParser()
+    {
+        // Patient?_revinclude=* -- the reverse bare wildcard. Both parsers now accept it (the active one
+        // via the "*" source sentinel, the legacy oracle by normalizing "*" -> "*:*"); this pins that they
+        // reach the same reversed-wildcard shape so the rollback lever stays safe.
+        var context = new SearchParserTestContext();
+        context.Add("Observation", "subject", SearchParamType.Reference, targets: Patient);
+
+        AssertIdenticalIncludeBehavior(context, Patient, "*", isReversed: true, iterate: false);
+    }
+
+    [Fact]
     public void GivenIncludeIterate_WhenParsingIterateFlagSet_ThenIdenticalToOldParser()
     {
         var context = new SearchParserTestContext();

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -1251,6 +1251,27 @@ public class EmitTests
     }
 
     [Fact]
+    public void GivenANotReferencedSourceWithSourceTypeButNoPath_WhenEmitted_ThenFiltersOnSourceTypeButNotSearchParamId()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:* -- source type 96, no reference path. The
+        // anti-join narrows to references originating from Observation, but not to any single path.
+        var plan = new QueryPlan([new CteDefinition.NotReferencedSource(103, 96, null)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain(
+            "      AND NOT EXISTS (\n" +
+            "        SELECT 1\n" +
+            "        FROM dbo.ReferenceSearchParam rsp\n" +
+            "        WHERE rsp.ReferenceResourceId = r.ResourceId\n" +
+            "          AND rsp.ReferenceResourceTypeId = r.ResourceTypeId\n" +
+            "          AND rsp.ResourceTypeId = 96)\n");
+        emitted.Sql.ShouldNotContain("rsp.SearchParamId");
+    }
+
+    [Fact]
     public void GivenANotReferencedSourceFullWildcard_WhenEmitted_ThenTheAntiJoinFiltersOnlyOnTargetIdentity()
     {
         // Arrange -- Patient?_not-referenced=*:* -- a Patient referenced by nothing at all.

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -1202,6 +1202,25 @@ public class EmitTests
     }
 
     [Fact]
+    public void GivenANotPredicateInTheOuterWhere_WhenEmitted_ThenWrapsTheOperandInNot()
+    {
+        // Arrange -- Patient?_id:not=a,b -- a negated resource-column filter over a Resource scan.
+        var idColumn = new SqlColumnRef("Resource", "ResourceId");
+        var outer = new Predicate.Not(
+            new Predicate.Or(
+                new Predicate.Equal(idColumn, new SqlParameterRef("a")),
+                new Predicate.Equal(idColumn, new SqlParameterRef("b"))));
+        var plan = new QueryPlan([new CteDefinition.ResourceSource(103)], new CteRef(0), OuterPredicate: outer);
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain("WHERE NOT ((ResourceId = @p1 OR ResourceId = @p2))");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(object)(short)103, "a", "b"]);
+    }
+
+    [Fact]
     public void GivenANotReferencedSourceWithSourceTypeAndPath_WhenEmitted_ThenAntiJoinsReferenceSearchParamByTargetIdentity()
     {
         // Arrange -- Patient?_not-referenced=Observation:subject. Target type 103, source type 96, ref

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -1200,4 +1200,54 @@ public class EmitTests
         emitted.Parameters[0].ShouldBe(new EmittedSqlParameter("@p0", expectedPattern));
         emitted.Parameters[1].ShouldBe(new EmittedSqlParameter("@p1", expectedPattern));
     }
+
+    [Fact]
+    public void GivenANotReferencedSourceWithSourceTypeAndPath_WhenEmitted_ThenAntiJoinsReferenceSearchParamByTargetIdentity()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject. Target type 103, source type 96, ref
+        // param 969. The anti-join correlates on reference-target identity: a ReferenceSearchParam row's
+        // ReferenceResourceId/ReferenceResourceTypeId against the candidate Resource's own id and type.
+        var plan = new QueryPlan([new CteDefinition.NotReferencedSource(103, 96, 969)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldBe(
+            ";WITH cte0 AS (\n" +
+            "    SELECT r.ResourceTypeId AS T1, r.ResourceSurrogateId AS Sid1\n" +
+            "    FROM dbo.Resource r\n" +
+            "    WHERE r.ResourceTypeId = @p0 AND r.IsHistory = 0 AND r.IsDeleted = 0\n" +
+            "      AND NOT EXISTS (\n" +
+            "        SELECT 1\n" +
+            "        FROM dbo.ReferenceSearchParam rsp\n" +
+            "        WHERE rsp.ReferenceResourceId = r.ResourceId\n" +
+            "          AND rsp.ReferenceResourceTypeId = r.ResourceTypeId\n" +
+            "          AND rsp.ResourceTypeId = 96\n" +
+            "          AND rsp.SearchParamId = 969)\n" +
+            ")\n" +
+            "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
+            "ORDER BY m.T1 ASC, m.Sid1 ASC");
+        emitted.Parameters.ShouldHaveSingleItem().ShouldBe(new EmittedSqlParameter("@p0", (short)103));
+    }
+
+    [Fact]
+    public void GivenANotReferencedSourceFullWildcard_WhenEmitted_ThenTheAntiJoinFiltersOnlyOnTargetIdentity()
+    {
+        // Arrange -- Patient?_not-referenced=*:* -- a Patient referenced by nothing at all.
+        var plan = new QueryPlan([new CteDefinition.NotReferencedSource(103, null, null)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- no source-type or param filter inside the NOT EXISTS
+        emitted.Sql.ShouldContain(
+            "      AND NOT EXISTS (\n" +
+            "        SELECT 1\n" +
+            "        FROM dbo.ReferenceSearchParam rsp\n" +
+            "        WHERE rsp.ReferenceResourceId = r.ResourceId\n" +
+            "          AND rsp.ReferenceResourceTypeId = r.ResourceTypeId)\n");
+        emitted.Sql.ShouldNotContain("rsp.SearchParamId");
+        emitted.Sql.ShouldNotContain("rsp.ResourceTypeId =");
+    }
 }

--- a/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
@@ -211,6 +211,44 @@ public class PlanExplainerTests
     }
 
     [Fact]
+    public void GivenANotReferencedSourceWithSourceAndPath_WhenExplained_ThenPrintsTargetSourceAndParam()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject.
+        var plan = new QueryPlan([new CteDefinition.NotReferencedSource(103, 96, 969)], new CteRef(0));
+
+        // Act
+        var explained = plan.Explain();
+
+        // Assert
+        explained.ShouldBe("root = NotReferencedSource[103] not referenced by source=96 ref=969");
+    }
+
+    [Fact]
+    public void GivenANotReferencedSourceFullWildcard_WhenExplainedAlongsideAParameterizedCte_ThenConsumesOneOrdinalForItsTargetType()
+    {
+        // Arrange -- the target ResourceTypeId is a bound @pN in Emit, so Explain must consume an ordinal
+        // for it too or the @pN numbering diverges from the emitted SQL when another parameterized CTE
+        // follows. `*:*` prints without source/ref suffixes.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var plan = new QueryPlan(
+        [
+            new CteDefinition.NotReferencedSource(103, null, null),
+            new CteDefinition.ParamSource(table, 103, 202, new Predicate.Equal(new SqlColumnRef("StringSearchParam", "Text"), new SqlParameterRef("Smith"))),
+            new CteDefinition.Intersect(new CteRef(0), new CteRef(1)),
+        ],
+        new CteRef(2));
+
+        // Act
+        var explained = plan.Explain();
+
+        // Assert -- the ParamSource's Text predicate is @p1, not @p0, because NotReferencedSource took @p0
+        explained.ShouldBe(
+            "cte0 = NotReferencedSource[103]\n" +
+            "cte1 = StringSearchParam[103,202]  Text = @p1\n" +
+            "root = Intersect(cte0, cte1)");
+    }
+
+    [Fact]
     public void GivenAPlanWithSortAndAPageBoundary_WhenExplained_ThenPrintsBothAsTrailingLines()
     {
         // Arrange

--- a/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogTests.cs
@@ -305,4 +305,24 @@ public class SqlCatalogTests
         table.Column("IsHistory").ShouldNotBeNull();
         table.Column("IsDeleted").ShouldNotBeNull();
     }
+
+    [Fact]
+    public void GivenTheTokenTextTable_WhenLookedUp_ThenMatchesRealDdl()
+    {
+        // Arrange -- the table `:text` searches. Its name does not end in "SearchParam", so it needs the
+        // catalog generator to name it explicitly, and unlike the other leaf tables it carries its own
+        // IsHistory column that any query against it has to filter.
+        var catalog = SqlCatalog.Default;
+
+        // Act
+        var table = catalog.Table("TokenText");
+        var text = table.Column("Text");
+
+        // Assert
+        text.SqlType.ShouldBe("nvarchar");
+        text.MaxLength.ShouldBe(400);
+        text.Collation.ShouldBe("Latin1_General_CI_AI");
+        text.IsNullable.ShouldBeFalse();
+        table.Column("IsHistory").ShouldNotBeNull();
+    }
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompilation.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompilation.cs
@@ -1,0 +1,11 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>The outcome of putting one captured URL through the compiler.</summary>
+public sealed record CorpusCompilation(CorpusEntry Entry, string? Sql, string? FailureStage, string? FailureMessage)
+{
+    public bool Succeeded => Sql is not null;
+
+    public static CorpusCompilation Compiled(CorpusEntry entry, string sql) => new(entry, sql, null, null);
+
+    public static CorpusCompilation Failed(CorpusEntry entry, string stage, string message) => new(entry, null, stage, message);
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompiler.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompiler.cs
@@ -3,6 +3,7 @@ using Ignixa.Search.Expressions.Parsers;
 using Ignixa.Search.Indexing.SearchValues;
 using Ignixa.Search.Parsing;
 using Ignixa.Search.Sql.Tracing;
+using Ignixa.Serialization.Abstractions;
 using Ignixa.Specification.Generated;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -34,7 +35,7 @@ public static class CorpusCompiler
         {
             parameters = QueryParser.Parse(entry.QueryString);
         }
-        catch (Exception exception)
+        catch (Exception exception) when (IsExpressibilityFailure(exception))
         {
             return CorpusCompilation.Failed(entry, "query-parse", exception.Message);
         }
@@ -61,7 +62,7 @@ public static class CorpusCompiler
 
             return CorpusCompilation.Compiled(entry, trace.Sql.Sql);
         }
-        catch (Exception exception)
+        catch (Exception exception) when (IsExpressibilityFailure(exception))
         {
             // SearchCompiler records Lower/Emit NotSupported and KeyNotFound as trace failures, but the
             // build stage ahead of it (search-parameter binding, value parsing) still throws. Those are
@@ -69,6 +70,21 @@ public static class CorpusCompiler
             return CorpusCompilation.Failed(entry, StageOf(exception), exception.Message);
         }
     }
+
+    /// <summary>
+    /// Whether an exception means "the compiler cannot express this query" (a corpus data point) rather
+    /// than a defect in the compiler itself. A NullReferenceException, an IndexOutOfRangeException, or any
+    /// other unexpected type is a real bug and must fail the test loudly instead of being recorded as a
+    /// known expressiveness limit; OperationCanceledException must propagate so cooperative cancellation
+    /// still works. Only the four families the build/lower/emit stages throw for genuinely-unsupported
+    /// input are treated as data.
+    /// </summary>
+    private static bool IsExpressibilityFailure(Exception exception) => exception switch
+    {
+        OperationCanceledException => false,
+        NotSupportedException or KeyNotFoundException or FhirException => true,
+        _ => false,
+    };
 
     private static string StageOf(Exception exception) => exception switch
     {

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompiler.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusCompiler.cs
@@ -1,0 +1,79 @@
+using Ignixa.Search.Definition;
+using Ignixa.Search.Expressions.Parsers;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Tracing;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// Compiles a captured request URL through the same stages a server would: query-string parsing, the
+/// real R4 search-parameter definitions, then Resolve/Lower/Emit via <see cref="SearchCompiler"/>.
+/// Nothing here is faked except the symbol ids (see <see cref="CorpusSymbolResolver"/>), so a failure
+/// is a genuine statement about what the compiler can and cannot do with a real-world query.
+/// </summary>
+public static class CorpusCompiler
+{
+    private static readonly R4CoreSchemaProvider Schema = new();
+    private static readonly QueryParameterParser QueryParser = new();
+    private static readonly SearchParameterDefinitionManager Definitions =
+        new(Schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+
+    private static readonly SearchOptionsBuilder OptionsBuilder = new(
+        new ExpressionParser(() => Definitions, new SearchParameterExpressionParser(new ReferenceSearchValueParser(Schema), Schema), Schema),
+        Definitions);
+
+    public static async Task<CorpusCompilation> CompileAsync(CorpusEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        IReadOnlyList<QueryParameter> parameters;
+        try
+        {
+            parameters = QueryParser.Parse(entry.QueryString);
+        }
+        catch (Exception exception)
+        {
+            return CorpusCompilation.Failed(entry, "query-parse", exception.Message);
+        }
+
+        try
+        {
+            var trace = await SearchCompiler.CompileAsync(
+                entry.ResourceType,
+                parameters,
+                OptionsBuilder,
+                new CorpusSymbolResolver(),
+                compartmentDefinitionManager: null,
+                searchParameterDefinitionManager: Definitions,
+                cancellationToken);
+
+            if (trace.Sql is null)
+            {
+                var failure = trace.Failure;
+                return CorpusCompilation.Failed(
+                    entry,
+                    failure is null ? "no-sql" : failure.Stage.ToString(),
+                    failure?.Message ?? "compilation produced no SQL and recorded no failure");
+            }
+
+            return CorpusCompilation.Compiled(entry, trace.Sql.Sql);
+        }
+        catch (Exception exception)
+        {
+            // SearchCompiler records Lower/Emit NotSupported and KeyNotFound as trace failures, but the
+            // build stage ahead of it (search-parameter binding, value parsing) still throws. Those are
+            // exactly the "the compiler cannot express this query" cases the report exists to surface.
+            return CorpusCompilation.Failed(entry, StageOf(exception), exception.Message);
+        }
+    }
+
+    private static string StageOf(Exception exception) => exception switch
+    {
+        NotSupportedException => "not-supported",
+        KeyNotFoundException => "unresolved-symbol",
+        _ => "build:" + exception.GetType().Name,
+    };
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusEntry.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusEntry.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// One captured search: the request URL a TestScript issued and the SQL the shipping search engine
+/// executed for it. Extracted from an ignixa-sql-capture artifact by Corpus/tools/extract-corpus.py.
+/// </summary>
+public sealed record CorpusEntry(
+    string Url,
+    string LegacySql,
+    IReadOnlyDictionary<string, string> ParameterTypes,
+    IReadOnlyDictionary<string, CorpusParameterValue> ParameterValues,
+    IReadOnlyList<string> SourceScripts,
+    [property: JsonPropertyName("corroboratingEvents")] int CorroboratingEvents,
+    [property: JsonPropertyName("rejectedVariants")] int RejectedVariants)
+{
+    /// <summary>The resource type the search targets, taken from the URL path.</summary>
+    public string ResourceType => Url.TrimStart('/').Split('/', '?')[0];
+
+    /// <summary>The raw query string, without the leading '?'.</summary>
+    public string QueryString
+    {
+        get
+        {
+            var index = Url.IndexOf('?', StringComparison.Ordinal);
+            return index < 0 ? string.Empty : Url[(index + 1)..];
+        }
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusParameterValue.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusParameterValue.cs
@@ -1,0 +1,7 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// A bound parameter the legacy engine passed with a captured query, recovered from the
+/// `DECLARE @p0 varchar(64) = '...'` preamble the engine's own LogEvent trace writes.
+/// </summary>
+public sealed record CorpusParameterValue(string Type, string Value);

--- a/test/Ignixa.Search.Sql.Tests/Corpus/CorpusSymbolResolver.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/CorpusSymbolResolver.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Symbols;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// Hands out a stable surrogate id for every symbol the compiler asks about, so a corpus query
+/// compiles without a database. The ids are arbitrary: the shipping engine's captured SQL carries ids
+/// from a live catalog that no longer exists, so <see cref="SqlShapeCanonicalizer"/> erases integer
+/// literals on both sides and comparison never depends on the two agreeing.
+///
+/// Nothing ever resolves to null. A null would lower to <c>1 = 0</c> and collapse the plan, turning a
+/// missing lookup row into a false "the compiler emits a different shape" finding.
+/// </summary>
+public sealed class CorpusSymbolResolver : ISymbolResolver
+{
+    private readonly ConcurrentDictionary<string, short> _searchParamIds = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, short> _resourceTypeIds = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _systemIds = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _quantityCodeIds = new(StringComparer.Ordinal);
+
+    public Task<short?> GetSearchParamIdAsync(SearchParameterInfo parameter, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+        var key = parameter.Url?.ToString() ?? parameter.Code ?? parameter.Name ?? "unnamed";
+        return Task.FromResult<short?>(_searchParamIds.GetOrAdd(key, _ => (short)(1000 + _searchParamIds.Count)));
+    }
+
+    public Task<short?> GetResourceTypeIdAsync(string resourceType, CancellationToken cancellationToken)
+        => Task.FromResult<short?>(_resourceTypeIds.GetOrAdd(resourceType, _ => (short)(1 + _resourceTypeIds.Count)));
+
+    public Task<int?> GetSystemIdAsync(string system, CancellationToken cancellationToken)
+        => Task.FromResult<int?>(_systemIds.GetOrAdd(system, _ => 1 + _systemIds.Count));
+
+    public Task<int?> GetQuantityCodeIdAsync(string code, CancellationToken cancellationToken)
+        => Task.FromResult<int?>(_quantityCodeIds.GetOrAdd(code, _ => 1 + _quantityCodeIds.Count));
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 181;
+    public const int CompiledQueries = 182;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 171;
+    public const int CompiledQueries = 174;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 167;
+    public const int CompiledQueries = 171;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 182;
+    public const int CompiledQueries = 185;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 177;
+    public const int CompiledQueries = 181;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -1,0 +1,11 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// What the corpus currently achieves. Guarded so a change that narrows the compiler's real-world
+/// coverage fails the build; the differential report explains what each remaining gap is.
+/// </summary>
+public static class DifferentialBaseline
+{
+    /// <summary>Captured queries the compiler can turn into SQL today.</summary>
+    public const int CompiledQueries = 167;
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialBaseline.cs
@@ -7,5 +7,5 @@ namespace Ignixa.Search.Sql.Tests.Corpus;
 public static class DifferentialBaseline
 {
     /// <summary>Captured queries the compiler can turn into SQL today.</summary>
-    public const int CompiledQueries = 174;
+    public const int CompiledQueries = 177;
 }

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialReport.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialReport.cs
@@ -1,0 +1,133 @@
+using System.Globalization;
+using System.Text;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>Renders the differential run as markdown for human triage.</summary>
+public static class DifferentialReport
+{
+    public static string Render(IReadOnlyList<DifferentialResult> results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var report = new StringBuilder();
+        report.AppendLine("# Legacy SQL differential report");
+        report.AppendLine();
+        report.AppendLine(CultureInfo.InvariantCulture, $"{results.Count} captured searches, each compiled and compared against the SQL the shipping engine executed.");
+        report.AppendLine();
+
+        AppendSummary(report, results);
+        AppendGaps(report, results);
+        AppendDivergences(report, results);
+
+        return report.ToString();
+    }
+
+    private static void AppendSummary(StringBuilder report, IReadOnlyList<DifferentialResult> results)
+    {
+        report.AppendLine("## Summary");
+        report.AppendLine();
+        report.AppendLine("| Verdict | Count |");
+        report.AppendLine("|---|---:|");
+
+        foreach (var verdict in Enum.GetValues<ShapeVerdict>())
+        {
+            report.AppendLine(CultureInfo.InvariantCulture, $"| {verdict} | {results.Count(r => r.Verdict == verdict)} |");
+        }
+
+        report.AppendLine();
+    }
+
+    private static void AppendGaps(StringBuilder report, IReadOnlyList<DifferentialResult> results)
+    {
+        var failures = results.Where(r => !r.Compilation.Succeeded).ToList();
+
+        report.AppendLine("## Gaps -- queries the compiler cannot express");
+        report.AppendLine();
+
+        if (failures.Count == 0)
+        {
+            report.AppendLine("None.");
+            report.AppendLine();
+            return;
+        }
+
+        foreach (var group in failures.GroupBy(r => r.Compilation.FailureStage).OrderByDescending(g => g.Count()))
+        {
+            report.AppendLine(CultureInfo.InvariantCulture, $"### {group.Key} ({group.Count()})");
+            report.AppendLine();
+
+            foreach (var reason in group.GroupBy(r => r.Compilation.FailureMessage).OrderByDescending(g => g.Count()))
+            {
+                report.AppendLine(CultureInfo.InvariantCulture, $"- **{reason.Count()}x** {Escape(reason.Key)}");
+                foreach (var result in reason.Take(3))
+                {
+                    report.AppendLine(CultureInfo.InvariantCulture, $"  - `{result.Entry.Url}`");
+                }
+            }
+
+            report.AppendLine();
+        }
+    }
+
+    private static void AppendDivergences(StringBuilder report, IReadOnlyList<DifferentialResult> results)
+    {
+        var divergent = results
+            .Where(r => r.Comparison is not null && r.Verdict != ShapeVerdict.Match)
+            .OrderBy(r => r.Verdict)
+            .ThenBy(r => r.Entry.Url, StringComparer.Ordinal)
+            .ToList();
+
+        report.AppendLine("## Divergences -- compiled, but asks the database for something different");
+        report.AppendLine();
+
+        if (divergent.Count == 0)
+        {
+            report.AppendLine("None.");
+            report.AppendLine();
+            return;
+        }
+
+        foreach (var result in divergent)
+        {
+            report.AppendLine(CultureInfo.InvariantCulture, $"### {result.Verdict}: `{result.Entry.Url}`");
+            report.AppendLine();
+
+            AppendList(report, "Only the shipping engine does", result.Comparison!.OnlyInLegacy);
+            AppendList(report, "Only the compiler does", result.Comparison.OnlyInCompiler);
+            AppendList(report, "Operator differences (encoding, not semantics)", result.Comparison.OperationDifferences);
+
+            report.AppendLine("<details><summary>shapes</summary>");
+            report.AppendLine();
+            report.AppendLine("```");
+            report.AppendLine("legacy:");
+            report.AppendLine(result.Legacy.Describe());
+            report.AppendLine();
+            report.AppendLine("compiler:");
+            report.AppendLine(result.Compiled!.Describe());
+            report.AppendLine("```");
+            report.AppendLine();
+            report.AppendLine("</details>");
+            report.AppendLine();
+        }
+    }
+
+    private static void AppendList(StringBuilder report, string title, IReadOnlyList<string> items)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        report.AppendLine(CultureInfo.InvariantCulture, $"{title}:");
+        foreach (var item in items)
+        {
+            report.AppendLine(CultureInfo.InvariantCulture, $"- `{item}`");
+        }
+
+        report.AppendLine();
+    }
+
+    private static string Escape(string? text)
+        => (text ?? "(no message)").Replace("\n", " ", StringComparison.Ordinal).Replace("|", "\\|", StringComparison.Ordinal);
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialResult.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/DifferentialResult.cs
@@ -1,0 +1,12 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>One corpus entry carried through compilation, canonicalization, and comparison.</summary>
+public sealed record DifferentialResult(
+    CorpusEntry Entry,
+    CorpusCompilation Compilation,
+    SqlShape Legacy,
+    SqlShape? Compiled,
+    ShapeComparison? Comparison)
+{
+    public ShapeVerdict Verdict => Comparison?.Verdict ?? ShapeVerdict.NotCompiled;
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/LegacyCorpus.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/LegacyCorpus.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using System.Text.Json;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>Loads the checked-in legacy-SQL corpus from the test output directory.</summary>
+public static class LegacyCorpus
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private static readonly Lazy<IReadOnlyList<CorpusEntry>> Cached = new(Load);
+
+    public static IReadOnlyList<CorpusEntry> Entries => Cached.Value;
+
+    private static IReadOnlyList<CorpusEntry> Load()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Corpus", "legacy-sql-corpus.json");
+        using var stream = File.OpenRead(path);
+        var document = JsonSerializer.Deserialize<CorpusDocument>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException($"corpus at {path} deserialized to null");
+        return document.Entries;
+    }
+
+    private sealed record CorpusDocument(string CaptureRunId, int EntryCount, IReadOnlyList<CorpusEntry> Entries);
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/LegacyCorpusDifferentialTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/LegacyCorpusDifferentialTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Text;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// Runs every captured real-world search through the compiler and compares what it asks the database
+/// for against what the shipping engine asked for. The point is triage, not parity: a divergence is a
+/// question to answer (a feature the compiler lacks, a table read the compiler avoids, or a filter the
+/// shipping engine applies for a reason worth knowing), so the suite writes a report and guards only
+/// the counts that must not regress.
+/// </summary>
+public class LegacyCorpusDifferentialTests
+{
+    [Fact]
+    public void GivenTheCapturedCorpus_WhenLoaded_ThenEveryEntryCarriesAQueryAndItsLegacySql()
+    {
+        var entries = LegacyCorpus.Entries;
+
+        entries.ShouldNotBeEmpty();
+        entries.ShouldAllBe(e => e.QueryString.Length > 0);
+        entries.ShouldAllBe(e => e.LegacySql.Contains(";WITH", StringComparison.Ordinal));
+        entries.ShouldAllBe(e => e.CorroboratingEvents >= 2);
+    }
+
+    [Fact]
+    public void GivenTheCapturedCorpus_WhenEachLegacyQueryIsCanonicalized_ThenItParsesAsTSql()
+    {
+        var unparseable = new List<string>();
+
+        foreach (var entry in LegacyCorpus.Entries)
+        {
+            try
+            {
+                SqlShapeCanonicalizer.Canonicalize(entry.LegacySql);
+            }
+            catch (FormatException exception)
+            {
+                unparseable.Add($"{entry.Url}: {exception.Message}");
+            }
+        }
+
+        unparseable.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenTheCapturedCorpus_WhenComparedAgainstTheCompiler_ThenTheDifferentialReportIsWritten()
+    {
+        var results = await RunAsync();
+
+        var report = DifferentialReport.Render(results);
+        var path = Path.Combine(AppContext.BaseDirectory, "legacy-sql-differential-report.md");
+        await File.WriteAllTextAsync(path, report, Encoding.UTF8);
+
+        report.ShouldContain("## Summary");
+    }
+
+    [Fact]
+    public async Task GivenTheCapturedCorpus_WhenCompiled_ThenNoFewerQueriesCompileThanTheRecordedBaseline()
+    {
+        var results = await RunAsync();
+        var compiled = results.Count(r => r.Compilation.Succeeded);
+
+        // Raise this with the compiler. Never lower it without recording why in the report's Gaps section.
+        compiled.ShouldBeGreaterThanOrEqualTo(DifferentialBaseline.CompiledQueries);
+    }
+
+    private static async Task<IReadOnlyList<DifferentialResult>> RunAsync()
+    {
+        var results = new List<DifferentialResult>();
+
+        foreach (var entry in LegacyCorpus.Entries)
+        {
+            var compilation = await CorpusCompiler.CompileAsync(entry);
+            var legacy = SqlShapeCanonicalizer.Canonicalize(entry.LegacySql);
+
+            if (!compilation.Succeeded)
+            {
+                results.Add(new DifferentialResult(entry, compilation, legacy, null, null));
+                continue;
+            }
+
+            var compiled = SqlShapeCanonicalizer.Canonicalize(compilation.Sql!);
+            results.Add(new DifferentialResult(entry, compilation, legacy, compiled, ShapeComparison.Compare(legacy, compiled)));
+        }
+
+        return results;
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/QueryScope.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/QueryScope.cs
@@ -1,0 +1,33 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>Accumulates what one CTE or top-level SELECT reads, filters, and combines.</summary>
+internal sealed class QueryScope
+{
+    public List<string> Tables { get; } = [];
+
+    public List<string> Dependencies { get; } = [];
+
+    public List<string> Filters { get; } = [];
+
+    public List<string> Operations { get; } = [];
+
+    public void AddTableOrDependency(string name)
+    {
+        if (name.StartsWith("dbo.", StringComparison.OrdinalIgnoreCase))
+        {
+            Tables.Add(name["dbo.".Length..]);
+            return;
+        }
+
+        // An unqualified name inside these queries is always a reference to another CTE
+        // (or to the @FilteredData table variable the shipping engine materializes).
+        Dependencies.Add(name);
+    }
+
+    public SqlShapeNode ToNode(string name) => new(
+        name,
+        [.. Tables.Order(StringComparer.Ordinal)],
+        [.. Dependencies.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)],
+        [.. Filters.Order(StringComparer.Ordinal)],
+        [.. Operations.Order(StringComparer.Ordinal)]);
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/QueryWalker.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/QueryWalker.cs
@@ -1,0 +1,279 @@
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// Recursive descent over a query expression, recording tables, semantic filters, and set operations
+/// into a <see cref="QueryScope"/>. Subqueries (EXISTS bodies, NOT IN bodies) fold into the same scope
+/// with a "sub:" marker, because that is where the shipping engine puts semantics the compiler puts in
+/// a CTE of its own.
+/// </summary>
+internal static class QueryWalker
+{
+    public static void Walk(QueryExpression query, QueryScope scope)
+    {
+        switch (query)
+        {
+            case QueryParenthesisExpression parenthesis:
+                Walk(parenthesis.QueryExpression, scope);
+                break;
+
+            case BinaryQueryExpression binary:
+                var setOperator = binary.BinaryQueryExpressionType switch
+                {
+                    BinaryQueryExpressionType.Union => "union",
+                    BinaryQueryExpressionType.Except => "except",
+                    BinaryQueryExpressionType.Intersect => "intersect",
+                    _ => "set-op",
+                };
+                scope.Operations.Add(binary.All ? setOperator + "-all" : setOperator);
+                Walk(binary.FirstQueryExpression, scope);
+                Walk(binary.SecondQueryExpression, scope);
+                break;
+
+            case QuerySpecification specification:
+                WalkSpecification(specification, scope);
+                break;
+        }
+    }
+
+    private static void WalkSpecification(QuerySpecification specification, QueryScope scope)
+    {
+        if (specification.UniqueRowFilter == UniqueRowFilter.Distinct)
+        {
+            scope.Operations.Add("distinct");
+        }
+
+        if (specification.TopRowFilter is not null)
+        {
+            scope.Operations.Add("top");
+        }
+
+        if (specification.OrderByClause is not null)
+        {
+            scope.Operations.Add("order-by");
+        }
+
+        foreach (var element in specification.SelectElements)
+        {
+            WalkSelectElement(element, scope);
+        }
+
+        if (specification.FromClause is not null)
+        {
+            foreach (var reference in specification.FromClause.TableReferences)
+            {
+                WalkTableReference(reference, scope);
+            }
+        }
+
+        if (specification.WhereClause is not null)
+        {
+            WalkBoolean(specification.WhereClause.SearchCondition, scope, nested: false);
+        }
+    }
+
+    private static void WalkSelectElement(SelectElement element, QueryScope scope)
+    {
+        if (element is not SelectScalarExpression scalar)
+        {
+            return;
+        }
+
+        foreach (var function in Descendants<FunctionCall>(scalar))
+        {
+            if (AggregateName(function) is { } name)
+            {
+                scope.Operations.Add(name);
+            }
+        }
+    }
+
+    private static void WalkTableReference(TableReference reference, QueryScope scope)
+    {
+        switch (reference)
+        {
+            case NamedTableReference named:
+                scope.AddTableOrDependency(Name(named.SchemaObject));
+                break;
+
+            case QualifiedJoin join:
+                scope.Operations.Add(join.QualifiedJoinType == QualifiedJoinType.Inner ? "inner-join" : "outer-join");
+                WalkTableReference(join.FirstTableReference, scope);
+                WalkTableReference(join.SecondTableReference, scope);
+                if (join.SearchCondition is not null)
+                {
+                    WalkBoolean(join.SearchCondition, scope, nested: false);
+                }
+
+                break;
+
+            case QueryDerivedTable derived:
+                Walk(derived.QueryExpression, scope);
+                break;
+
+            case JoinParenthesisTableReference parenthesis:
+                WalkTableReference(parenthesis.Join, scope);
+                break;
+        }
+    }
+
+    private static void WalkBoolean(BooleanExpression expression, QueryScope scope, bool nested)
+    {
+        switch (expression)
+        {
+            case BooleanParenthesisExpression parenthesis:
+                WalkBoolean(parenthesis.Expression, scope, nested);
+                break;
+
+            case BooleanBinaryExpression binary:
+                if (binary.BinaryExpressionType == BooleanBinaryExpressionType.Or)
+                {
+                    scope.Operations.Add("or");
+                }
+
+                WalkBoolean(binary.FirstExpression, scope, nested);
+                WalkBoolean(binary.SecondExpression, scope, nested);
+                break;
+
+            case BooleanNotExpression not:
+                scope.Operations.Add("not");
+                WalkBoolean(not.Expression, scope, nested);
+                break;
+
+            case BooleanComparisonExpression comparison:
+                AddComparison(comparison, scope, nested);
+                break;
+
+            case BooleanIsNullExpression isNull:
+                scope.Filters.Add(Prefix(nested) + $"{Operand(isNull.Expression)} is{(isNull.IsNot ? "-not" : string.Empty)}-null");
+                break;
+
+            case ExistsPredicate exists:
+                scope.Operations.Add("exists");
+                WalkSubquery(exists.Subquery, scope);
+                break;
+
+            case InPredicate inPredicate:
+                scope.Operations.Add(inPredicate.NotDefined ? "not-in" : "in");
+                if (inPredicate.Subquery is not null)
+                {
+                    WalkSubquery(inPredicate.Subquery, scope);
+                }
+
+                break;
+
+            case LikePredicate like:
+                scope.Filters.Add(Prefix(nested) + $"{Operand(like.FirstExpression)} {(like.NotDefined ? "not-like" : "like")} {Operand(like.SecondExpression)}");
+                break;
+
+            case BooleanTernaryExpression ternary:
+                scope.Filters.Add(Prefix(nested) + $"{Operand(ternary.FirstExpression)} between");
+                break;
+        }
+    }
+
+    private static void WalkSubquery(ScalarSubquery subquery, QueryScope scope)
+        => WalkSubquery(subquery.QueryExpression, scope);
+
+    private static void WalkSubquery(QueryExpression query, QueryScope scope)
+    {
+        var inner = new QueryScope();
+        Walk(query, inner);
+
+        scope.Tables.AddRange(inner.Tables.Select(t => "sub:" + t));
+        scope.Dependencies.AddRange(inner.Dependencies);
+        scope.Filters.AddRange(inner.Filters.Select(f => f.StartsWith("sub:", StringComparison.Ordinal) ? f : "sub:" + f));
+        scope.Operations.AddRange(inner.Operations.Where(o => o is not ("distinct" or "top" or "order-by")));
+    }
+
+    private static void AddComparison(BooleanComparisonExpression comparison, QueryScope scope, bool nested)
+    {
+        var left = Operand(comparison.FirstExpression);
+        var right = Operand(comparison.SecondExpression);
+
+        // Column-to-column equality is how a query stitches rows of one relation to another. The two
+        // dialects do that differently for identical semantics, so it is plumbing, not a filter.
+        if (left.StartsWith("col:", StringComparison.Ordinal) && right.StartsWith("col:", StringComparison.Ordinal))
+        {
+            scope.Operations.Add("correlate");
+            return;
+        }
+
+        var column = left.StartsWith("col:", StringComparison.Ordinal) ? left["col:".Length..] : left;
+        scope.Filters.Add(Prefix(nested) + $"{column} {Symbol(comparison.ComparisonType)} {right}");
+    }
+
+    private static string Prefix(bool nested) => nested ? "sub:" : string.Empty;
+
+    /// <summary>Names the aggregates worth reporting, case-insensitively -- the two dialects differ in casing.</summary>
+    private static string? AggregateName(FunctionCall function)
+    {
+        var name = function.FunctionName.Value;
+        if (string.Equals(name, "count_big", StringComparison.OrdinalIgnoreCase))
+        {
+            return "count-big";
+        }
+
+        if (string.Equals(name, "count", StringComparison.OrdinalIgnoreCase))
+        {
+            return "count";
+        }
+
+        return string.Equals(name, "row_number", StringComparison.OrdinalIgnoreCase) ? "row-number" : null;
+    }
+
+    private static string FunctionOperand(FunctionCall function)
+        => "fn:" + (AggregateName(function) ?? function.FunctionName.Value);
+
+    private static string Operand(ScalarExpression expression) => expression switch
+    {
+        ColumnReferenceExpression column => "col:" + column.MultiPartIdentifier.Identifiers[^1].Value,
+        IntegerLiteral or NumericLiteral or RealLiteral => "<n>",
+        StringLiteral => "<s>",
+        BinaryLiteral => "<b>",
+        NullLiteral => "<null>",
+        VariableReference => "@p",
+        FunctionCall function => FunctionOperand(function),
+        ConvertCall => "fn:convert",
+        CastCall => "fn:cast",
+        UnaryExpression unary => Operand(unary.Expression),
+        BinaryExpression binary => $"({Operand(binary.FirstExpression)} op {Operand(binary.SecondExpression)})",
+        _ => "<expr>",
+    };
+
+    private static string Symbol(BooleanComparisonType type) => type switch
+    {
+        BooleanComparisonType.Equals => "=",
+        BooleanComparisonType.NotEqualToBrackets or BooleanComparisonType.NotEqualToExclamation => "<>",
+        BooleanComparisonType.GreaterThan => ">",
+        BooleanComparisonType.GreaterThanOrEqualTo => ">=",
+        BooleanComparisonType.LessThan => "<",
+        BooleanComparisonType.LessThanOrEqualTo => "<=",
+        _ => type.ToString(),
+    };
+
+    private static string Name(SchemaObjectName name) => name.SchemaIdentifier is null
+        ? name.BaseIdentifier.Value
+        : $"{name.SchemaIdentifier.Value}.{name.BaseIdentifier.Value}";
+
+    private static IEnumerable<T> Descendants<T>(TSqlFragment fragment)
+        where T : TSqlFragment
+    {
+        var found = new List<T>();
+        fragment.Accept(new Collector<T>(found));
+        return found;
+    }
+
+    private sealed class Collector<T>(List<T> found) : TSqlFragmentVisitor
+        where T : TSqlFragment
+    {
+        public override void Visit(TSqlFragment node)
+        {
+            if (node is T typed)
+            {
+                found.Add(typed);
+            }
+        }
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/README.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/README.md
@@ -1,0 +1,58 @@
+# Legacy SQL differential corpus
+
+185 real FHIR searches, each paired with the SQL the **shipping** search engine actually executed for
+it, captured during a TestScript conformance run. The suite compiles each URL with
+`Ignixa.Search.Sql` and compares what the two engines ask the database for.
+
+The point is **triage, not parity**. The shipping engine is a reference, not an oracle: a divergence
+is a question — a feature the compiler lacks, a table read the compiler avoids, or a filter the
+shipping engine applies for a reason worth understanding — and some divergences are wins we should
+keep. Only two things are asserted: every captured legacy query still parses, and no fewer queries
+compile than `DifferentialBaseline.CompiledQueries`.
+
+## Running it
+
+```bash
+dotnet test test/Ignixa.Search.Sql.Tests --filter "FullyQualifiedName~Corpus"
+```
+
+The report lands at `legacy-sql-differential-report.md` in the test output directory. A snapshot for
+review lives in `reports/differential-report.md`.
+
+## Refreshing the corpus
+
+```bash
+python Corpus/tools/extract-corpus.py <ignixa-sql-capture-artifact-dir>
+```
+
+The capture correlates SQL to requests by timestamp window, so a request can pick up a neighbour's
+SQL. Every SQL event of a request carries the whole batch text, so the request's own query appears on
+several events while a leaked neighbour appears on one — the extractor keeps the modal text per URL
+and drops entries with fewer than two corroborating events.
+
+## What comparison ignores, and why
+
+Byte comparison is meaningless here: the two dialects express the same set algebra with different
+syntax, and the compiler's result contract differs from the shipping engine's by design. Comparison
+therefore runs on whole-query multisets of *tables read* and *semantic filters applied*, with these
+deliberately erased:
+
+| Erased | Why |
+|---|---|
+| Row hydration (`JOIN dbo.Resource` + `IsHistory`/`IsDeleted` in the terminal SELECT) | The compiler returns identity columns and leaves the fetch to its caller. Resource-column filters in that same SELECT (`_id`, `_type`, `_lastUpdated`) still count. |
+| CTE boundaries | The shipping engine folds an intersection into the next source CTE as a correlated `EXISTS`; the compiler emits a separate `INNER JOIN` CTE. Same semantics. |
+| Subquery vs CTE placement (`sub:` marker) | `NOT IN (SELECT ...)` versus a dedicated except CTE — same tables, same filters. |
+| Literal values, and parameter-versus-literal | The captured ids come from a live catalog that no longer exists, so both sides' integers are erased. Whether a value is bound or inlined is parameterization policy. |
+| Column-to-column comparisons | Row correlation plumbing, which the two dialects do differently for identical semantics. |
+| Set operators | Reported, never verdict-deciding: `EXISTS` vs `INNER JOIN`, `NOT IN` vs `NOT EXISTS`. |
+
+## What it can't tell you
+
+- **Search-parameter identity.** Legacy ids are opaque integers with no name map in the capture, so
+  "both sides filter *a* SearchParamId" is verifiable; "both sides filter *the same* parameter" is
+  not. Unifying the ids across the corpus would fix this and has not been done.
+- **Row-level correctness.** Nothing executes. Two shapes that read the same tables with the same
+  filters can still return different rows.
+- **Deep coverage.** The corpus is broad but shallow: heavy on `_tag`-scoped and plain-parameter
+  searches, with only two chained queries, one `_has`, and one `_sort`. It is a smoke net over real
+  traffic, not a replacement for the per-rule unit matrix.

--- a/test/Ignixa.Search.Sql.Tests/Corpus/ShapeComparison.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/ShapeComparison.cs
@@ -1,0 +1,72 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// A multiset comparison of two shapes. Tables and filters decide the verdict; operations are reported
+/// but never decide it, because the two dialects legitimately express the same set algebra with
+/// different operators (correlated EXISTS versus INNER JOIN, NOT IN versus NOT EXISTS).
+/// </summary>
+public sealed record ShapeComparison(
+    ShapeVerdict Verdict,
+    IReadOnlyList<string> OnlyInLegacy,
+    IReadOnlyList<string> OnlyInCompiler,
+    IReadOnlyList<string> OperationDifferences)
+{
+    public static ShapeComparison Compare(SqlShape legacy, SqlShape compiler)
+    {
+        ArgumentNullException.ThrowIfNull(legacy);
+        ArgumentNullException.ThrowIfNull(compiler);
+
+        var onlyInLegacy = new List<string>();
+        var onlyInCompiler = new List<string>();
+
+        Subtract("table", legacy.Tables, compiler.Tables, onlyInLegacy, onlyInCompiler);
+        Subtract("filter", legacy.Filters, compiler.Filters, onlyInLegacy, onlyInCompiler);
+
+        var operations = new List<string>();
+        var left = new List<string>();
+        var right = new List<string>();
+        Subtract("op", legacy.Operations, compiler.Operations, left, right);
+        operations.AddRange(left.Select(o => "legacy: " + o));
+        operations.AddRange(right.Select(o => "compiler: " + o));
+
+        return new ShapeComparison(Decide(onlyInLegacy, onlyInCompiler), onlyInLegacy, onlyInCompiler, operations);
+    }
+
+    private static ShapeVerdict Decide(List<string> onlyInLegacy, List<string> onlyInCompiler) =>
+        (onlyInLegacy.Count, onlyInCompiler.Count) switch
+        {
+            (0, 0) => ShapeVerdict.Match,
+            (> 0, 0) => ShapeVerdict.CompilerDoesLess,
+            (0, > 0) => ShapeVerdict.CompilerDoesMore,
+            _ => ShapeVerdict.Divergent,
+        };
+
+    private static void Subtract(
+        string kind,
+        IReadOnlyDictionary<string, int> legacy,
+        IReadOnlyDictionary<string, int> compiler,
+        List<string> onlyInLegacy,
+        List<string> onlyInCompiler)
+    {
+        foreach (var (key, count) in legacy.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            var surplus = count - (compiler.TryGetValue(key, out var mirrored) ? mirrored : 0);
+            if (surplus > 0)
+            {
+                onlyInLegacy.Add(Format(kind, key, surplus));
+            }
+        }
+
+        foreach (var (key, count) in compiler.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            var surplus = count - (legacy.TryGetValue(key, out var mirrored) ? mirrored : 0);
+            if (surplus > 0)
+            {
+                onlyInCompiler.Add(Format(kind, key, surplus));
+            }
+        }
+    }
+
+    private static string Format(string kind, string key, int surplus)
+        => surplus == 1 ? $"{kind} {key}" : $"{kind} {key} (x{surplus})";
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/ShapeVerdict.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/ShapeVerdict.cs
@@ -1,0 +1,20 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>How the compiler's SQL relates to the shipping engine's for the same query.</summary>
+public enum ShapeVerdict
+{
+    /// <summary>The compiler could not produce SQL at all -- a feature gap.</summary>
+    NotCompiled,
+
+    /// <summary>Same tables, same semantic filters. Any remaining difference is encoding.</summary>
+    Match,
+
+    /// <summary>The compiler reads or filters strictly less than the shipping engine does.</summary>
+    CompilerDoesLess,
+
+    /// <summary>The compiler reads or filters strictly more than the shipping engine does.</summary>
+    CompilerDoesMore,
+
+    /// <summary>Each side does something the other does not.</summary>
+    Divergent,
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/SqlShape.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/SqlShape.cs
@@ -1,0 +1,22 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// A dialect-independent description of what a search query actually asks the database for: which
+/// index tables it reads, which semantic filters it applies, and which set operations combine them.
+///
+/// The two dialects under comparison express the same semantics with different syntax -- the shipping
+/// engine folds an intersection into the next source CTE as a correlated EXISTS, the compiler emits a
+/// separate INNER JOIN CTE -- so CTE-by-CTE equality is meaningless. The multisets below are collected
+/// over the whole statement, which makes those encoding choices invisible while keeping every semantic
+/// difference (an extra table read, a missing filter, a different set operation) visible.
+/// </summary>
+public sealed record SqlShape(
+    IReadOnlyList<SqlShapeNode> Nodes,
+    IReadOnlyDictionary<string, int> Tables,
+    IReadOnlyDictionary<string, int> Filters,
+    IReadOnlyDictionary<string, int> Operations)
+{
+    public int CteCount => Nodes.Count(n => n.Name.StartsWith("cte", StringComparison.OrdinalIgnoreCase));
+
+    public string Describe() => string.Join("\n", Nodes.Select(n => n.Describe()));
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/SqlShapeCanonicalizer.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/SqlShapeCanonicalizer.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// Turns either dialect's SQL text into a <see cref="SqlShape"/> using the real SQL Server grammar.
+/// Literals are erased to their kind (&lt;n&gt;, &lt;s&gt;, @p) so surrogate ids and user values never
+/// drive a comparison, and column-to-column comparisons are classified as correlation plumbing rather
+/// than semantic filters -- the two dialects correlate rows differently for identical semantics.
+/// </summary>
+public static class SqlShapeCanonicalizer
+{
+    public static SqlShape Canonicalize(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        var parser = new TSql160Parser(initialQuotedIdentifiers: false);
+        using var reader = new StringReader(sql);
+        var fragment = parser.Parse(reader, out IList<ParseError> errors);
+
+        if (errors.Count > 0)
+        {
+            var detail = string.Join("; ", errors.Select(e => $"L{e.Line}:{e.Column} {e.Message}"));
+            throw new FormatException($"SQL did not parse: {detail}");
+        }
+
+        var nodes = new List<SqlShapeNode>();
+        var collector = new StatementCollector(nodes);
+        fragment.Accept(collector);
+
+        return new SqlShape(
+            nodes,
+            Tally(nodes.SelectMany(Tables).Select(ForComparison)),
+            Tally(nodes.SelectMany(Filters).Select(ForComparison)),
+            Tally(nodes.SelectMany(n => n.Operations)));
+    }
+
+    /// <summary>
+    /// Row hydration is where the two dialects part company by design: the shipping engine's terminal
+    /// SELECT joins dbo.Resource to fetch RawResource, the compiler returns identity columns and leaves
+    /// the fetch to its caller. Only that join is excluded -- the rest of the terminal SELECT still
+    /// counts, because it is where the compiler puts the resource-column filters (_id, _type,
+    /// _lastUpdated) it lifts out of the CTE graph.
+    /// </summary>
+    private static bool IsHydration(SqlShapeNode node) => node.Name.StartsWith("select", StringComparison.Ordinal);
+
+    private static IEnumerable<string> Tables(SqlShapeNode node)
+        => IsHydration(node) ? node.Tables.Where(t => t != "Resource") : node.Tables;
+
+    private static IEnumerable<string> Filters(SqlShapeNode node)
+        => IsHydration(node)
+            ? node.Filters.Where(f => !f.StartsWith("IsHistory", StringComparison.Ordinal) && !f.StartsWith("IsDeleted", StringComparison.Ordinal))
+            : node.Filters;
+
+    /// <summary>
+    /// Erases two further encoding choices before comparison. Whether a read sits in a subquery or in a
+    /// CTE of its own is the difference between the shipping engine's `NOT IN (SELECT ...)` and the
+    /// compiler's dedicated except CTE -- same tables, same filters. And whether a value arrives as a
+    /// bound parameter or an inlined literal is a parameterization policy, not a question the query asks
+    /// the database differently; the value itself is already erased on both sides.
+    /// </summary>
+    private static string ForComparison(string item)
+    {
+        var stripped = item.StartsWith("sub:", StringComparison.Ordinal) ? item["sub:".Length..] : item;
+        return stripped.Replace("@p", "<v>", StringComparison.Ordinal).Replace("<n>", "<v>", StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, int> Tally(IEnumerable<string> values)
+    {
+        var tally = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            tally[value] = tally.TryGetValue(value, out var count) ? count + 1 : 1;
+        }
+
+        return tally;
+    }
+
+    /// <summary>Walks named CTEs and top-level SELECTs, turning each into one shape node.</summary>
+    private sealed class StatementCollector(List<SqlShapeNode> nodes) : TSqlFragmentVisitor
+    {
+        private int _selectOrdinal;
+
+        public override void Visit(CommonTableExpression node)
+        {
+            var scope = new QueryScope();
+            QueryWalker.Walk(node.QueryExpression, scope);
+            nodes.Add(scope.ToNode(node.ExpressionName.Value));
+        }
+
+        public override void Visit(SelectStatement node)
+        {
+            // A SELECT that owns CTEs contributes only its own body here; each CTE is visited separately.
+            var scope = new QueryScope();
+            QueryWalker.Walk(node.QueryExpression, scope);
+            nodes.Add(scope.ToNode($"select{_selectOrdinal++}"));
+        }
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/SqlShapeNode.cs
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/SqlShapeNode.cs
@@ -1,0 +1,40 @@
+namespace Ignixa.Search.Sql.Tests.Corpus;
+
+/// <summary>
+/// One named CTE (or the final SELECT) of a canonicalized query, kept for the human-readable side of
+/// the differential report. Comparison itself runs on <see cref="SqlShape"/>'s whole-query multisets,
+/// because the two dialects draw CTE boundaries in different places for the same semantics.
+/// </summary>
+public sealed record SqlShapeNode(
+    string Name,
+    IReadOnlyList<string> Tables,
+    IReadOnlyList<string> Dependencies,
+    IReadOnlyList<string> Filters,
+    IReadOnlyList<string> Operations)
+{
+    public string Describe()
+    {
+        var parts = new List<string>();
+        if (Tables.Count > 0)
+        {
+            parts.Add(string.Join("+", Tables));
+        }
+
+        if (Dependencies.Count > 0)
+        {
+            parts.Add($"<-{string.Join(",", Dependencies)}");
+        }
+
+        if (Filters.Count > 0)
+        {
+            parts.Add(string.Join(" ", Filters));
+        }
+
+        if (Operations.Count > 0)
+        {
+            parts.Add($"[{string.Join(",", Operations)}]");
+        }
+
+        return $"{Name} = {string.Join("  ", parts)}";
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/legacy-sql-corpus.json
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/legacy-sql-corpus.json
@@ -1,0 +1,6347 @@
+{
+ "captureRunId": "20260722-233014-6c1b78f0",
+ "entryCount": 185,
+ "entries": [
+  {
+   "url": "/AllergyIntolerance?category=medication&category=biologic&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 44\n        AND Code = @p0\n        AND ResourceTypeId = 4 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 44\n        AND Code = @p1\n        AND ResourceTypeId = 4 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 4 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH zBtLfZYLid0Aj4+LgSQOVHI4rwLpDjBVzTZK6KHFAWY= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "medication"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "biologic"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\array-joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/AllergyIntolerance?category=medication,biologic&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 44\n        AND ((Code = @p0)\n        OR (Code = @p1)) \n        AND ResourceTypeId = 4 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 4 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH zBtLfZYLid0Aj4+LgSQOVHI4rwLpDjBVzTZK6KHFAWY= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "medication"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "biologic"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\array-joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DiagnosticReport?specimen:missing=true&_id=ignixa-inc-dr1&_include=DiagnosticReport:result",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 40\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 40\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.ReferenceSearchParam\n        WHERE SearchParamId = 412 \n            AND ResourceTypeId = 40 \n    )\n)\n,cte3 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte2\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte3\n;WITH cte3 AS (SELECT * FROM @FilteredData)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 410\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (40)\n        AND EXISTS (SELECT * FROM cte3 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte3\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte3 WHERE cte3.Sid1 = cte5.Sid1 AND cte3.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-dr1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference/$docref?patient=ignixa-docref-pat0",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 445\n        AND ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId IS NULL))  \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH /0XnlNCBiiOVCpbSX6WX4dXxxmDbjSyeDX4teiQt5a8= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-docref-pat0"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\docref-operation.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/DocumentReference/$docref?patient=ignixa-docref-pat0&type=http://loinc.org%7C55107-7",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 445\n        AND ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId IS NULL))  \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 207\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH kuHuKsU7XCCN/Ss3iMYKHUo9FBRSXLiaPGc5M1f7EAw= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-docref-pat0"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "55107-7"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\docref-operation.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference/$docref?patient=ignixa-docref-pat0&unknown=unknownvalue",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 445\n        AND ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId IS NULL))  \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH /0XnlNCBiiOVCpbSX6WX4dXxxmDbjSyeDX4teiQt5a8= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-docref-pat0"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\docref-operation.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference/$docref?patient=ignixa-docref-pat0,ignixa-docref-pat1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 445\n        AND ((ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId IS NULL))  )\n        OR (ReferenceResourceId = @p1\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId IS NULL))  )) \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH gNDmMooRpzvNwSJxVaid6MICyn5R9TMri9z+i5DWre0= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-docref-pat0"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-docref-pat1"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\docref-operation.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/example-appends$appends&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND Code2 = @p1 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH jgUIZJK7C3cYz4Pl9BMVBxLkfZFFGqHTaPFA6Vb832s= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "example-appends"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "appends"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/example-appends$http://hl7.org/fhir/document-relationship-type%7Cappends&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND SystemId2 = @p1\n        AND Code2 = @p2 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH ofUsg5y3mSHK17qETqVcXTUptIN+g1svWSRkjWALKmw= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "example-appends"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "86"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "appends"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/example-appends$replaces&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND Code2 = @p1 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH DGS10goYmQv8Wrv1B6DHYdg05bQk3QXP0LKUSSyidZ0= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "example-appends"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "replaces"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/example-replaces$replaces&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND Code2 = @p1 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OGAnfLoaAP4GBLIdePSQVvQ4wX3pDmmlm551ejp6cFU= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "example-replaces"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "replaces"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/ignixa-impsrch-comp-docref-a$appends&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND Code2 = @p1 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH DXtG/Iau/8ejkuPGo1/kkraOGEkPRQwdL4taVpZ1OHY= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-comp-docref-a"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "appends"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 12,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/DocumentReference?relationship=DocumentReference/ignixa-impsrch-comp-docref-a$replaces&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceTokenCompositeSearchParam\n    WHERE SearchParamId = 441\n        AND ReferenceResourceTypeId1 = 42\n        AND ReferenceResourceId1 = @p0\n        AND Code2 = @p1 \n        AND ResourceTypeId = 42 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 42 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH Zub24hefEBWR/LKzKGsDzT83O6efqFTl2xPFCK2IG1s= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-comp-docref-a"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "replaces"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/HealthcareService?_id=ignixa-id-a,ignixa-id-b,ignixa-id-c&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 60\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 625\n        AND Code = @p1\n        AND ResourceTypeId = 60 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OYnLigphDj8pA5ZOv+5vbeoeo1cDocsTRgUyA+/ngfs= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {},
+   "sourceScripts": [
+    "Search\\id.json"
+   ],
+   "corroboratingEvents": 2,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/HealthcareService?_id=ignixa-id-b&active=true",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 60\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 625\n        AND Code = @p1\n        AND ResourceTypeId = 60 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OYnLigphDj8pA5ZOv+5vbeoeo1cDocsTRgUyA+/ngfs= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-id-b"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "true"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\id.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/HealthcareService?_id=ignixa-id-c&active=true",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 60\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 625\n        AND Code = @p1\n        AND ResourceTypeId = 60 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OYnLigphDj8pA5ZOv+5vbeoeo1cDocsTRgUyA+/ngfs= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-id-c"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "true"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\id.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/HealthcareService?active:not=false&name:missing=false&_has:PractitionerRole:service:active=true&identifier=http://ignixa.io/testscript/suite/escape%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT refSource.ResourceTypeId AS T2, refSource.ResourceSurrogateId AS Sid2, refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1 \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1076\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (109)\n        AND refSource.ReferenceResourceTypeId IN (60)\n        AND refTarget.ResourceTypeId = 60\n)\n,cte1 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.TokenSearchParam\n         JOIN cte0 ON ResourceTypeId = T2 AND ResourceSurrogateId = Sid2\n    WHERE SearchParamId = 1068\n        AND Code = @p0\n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n         JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE SearchParamId = 629\n        AND SystemId = @p1\n        AND ResourceTypeId = 60 \n)\n,cte3 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n         JOIN cte2 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE SearchParamId = 631 \n        AND ResourceTypeId = 60 \n)\n,cte4 AS\n(\n    SELECT T1, Sid1\n    FROM cte3\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 625\n            AND Code = @p2\n            AND ResourceTypeId = 60 \n    )\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte4\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH r0sROFaGpysWAs8t1v3al1WpGy2IgvF7z+BgX2ecMjU= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte5 ON r.ResourceTypeId = cte5.T1 AND r.ResourceSurrogateId = cte5.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "true"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "98"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "false"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\escape-characters.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Location?_id=ignixa-inc-loc-self&_include=Location:partof",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 71\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 771\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (71)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-loc-self"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/MedicationDispense?_id=ignixa-inco-md1&_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:subject&_includesCount=1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 77\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 868\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (77)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 864\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (79)\n        AND EXISTS (SELECT * FROM cte3 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p8 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inco-md1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-includes-operation.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 2
+  },
+  {
+   "url": "/Observation?_id=ignixa-inc-obs1&_include=Observation:performer",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 96\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 966\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (96)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-obs1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?_id=ignixa-inc-obs1&_include=Observation:subject&_include:iterate=Patient:general-practitioner",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 96\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 969\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (96)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1012\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte3 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p8 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-obs1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?_id=ignixa-inc-obs1&_include=Observation:subject&_include:iterate=Patient:organization",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 96\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 969\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (96)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1017\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte3 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p8 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-obs1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?_profile=http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab%7C1%23fragment&_count=50",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 1214\n        AND Uri = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH jpOQ9g9K3UV/taELxX1iyHJnw9/xdcVoQJVs1bqrdRU= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab|1#fragment"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "51"
+    }
+   },
+   "sourceScripts": [
+    "Search\\canonical.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?_profile=http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab%7C2&_count=50",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 1214\n        AND Uri = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 62Gp3twNvNXme60lqxFSs7ortDOKoFSODsQNSOC6xWA= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab|2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "51"
+    }
+   },
+   "sourceScripts": [
+    "Search\\canonical.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?_profile=http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab&_count=50",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 1214\n        AND Uri = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH aF36bR9IZJniVR1EZLwmbPkBGZ9OKAQ1rAM3rLW/VYo= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "51"
+    }
+   },
+   "sourceScripts": [
+    "Search\\canonical.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?_profile=http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab-alt&_count=50",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 1214\n        AND Uri = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH lqAt0WB52XeUCW6CPc4YYockWOkUiTUob3jmbhYSnrM= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.io/tests/StructureDefinition/ignixa-canonical-lab-alt"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "51"
+    }
+   },
+   "sourceScripts": [
+    "Search\\canonical.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?category:not=test&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1218\n        AND SystemId = @p0\n        AND Code = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 942\n            AND Code = @p2\n            AND ResourceTypeId = 96 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 6uMILcvu79g5TcdHRMwhDRdtOUVjJ3hmpGmRhNEhXlA= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "test"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?code-value-quantity=http://loinc.org%7C8310-5$gt38%7Chttp://unitsofmeasure.org%7CCel&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 945\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND SingleValue2 IS NOT NULL AND SingleValue2 > @p4 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 945\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND HighValue2 > @p4 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p5\n        AND Code = @p6 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH MkvT4KbsFJxjsFzUxjpSI6YSoeIyR1cG4mCRQnGOz+Y= params=@p0,@p1,@p2,@p3,@p4,@p5,@p6 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "decimal(36,18)",
+    "@p5": "int",
+    "@p6": "varchar(256)",
+    "@p7": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "8310-5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "73"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "1"
+    },
+    "@p4": {
+     "type": "decimal(36,18)",
+     "value": "38"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p6": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 16,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?code-value-string=162806009$Lorem%20ipsum%20dolor%20sit%20amet%20consectetur%20adipiscing%20elit.%20Ut%20eget%20ultricies%20justo.%20Maecenas%20bibendum%20convallis%20sodales.%20Vestibulum%20quis%20molestie%20dui.%20Nulla%20porta%20elementum%20tristique.%20Aenean%20neque%20libero%20convallis%20sit%20amet%20dui%20ullamcorper%20congue%20lacinia%20erat.%20Sed%20finibus%20ex%20ac%20massa%20tincidunt%20tristique.%20In%20sed%20auctor%20massa.%20Proin%20cursus%20porttitor%20arcu.%20Maecenas%20a%20leo%20nunc.%20Sed%20pretium%20porta%20volutpat.%20In%20aliquet%20tempor%20sapien%20vitae%20laoreet%20nisl%20tempor%20ac.%20Vestibulum%20lacus%20leo%20luctus%20vitae%20pharetra%20at%20tempus%20ac%20diam.%20Integer%20at%20dui%20eu%20dolor%20gravida%20vehicula.%20Phasellus%20malesuada%20elit%20orci%20quis%20maximus%20purus%20consectetur%20ac.%20In%20semper%20consequat%20augue%20sit%20amet%20ultricies.&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND Code1 = @p0\n        AND Text2 LIKE @p1\n        AND TextOverflow2 IS NOT NULL AND TextOverflow2 LIKE @p2  \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 1LH77HQ3gSYu9560kh4LGYcscU5Q8taaEf0brjXjEQE= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "nvarchar(max)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat.%'"
+    },
+    "@p2": {
+     "type": "nvarchar(max)",
+     "value": "N'Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultricies.%'"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code-value-string=162806009$Lorem%20ipsum%20dolor%20sit%20amet%20consectetur%20adipiscing%20elit.%20Ut%20eget%20ultricies%20justo.%20Maecenas%20bibendum%20convallis%20sodales.%20Vestibulum%20quis%20molestie%20dui.%20Nulla%20porta%20elementum%20tristique.%20Aenean%20neque%20libero%20convallis%20sit%20amet%20dui%20ullamcorper%20congue%20lacinia%20erat.%20Sed%20finibus%20ex%20ac%20massa%20tincidunt%20tristique.%20In%20sed%20auctor%20massa.%20Proin%20cursus%20porttitor%20arcu.%20Maecenas%20a%20leo%20nunc.%20Sed%20pretium%20porta%20volutpat.%20In%20aliquet%20tempor%20sapien%20vitae%20laoreet%20nisl%20tempor%20ac.%20Vestibulum%20lacus%20leo%20luctus%20vitae%20pharetra%20at%20tempus%20ac%20diam.%20Integer%20at%20dui%20eu%20dolor%20gravida%20vehicula.%20Phasellus%20malesuada%20elit%20orci%20quis%20maximus%20purus%20consectetur%20ac.%20In%20semper%20consequat%20augue%20sit%20amet%20ultriciesNot&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND Code1 = @p0\n        AND Text2 LIKE @p1\n        AND TextOverflow2 IS NOT NULL AND TextOverflow2 LIKE @p2  \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH uw+ptGGaknpHqOxo6GLqtd389tAB5PtX+iLGiLpHvcE= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "nvarchar(max)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat.%'"
+    },
+    "@p2": {
+     "type": "nvarchar(max)",
+     "value": "N'Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultriciesNot%'"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code-value-string=162806009$Lorem&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND Code1 = @p0\n        AND Text2 LIKE @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IfJE/yVzM/BbXvhFkVkkDh1H4XuJAd+ZxpaMO+NkF8k= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Lorem%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 10,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code-value-string=162806009$Lorem&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND Code1 = @p0\n        AND Text2 LIKE @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH KVtrj0Cg2AEx3SSpexWskZPmexo4mdQC5ioiyECLgbM= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Lorem%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code-value-string=162806009$Lorem,162806009$blue&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND ((Code1 = @p0\n        AND Text2 LIKE @p1 )\n        OR (Code1 = @p0\n        AND Text2 LIKE @p2 )) \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 56de8Gnzmpq1cVHfrm0kBNdYT9FpBM4gGVGESeYkxgE= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "nvarchar(256)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Lorem%'"
+    },
+    "@p2": {
+     "type": "nvarchar(256)",
+     "value": "N'blue%'"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code-value-string=http://snomed.info/sct%7C162806009$blue&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenStringCompositeSearchParam\n    WHERE SearchParamId = 946\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND Text2 LIKE @p2 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH FKG1SUIeWr0uu9eKw3i8nuj2qDPAWjhl/tlCQGNMaeA= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "nvarchar(256)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "162806009"
+    },
+    "@p2": {
+     "type": "nvarchar(256)",
+     "value": "N'blue%'"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code:text=aux&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenText\n    WHERE IsHistory = 0 \n        AND SearchParamId = 202\n        AND Text LIKE @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p1\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH yrif+LiA8zXulc7Jn6nbZFtVerJGaNiwVpwv+Zvl1BM= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(400)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(400)",
+     "value": "N'aux%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code:text=free&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenText\n    WHERE IsHistory = 0 \n        AND SearchParamId = 202\n        AND Text LIKE @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p1\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH HiHJus1S9f7m5+dag7ehHpEXJ3STLd6XyRwLJX+bYSU= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(400)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(400)",
+     "value": "N'free%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code=%7Ccode3&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND SystemId IS NULL\n        AND Code = @p0 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p1\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 4gBHytyyIYDeTePPJAciHpTb+5WGNNfAwrlZawxV9N0= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "code3"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code=code1,http://ignixa.io/testscript/suite/token-sys-b%7Ccode2&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND ((Code = @p0)\n        OR (SystemId = @p1\n        AND Code = @p2 )) \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p3\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH PwDIimwBgUNfNUUmOsZIsy764wINsj3xow0hcXXDZPo= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "code1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "105"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "code2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code=code3&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND Code = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p1\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 4gBHytyyIYDeTePPJAciHpTb+5WGNNfAwrlZawxV9N0= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "code3"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code=http://ignixa.io/testscript/suite/token-sys-a%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND SystemId = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH HKJ+6wmauZc8NeiAkY4L1DohIVKSf9Vp/JJi2TesC2w= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "103"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?code=ignixa-date-test&date=1980-05-16T16:32:15.500Z",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND Code = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 203\n        AND StartDateTime <= @p1\n        AND EndDateTime >= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 8mWvVPcmxdHuQZxisDs26RhaxBxu8ZDESZWzav3SPL8= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "datetime",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "ignixa-date-test"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\date.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?code=ignixa-date-test&date=gt1980-05-10&date=lt1980-05-12",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 202\n        AND Code = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 203\n        AND EndDateTime > @p1\n        AND StartDateTime < @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CFbMRSCxysLXuqWkcz2gWEEBYfO2/95nWFQUak+liOw= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "datetime",
+    "@p2": "datetime",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "ignixa-date-test"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\date.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://acme.ped/apgarcolor%7C1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p4\n        AND Code = @p5 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p6) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH aG9VOXSDAcrOc+hNqB4YNF602mrVcaxzIhwT3U4QSzI= params=@p0,@p1,@p2,@p3,@p4,@p5 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int",
+    "@p5": "varchar(256)",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "249227004"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "85"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "1"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p5": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://acme.ped/apgarcolor%7C2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p4\n        AND Code = @p5 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p6) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH aG9VOXSDAcrOc+hNqB4YNF602mrVcaxzIhwT3U4QSzI= params=@p0,@p1,@p2,@p3,@p4,@p5 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int",
+    "@p5": "varchar(256)",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "249227004"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "85"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "2"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p5": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 12,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6722-8&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p4\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 9dYS3LZbBCw/R4psYRqT7jxX/Ec/wzsApjCtJupF/Ig= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "249227004"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "93"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "LA6722-8"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6722-8,http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6724-4&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND ((SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 )\n        OR (SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p4 )) \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p5\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p6) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 40AgUBdpFSG7jXg4XywBG6gzfzMaXreD4TM/y8MOT1s= params=@p0,@p1,@p2,@p3,@p4,@p5 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "varchar(256)",
+    "@p5": "int",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "249227004"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "93"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "LA6722-8"
+    },
+    "@p4": {
+     "type": "varchar(256)",
+     "value": "LA6724-4"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6724-4&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p4\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH m+HZEd+HJLGfm1gkbNExmGNDlN2OKoiz5lBExwYVAIc= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "249227004"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "93"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "LA6724-4"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-concept=http://snomed.info/sct%7C443849008$http://loinc.org/la%7CLA6724-4&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenTokenCompositeSearchParam\n    WHERE SearchParamId = 948\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND Code2 = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p4\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CuACz413wNl8GEZl0cZwyTn6GRIv/L65UAIR+veG2HE= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "15"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "443849008"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "93"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "LA6724-4"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$107%7Chttp://unitsofmeasure.org%7Cmm%5BHg%5D&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND SingleValue2 IS NOT NULL AND SingleValue2 >= @p4\n        AND SingleValue2 IS NOT NULL AND SingleValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND HighValue2 >= @p4\n        AND LowValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p6\n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH jxxR+5Ku56gkitXmAI9PlHMjPfY4xYiywdd3y/1GfeA= params=@p0,@p1,@p2,@p3,@p4,@p5,@p6 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "decimal(36,18)",
+    "@p5": "decimal(36,18)",
+    "@p6": "int",
+    "@p7": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "8480-6"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "73"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "9"
+    },
+    "@p4": {
+     "type": "decimal(36,18)",
+     "value": "106.5"
+    },
+    "@p5": {
+     "type": "decimal(36,18)",
+     "value": "107.5"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$120%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND SingleValue2 IS NOT NULL AND SingleValue2 >= @p4\n        AND SingleValue2 IS NOT NULL AND SingleValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND HighValue2 >= @p4\n        AND LowValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p6\n        AND Code = @p7 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH SKUp3bp0ny03gZTPL3iHp16HsMm3uFYhGio7glF8Em0= params=@p0,@p1,@p2,@p3,@p4,@p5,@p6,@p7 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "decimal(36,18)",
+    "@p5": "decimal(36,18)",
+    "@p6": "int",
+    "@p7": "varchar(256)",
+    "@p8": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "8480-6"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "73"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "5"
+    },
+    "@p4": {
+     "type": "decimal(36,18)",
+     "value": "119.5"
+    },
+    "@p5": {
+     "type": "decimal(36,18)",
+     "value": "120.5"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p7": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$60&identifier=http://ignixa.io/testscript/suite/composite%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SingleValue2 IS NOT NULL AND SingleValue2 >= @p2\n        AND SingleValue2 IS NOT NULL AND SingleValue2 <= @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND HighValue2 >= @p2\n        AND LowValue2 <= @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p4\n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH d0HTYSYl7KmYvn9DD0EXL0tS8QqFX0/51uv2072SwZc= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "decimal(36,18)",
+    "@p3": "decimal(36,18)",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "8480-6"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "59.5"
+    },
+    "@p3": {
+     "type": "decimal(36,18)",
+     "value": "60.5"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "95"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\composite.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$80%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND SingleValue2 IS NOT NULL AND SingleValue2 >= @p4\n        AND SingleValue2 IS NOT NULL AND SingleValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenQuantityCompositeSearchParam\n    WHERE SearchParamId = 949\n        AND SystemId1 = @p0\n        AND Code1 = @p1\n        AND SystemId2 = @p2\n        AND QuantityCodeId2 = @p3\n        AND HighValue2 >= @p4\n        AND LowValue2 <= @p5 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p6\n        AND Code = @p7 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH wFbUQzKS42nWf5sBSyyPRqxsbW9jhuqFYEqpShHe5mI= params=@p0,@p1,@p2,@p3,@p4,@p5,@p6,@p7 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "decimal(36,18)",
+    "@p5": "decimal(36,18)",
+    "@p6": "int",
+    "@p7": "varchar(256)",
+    "@p8": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "6"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "8480-6"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "73"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "5"
+    },
+    "@p4": {
+     "type": "decimal(36,18)",
+     "value": "79.5"
+    },
+    "@p5": {
+     "type": "decimal(36,18)",
+     "value": "80.5"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p7": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?date=1980&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 203\n        AND StartDateTime <= @p0\n        AND EndDateTime >= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH F9LxMMmN3RXHIkxRhK3nZB5hYUw2ojAdpr2Il+HUtG0= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "datetime",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?date=1980-05-11&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 203\n        AND StartDateTime <= @p0\n        AND EndDateTime >= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH F9LxMMmN3RXHIkxRhK3nZB5hYUw2ojAdpr2Il+HUtG0= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "datetime",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?date=ge1981-01-01&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 203\n        AND EndDateTime >= @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH E8K4aSIEc5P7prlAoPMUNahGgsElRP6OOp5a6pDBxuc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?date=lt1980-05-11&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 203\n        AND StartDateTime < @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH E8K4aSIEc5P7prlAoPMUNahGgsElRP6OOp5a6pDBxuc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 96\n        AND NOT ((ResourceId = @p0)\n        OR (ResourceId = @p1))  \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p2\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH rqdakoAk02a61G+RCpKvSYk1Z7YVBEuH8jh4WO030Uk= params=@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-tok-o1"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-tok-o2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&code:not=http://ignixa.io/testscript/suite/token-sys-a%7Ccode1&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 205\n        AND SystemId = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 202\n            AND SystemId = @p1\n            AND Code = @p2 \n            AND ResourceTypeId = 96 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH pauwa6IbOfaJs6+2ukAlWDDPRSgQvBv5SgQdgFandQ8= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "104"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "103"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "code1"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?subject:Patient.family=Smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, refTarget.ResourceTypeId AS T2, refTarget.ResourceSurrogateId AS Sid2 \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 969\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (96)\n        AND refSource.ReferenceResourceTypeId IN (103)\n        AND refSource.ResourceTypeId = 96\n)\n,cte1 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.StringSearchParam\n         JOIN cte0 ON ResourceTypeId = T2 AND ResourceSurrogateId = Sid2\n    WHERE SearchParamId = 692\n        AND Text LIKE @p0\n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 205\n        AND SystemId = @p1\n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH obKWnu2N3G96V+fIcdxgspxtx1seiKEtI1ImSGTVfeM= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\chaining.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-concept:not=code1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1218\n        AND SystemId = @p0\n        AND Code = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 970\n            AND Code = @p2\n            AND ResourceTypeId = 96 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH FL5WMZOsgRJn9ZpBPH3/5aTEXLkePFE1X8tXqEOmu4o= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "code1"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-concept:text=text2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenText\n    WHERE IsHistory = 0 \n        AND SearchParamId = 970\n        AND Text LIKE @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH kV2OHUVZaIZT16Ki1F2GJ1E7qP7RFbvNaMGJPBX9aGg= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(400)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(400)",
+     "value": "N'text2%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-concept=%7Ccode3&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 970\n        AND SystemId IS NULL\n        AND Code = @p0 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xnBmhWkrgh0lZNK4B/yNJbww1K3RYXYcZdMBrjCFvVQ= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "code3"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-concept=code1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 970\n        AND Code = @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xnBmhWkrgh0lZNK4B/yNJbww1K3RYXYcZdMBrjCFvVQ= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "code1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-concept=system2%7Ccode2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 970\n        AND SystemId = @p0\n        AND Code = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH d7TNqUPy3UTfv5o+dcUryxNsTS1oYlUI9I/nWfP4eCk= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "82"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "code2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=2e-3&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7T7xH3ZkVSomeu9sLuP6DwO3f0F6G6rvZAGlFF0fg8g= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "0.0015"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "0.0025"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5%7C%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND QuantityCodeId = @p0\n        AND SingleValue IS NOT NULL AND SingleValue >= @p1\n        AND SingleValue IS NOT NULL AND SingleValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND QuantityCodeId = @p0\n        AND HighValue >= @p1\n        AND LowValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p3\n        AND Code = @p4 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IDd7FfJ2oYa2fQippmMr3r33IVv9cwXQGYNWqgwWh10= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "decimal(36,18)",
+    "@p2": "decimal(36,18)",
+    "@p3": "int",
+    "@p4": "varchar(256)",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "7"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p4": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5%7C%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND QuantityCodeId = @p0\n        AND SingleValue IS NOT NULL AND SingleValue >= @p1\n        AND SingleValue IS NOT NULL AND SingleValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND QuantityCodeId = @p0\n        AND HighValue >= @p1\n        AND LowValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p3\n        AND Code = @p4 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH ymf0A4mc5wDquK4wBLDkreMm4gY6D/clXBdgv2JdJ3w= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "decimal(36,18)",
+    "@p2": "decimal(36,18)",
+    "@p3": "int",
+    "@p4": "varchar(256)",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "7"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p4": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5%7Csystem1%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND QuantityCodeId = @p1\n        AND SingleValue IS NOT NULL AND SingleValue >= @p2\n        AND SingleValue IS NOT NULL AND SingleValue <= @p3 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND QuantityCodeId = @p1\n        AND HighValue >= @p2\n        AND LowValue <= @p3 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p4\n        AND Code = @p5 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p6) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH UUtZACpgCUp6OhF9//zEgIj/BRrUI4TwgCWdiFV1oFs= params=@p0,@p1,@p2,@p3,@p4,@p5 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int",
+    "@p2": "decimal(36,18)",
+    "@p3": "decimal(36,18)",
+    "@p4": "int",
+    "@p5": "varchar(256)",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "81"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "7"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p3": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p5": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5%7Csystem1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND SingleValue IS NOT NULL AND SingleValue >= @p1\n        AND SingleValue IS NOT NULL AND SingleValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND HighValue >= @p1\n        AND LowValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p3\n        AND Code = @p4 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IDd7FfJ2oYa2fQippmMr3r33IVv9cwXQGYNWqgwWh10= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "decimal(36,18)",
+    "@p2": "decimal(36,18)",
+    "@p3": "int",
+    "@p4": "varchar(256)",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "81"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p4": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5%7Csystem1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND SingleValue IS NOT NULL AND SingleValue >= @p1\n        AND SingleValue IS NOT NULL AND SingleValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SystemId = @p0\n        AND HighValue >= @p1\n        AND LowValue <= @p2 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p3\n        AND Code = @p4 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH ymf0A4mc5wDquK4wBLDkreMm4gY6D/clXBdgv2JdJ3w= params=@p0,@p1,@p2,@p3,@p4 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "decimal(36,18)",
+    "@p2": "decimal(36,18)",
+    "@p3": "int",
+    "@p4": "varchar(256)",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "81"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p2": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p4": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH uUF8caOU3EvGYqkh2QjAd2lt7c+EM9qgodDr9KfxaZY= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 10,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7T7xH3ZkVSomeu9sLuP6DwO3f0F6G6rvZAGlFF0fg8g= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?value-quantity=eb5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue < @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND LowValue < @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=eq5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7T7xH3ZkVSomeu9sLuP6DwO3f0F6G6rvZAGlFF0fg8g= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Observation?value-quantity=ge5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue >= @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=gt4.9&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH F9LxMMmN3RXHIkxRhK3nZB5hYUw2ojAdpr2Il+HUtG0= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.9"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue <= @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND LowValue <= @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=lt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue < @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND LowValue < @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND ((SingleValue IS NOT NULL AND SingleValue < @p0)\n        OR (SingleValue IS NOT NULL AND SingleValue > @p1)) \n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND ((LowValue < @p0)\n        OR (HighValue > @p1)) \n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7T7xH3ZkVSomeu9sLuP6DwO3f0F6G6rvZAGlFF0fg8g= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Observation?value-quantity=sa5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.QuantitySearchParam\n    WHERE SearchParamId = 972\n        AND HighValue > @p0\n        AND ResourceTypeId = 96 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 7V13oA8w7bUqkNnfj/OnRZaKlFpavnUNC6gmE6wFt14= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-qty-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\quantity.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Organization?_id=ignixa-inc-org-a&_include:iterate=Organization:partof",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 100\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 992\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (100)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p4 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-org-a"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient/ignixa-cmp-pat1/Observation?_include=Observation:performer:Practitioner&performer=Practitioner/ignixa-cmp-prac1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE ((SearchParamId = 969\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 71)\n        OR (ReferenceResourceTypeId IS NULL))  )\n        OR (SearchParamId = 966\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 100)\n        OR (ReferenceResourceTypeId = 15)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 109)\n        OR (ReferenceResourceTypeId = 114)\n        OR (ReferenceResourceTypeId IS NULL))  )) \n        AND ReferenceResourceTypeId = 103\n        AND ReferenceResourceId = @p0 \n),\ncte1 AS\n(\n    SELECT * FROM cte0\n), \ncte2 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.Resource\n         JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE IsHistory = 0 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n         JOIN cte2 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE SearchParamId = 966\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte4 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte3\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n/* HASH 91feGAo3uwnyh2g9TjXjieNqMOiKu6SWMDiww48WHBM= params=@p0,@p1 */\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte4\n;WITH cte4 AS (SELECT * FROM @FilteredData)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p3) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 966\n        AND refSource.ReferenceResourceTypeId = 108\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (96)\n        AND EXISTS (SELECT * FROM cte4 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p4)\n)\n,cte6 AS\n(\n    SELECT DISTINCT TOP (@p5) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p6 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte5\n)\n,cte7 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte4\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte6 WHERE NOT EXISTS (SELECT * FROM cte4 WHERE cte4.Sid1 = cte6.Sid1 AND cte4.T1 = cte6.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte7 ON r.ResourceTypeId = cte7.T1 AND r.ResourceSurrogateId = cte7.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-pat1"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-prac1"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\compartments.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient/ignixa-cmp-pat1/Observation?performer=Practitioner/ignixa-cmp-prac-other",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE ((SearchParamId = 969\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 71)\n        OR (ReferenceResourceTypeId IS NULL))  )\n        OR (SearchParamId = 966\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 100)\n        OR (ReferenceResourceTypeId = 15)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 109)\n        OR (ReferenceResourceTypeId = 114)\n        OR (ReferenceResourceTypeId IS NULL))  )) \n        AND ReferenceResourceTypeId = 103\n        AND ReferenceResourceId = @p0 \n),\ncte1 AS\n(\n    SELECT * FROM cte0\n), \ncte2 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.Resource\n         JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE IsHistory = 0 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE EXISTS (SELECT * FROM cte2 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 966\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte3\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH XUmMog1/pZGOXDPWaRwd+tlcEMHw5EAETihBBGg6vNg= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-pat1"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-prac-other"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\compartments.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient/ignixa-cmp-pat1/Observation?performer=Practitioner/ignixa-cmp-prac1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE ((SearchParamId = 969\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 58)\n        OR (ReferenceResourceTypeId = 35)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 71)\n        OR (ReferenceResourceTypeId IS NULL))  )\n        OR (SearchParamId = 966\n        AND ResourceTypeId = 96\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 100)\n        OR (ReferenceResourceTypeId = 15)\n        OR (ReferenceResourceTypeId = 103)\n        OR (ReferenceResourceTypeId = 109)\n        OR (ReferenceResourceTypeId = 114)\n        OR (ReferenceResourceTypeId IS NULL))  )) \n        AND ReferenceResourceTypeId = 103\n        AND ReferenceResourceId = @p0 \n),\ncte1 AS\n(\n    SELECT * FROM cte0\n), \ncte2 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.Resource\n         JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1\n    WHERE IsHistory = 0 \n        AND ResourceTypeId = 96 \n)\n,cte3 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE EXISTS (SELECT * FROM cte2 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 966\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p1 \n        AND ResourceTypeId = 96 \n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte3\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 91feGAo3uwnyh2g9TjXjieNqMOiKu6SWMDiww48WHBM= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-pat1"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-cmp-prac1"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\compartments.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient/ignixa-evx-pat/$everything?_count=100&foo=bar",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1012\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1017\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p7)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p9 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int",
+    "@p9": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-evx-pat"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p9": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\everything-operation.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient/ignixa-evx-pat/$everything?_since=3000",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1012\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1017\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p7)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p9 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int",
+    "@p9": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-evx-pat"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p9": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\everything-operation.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 2
+  },
+  {
+   "url": "/Patient/ignixa-evx-pat/$everything?_type=foo",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1012\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1017\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p7)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p9 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int",
+    "@p9": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-evx-pat"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p9": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\everything-operation.json"
+   ],
+   "corroboratingEvents": 8,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_expiryDate=gt2025&identifier=http://ignixa.io/testscript/suite/ms-param%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 1377\n        AND EndDateTime > @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2OUGuu02b68noSOHTb0Mo0p5Bsbk0mWqboloPV4iAgo= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p1": {
+     "type": "int",
+     "value": "80"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-search-parameter.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_expiryDate=lt2025&identifier=http://ignixa.io/testscript/suite/ms-param%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 1377\n        AND StartDateTime < @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH lFxRJk1PIpo67KzW3EJTYEWA/dEaNOzebktKYv9ULbQ= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p1": {
+     "type": "int",
+     "value": "80"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-search-parameter.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_id=880fb2d8-f23b-47a5-a398-0939a79a9c5e,63220610-3dac-4eff-af3f-a179f187758b,b0ac0bcb-9599-48d8-b688-c7612377c558,38bfef7f-1475-48f7-812f-35c31261fc46&birthdate=ge1980-01-01&birthdate=lt2000-01-01",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ((ResourceId = @p0)\n        OR (ResourceId = @p1)\n        OR (ResourceId = @p2)\n        OR (ResourceId = @p3))  \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 690\n        AND EndDateTime >= @p4\n        AND StartDateTime < @p5 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p6) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH p5+QvQK2f8A/68EG1iHX7kR5lRNMQBFWfrgIfmauOTU= params=@p4,@p5 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "varchar(64)",
+    "@p3": "varchar(64)",
+    "@p4": "datetime",
+    "@p5": "datetime",
+    "@p6": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "880fb2d8-f23b-47a5-a398-0939a79a9c5e"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "63220610-3dac-4eff-af3f-a179f187758b"
+    },
+    "@p2": {
+     "type": "varchar(64)",
+     "value": "b0ac0bcb-9599-48d8-b688-c7612377c558"
+    },
+    "@p3": {
+     "type": "varchar(64)",
+     "value": "38bfef7f-1475-48f7-812f-35c31261fc46"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_id=e04c1b8a-fe84-4111-8b44-34135571d0ec,512ffdc7-8292-4acb-a9e4-94f664dc30b4,cad0864f-c442-49e1-a0a0-a7554e334d02&_sort=-birthdate",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int, SortValue datetime2)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ((ResourceId = @p0)\n        OR (ResourceId = @p1)\n        OR (ResourceId = @p2))  \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1, StartDateTime AS SortValue\n    FROM dbo.DateTimeSearchParam\n    WHERE IsMax = 1\n        AND SearchParamId = 690 \n        AND ResourceTypeId = 103 \n        AND EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial , cte1.SortValue\n    FROM cte1\n    ORDER BY SortValue  DESC, Sid1 ASC\n)\n\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource, cte2.SortValue\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.SortValue DESC, t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "varchar(64)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "e04c1b8a-fe84-4111-8b44-34135571d0ec"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "512ffdc7-8292-4acb-a9e4-94f664dc30b4"
+    },
+    "@p2": {
+     "type": "varchar(64)",
+     "value": "cad0864f-c442-49e1-a0a0-a7554e334d02"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\sort.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 2
+  },
+  {
+   "url": "/Patient?_id=e5ec00b6-1167-49b3-a754-c2f8d57ab7cb",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 690\n        AND EndDateTime >= @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IEeuz3k6yb6zXFlW0zjiwaDnov4llwv+j51lo/CIj4E= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {},
+   "sourceScripts": [
+    "Search\\basic.json"
+   ],
+   "corroboratingEvents": 2,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_id=ignixa-inc-pat1&_include=*",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte4 ON r.ResourceTypeId = cte4.T1 AND r.ResourceSurrogateId = cte4.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inc-pat1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Search\\includes.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_id=ignixa-inco-p1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 77\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 868\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (77)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 864\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (79)\n        AND EXISTS (SELECT * FROM cte3 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p7) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p8 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int"
+   },
+   "parameterValues": {},
+   "sourceScripts": [
+    "Microsoft\\ms-includes-operation.json"
+   ],
+   "corroboratingEvents": 2,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refTarget.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refTarget.ResourceTypeId = T1 AND refTarget.ResourceSurrogateId = Sid1 AND Row < @p7)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p9 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int",
+    "@p9": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inco-p1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1000"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "1001"
+    },
+    "@p9": {
+     "type": "int",
+     "value": "1000"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-includes-operation.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 103\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT row_number() OVER (ORDER BY T1 ASC, Sid1 ASC) AS Row, *\n    FROM\n    (\n        SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n        FROM cte0\n        ORDER BY T1 ASC, Sid1 ASC\n    ) t\n)\n\nINSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row FROM cte1\n;WITH cte1 AS (SELECT * FROM @FilteredData)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p3)\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p5 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte2\n)\n,cte4 AS\n(\n    SELECT DISTINCT TOP (@p6) refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, 0 AS IsMatch, 0 AS IsPartial \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refTarget.ResourceTypeId IN (103)\n        AND EXISTS (SELECT * FROM cte1 WHERE refTarget.ResourceTypeId = T1 AND refTarget.ResourceSurrogateId = Sid1 AND Row < @p7)\n)\n,cte5 AS\n(\n    SELECT DISTINCT TOP (@p8) T1, Sid1, IsMatch, CASE WHEN count_big(*) over() > @p9 THEN 1 ELSE 0 END AS IsPartial \n    FROM cte4\n)\n,cte6 AS\n(\n    SELECT T1, Sid1, IsMatch, IsPartial \n    FROM cte1\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte3 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte3.Sid1 AND cte1.T1 = cte3.T1)\n    UNION ALL\n    SELECT T1, Sid1, IsMatch, IsPartial\n    FROM cte5 WHERE NOT EXISTS (SELECT * FROM cte1 WHERE cte1.Sid1 = cte5.Sid1 AND cte1.T1 = cte5.T1)\n)\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte6 ON r.ResourceTypeId = cte6.T1 AND r.ResourceSurrogateId = cte6.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY IsMatch DESC, (CASE WHEN IsMatch = 1 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 1 THEN t.ResourceSurrogateId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceTypeId ELSE NULL END) ASC, (CASE WHEN IsMatch = 0 THEN t.ResourceSurrogateId ELSE NULL END) ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "int",
+    "@p3": "int",
+    "@p4": "int",
+    "@p5": "int",
+    "@p6": "int",
+    "@p7": "int",
+    "@p8": "int",
+    "@p9": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-inco-p1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p5": {
+     "type": "int",
+     "value": "1"
+    },
+    "@p6": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p7": {
+     "type": "int",
+     "value": "11"
+    },
+    "@p8": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p9": {
+     "type": "int",
+     "value": "1"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-includes-operation.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_not-referenced=*:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND IsHistory = 0\n        AND IsDeleted = 0\n        AND NOT EXISTS \n        (\n            SELECT *\n            FROM (SELECT SourceResourceTypeId = ResourceTypeId, SearchParamId, ReferenceResourceId, ReferenceResourceTypeId FROM dbo.ReferenceSearchParam) R\n            WHERE ReferenceResourceId = ResourceId\n                AND ReferenceResourceTypeId = ResourceTypeId\n        )\n        \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH z/YR5v7LJkn+NjwNz3nLVWpZ0BMDgI6x+MDTCxAsvjw= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "79"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-referenced.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?_not-referenced=Observation:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND IsHistory = 0\n        AND IsDeleted = 0\n        AND NOT EXISTS \n        (\n            SELECT *\n            FROM (SELECT SourceResourceTypeId = ResourceTypeId, SearchParamId, ReferenceResourceId, ReferenceResourceTypeId FROM dbo.ReferenceSearchParam) R\n            WHERE ReferenceResourceId = ResourceId\n                AND ReferenceResourceTypeId = ResourceTypeId\n                AND SourceResourceTypeId = 96\n        )\n        \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH z/YR5v7LJkn+NjwNz3nLVWpZ0BMDgI6x+MDTCxAsvjw= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "79"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-referenced.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_not-referenced=Observation:subject&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND IsHistory = 0\n        AND IsDeleted = 0\n        AND NOT EXISTS \n        (\n            SELECT *\n            FROM (SELECT SourceResourceTypeId = ResourceTypeId, SearchParamId, ReferenceResourceId, ReferenceResourceTypeId FROM dbo.ReferenceSearchParam) R\n            WHERE ReferenceResourceId = ResourceId\n                AND ReferenceResourceTypeId = ResourceTypeId\n                AND SourceResourceTypeId = 96\n                AND SearchParamId = 969\n        )\n        \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH z/YR5v7LJkn+NjwNz3nLVWpZ0BMDgI6x+MDTCxAsvjw= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "79"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-referenced.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?_not-referenced=invalid&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH z/YR5v7LJkn+NjwNz3nLVWpZ0BMDgI6x+MDTCxAsvjw= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "79"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-referenced.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?address-city:contains=Vestibulum&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 685\n        AND ((Text LIKE @p0)\n        OR (TextOverflow IS NOT NULL AND TextOverflow LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH NiuvNWEM3SUDuX2KMzZgv5eYpTZyrXAG0u3uvbzKI1U= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(max)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'%Vestibulum%'"
+    },
+    "@p1": {
+     "type": "nvarchar(max)",
+     "value": "N'%Vestibulum%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?address-city:contains=att&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 685\n        AND ((Text LIKE @p0)\n        OR (TextOverflow IS NOT NULL AND TextOverflow LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH +HXBuFFZy7RpaF4Pm21k0RsMNJqfFLrLlY+5UiWr2Ig= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(max)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'%att%'"
+    },
+    "@p1": {
+     "type": "nvarchar(max)",
+     "value": "N'%att%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?address-city:exact=Seattle&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 685\n        AND Text = @p0 AND Text = @p0 COLLATE Latin1_General_100_CS_AS\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH d7TNqUPy3UTfv5o+dcUryxNsTS1oYlUI9I/nWfP4eCk= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Seattle'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?address-city:exact=seattle&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 685\n        AND Text = @p0 AND Text = @p0 COLLATE Latin1_General_100_CS_AS\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH d7TNqUPy3UTfv5o+dcUryxNsTS1oYlUI9I/nWfP4eCk= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'seattle'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?address-city=sea&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 685\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH E8K4aSIEc5P7prlAoPMUNahGgsElRP6OOp5a6pDBxuc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'sea%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?birthdate:missing=false&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 690 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JrJdRXWXp7BGP5Yg9mbdEKosQ3OlBZZ8fI1wkiotbs4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?birthdate:missing=true&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.DateTimeSearchParam\n        WHERE SearchParamId = 690 \n            AND ResourceTypeId = 103 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JrJdRXWXp7BGP5Yg9mbdEKosQ3OlBZZ8fI1wkiotbs4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?birthdate=ge1985-01-01&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.DateTimeSearchParam\n    WHERE SearchParamId = 690\n        AND EndDateTime >= @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IEeuz3k6yb6zXFlW0zjiwaDnov4llwv+j51lo/CIj4E= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "datetime",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p1": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\basic.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family:contains=SON&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND ((Text LIKE @p0)\n        OR (TextOverflow IS NOT NULL AND TextOverflow LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH GsGr0BPtfZwkoMw7SMiKMasb/6Ai0Jr2zvHuQh0pfNE= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(max)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'%SON%'"
+    },
+    "@p1": {
+     "type": "nvarchar(max)",
+     "value": "N'%SON%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family:contains=son&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND ((Text LIKE @p0)\n        OR (TextOverflow IS NOT NULL AND TextOverflow LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 3Q7LB1ZpDQhxr/bAKf1k6usL5vhDXIVO+Sx7KC/Csng= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(max)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'%son%'"
+    },
+    "@p1": {
+     "type": "nvarchar(max)",
+     "value": "N'%son%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family:exact=Smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND Text = @p0 AND Text = @p0 COLLATE Latin1_General_100_CS_AS\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH jXKDlMQdLO5fx+g3W8L97mjUndofBBVH3W0+x/vH6AA= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?family:exact=smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND Text = @p0 AND Text = @p0 COLLATE Latin1_General_100_CS_AS\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH Qh1jnECqguVD1M2xrFkxrrp2NOuM2jss/lj6IebgorA= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'smith'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family=Smith,Anderson&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND ((Text LIKE @p0)\n        OR (Text LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IfJE/yVzM/BbXvhFkVkkDh1H4XuJAd+ZxpaMO+NkF8k= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Anderson%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family=Zephyr%5C,Orion&identifier=http://ignixa.io/testscript/suite/escape%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH DvEP38k5vEYC2wh3b8x2ccp17Rc31sfSpPC9HXPhrqQ= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Zephyr,Orion%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "98"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\escape-characters.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?family=Zephyr,Jones&identifier=http://ignixa.io/testscript/suite/escape%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND ((Text LIKE @p0)\n        OR (Text LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 9aNVOmX1d899SgNqCS2WKWeCuY1HrEfCdw2Qq8MXB9o= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Zephyr%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Jones%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "98"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\escape-characters.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?family=smi&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 692\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH eRk/2GomPUmAFcSMOuCDT8Rqwo+4AIgND89+sYK4MfQ= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'smi%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\basic.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?gender:missing=false&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 693 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JrJdRXWXp7BGP5Yg9mbdEKosQ3OlBZZ8fI1wkiotbs4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?gender:missing=true&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 693 \n            AND ResourceTypeId = 103 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JrJdRXWXp7BGP5Yg9mbdEKosQ3OlBZZ8fI1wkiotbs4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?gender:not=male&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT T1, Sid1\n    FROM cte0\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 693\n            AND Code = @p1\n            AND ResourceTypeId = 103 \n    )\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH ciu1PTLfn+iakrg3qRx2eJk7WaL057JvttoxEw7Lx/Q= params=@p0,@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "male"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\string-modifiers.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?general-practitioner:Practitioner=Practitioner/ignixa-ref-p1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CLV6//JrurRlfIyy1DMjU4M0GJVIZgbY6H5CYWLyoxc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-p1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?general-practitioner:Practitioner=ignixa-impsrch-ref-pract&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xGs64egUiKybiWxiuP+RGaQOAvuTHpRZ04UHmJWkKng= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-pract"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?general-practitioner:Practitioner=ignixa-impsrch-ref-pract-untyped&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH qu0hQlX6b5MgwyXP2TEaPxNMi2q9reO3dV2D8ggbw3g= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-pract-untyped"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?general-practitioner:Practitioner=ignixa-ref-p2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CLV6//JrurRlfIyy1DMjU4M0GJVIZgbY6H5CYWLyoxc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-p2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?general-practitioner=Practitioner/ignixa-impsrch-ref-pract&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xGs64egUiKybiWxiuP+RGaQOAvuTHpRZ04UHmJWkKng= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-pract"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?general-practitioner=Practitioner/ignixa-ref-p1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CLV6//JrurRlfIyy1DMjU4M0GJVIZgbY6H5CYWLyoxc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-p1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?general-practitioner=Practitioner/ignixa-ref-p2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceTypeId = 108\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CLV6//JrurRlfIyy1DMjU4M0GJVIZgbY6H5CYWLyoxc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-p2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?general-practitioner=ignixa-impsrch-ref-pract-untyped&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 100)\n        OR (ReferenceResourceTypeId = 109)\n        OR (ReferenceResourceTypeId IS NULL))  \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH qu0hQlX6b5MgwyXP2TEaPxNMi2q9reO3dV2D8ggbw3g= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-pract-untyped"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?general-practitioner=ignixa-ref-p2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1012\n        AND ReferenceResourceId = @p0\n        AND ((ReferenceResourceTypeId = 108)\n        OR (ReferenceResourceTypeId = 100)\n        OR (ReferenceResourceTypeId = 109)\n        OR (ReferenceResourceTypeId IS NULL))  \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CLV6//JrurRlfIyy1DMjU4M0GJVIZgbY6H5CYWLyoxc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-p2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?given:exact=Alex,Carol&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 694\n        AND ((Text = @p0 AND Text = @p0 COLLATE Latin1_General_100_CS_AS)\n        OR (Text = @p1 AND Text = @p1 COLLATE Latin1_General_100_CS_AS)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH G+2ID2y/+1UB4ZjDAkJ5NmrRv83oXv6ixeoxycUwWyU= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Alex'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Carol'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?given=Alex&family=Doe&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 694\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 692\n        AND Text LIKE @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH eXHXbvU1h/7LegP+gNULJX6Mqahz9d9vX6N7GqSRQE8= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Alex%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Doe%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?given=Alex,Bob&family=Smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 694\n        AND ((Text LIKE @p0)\n        OR (Text LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 692\n        AND Text LIKE @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p3\n        AND ResourceTypeId = 103 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH moQZ7u+Ol/KCeWbZw9sE889ORe2THNXa/UDqDX6H4iw= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "nvarchar(256)",
+    "@p3": "int",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Alex%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Bob%'"
+    },
+    "@p2": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?given=Alex,Carol&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 694\n        AND ((Text LIKE @p0)\n        OR (Text LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH q7nVaty4+1cTy78MH38RXsYuf9hSGow3lryOx0/E0RQ= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Alex%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Carol%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?identifier=http://fhir262/pagination%7C&_total=accurate",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH j8bLSpgW11YhZS3ngxGO7hMRLNoZbmHRveBGDymybj4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "101"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\pagination.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?identifier=http://fhir262/pagination%7C&_total=none",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH j8bLSpgW11YhZS3ngxGO7hMRLNoZbmHRveBGDymybj4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "101"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\pagination.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?identifier=http://fhir262/test%7C&_total=accurate",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JrJdRXWXp7BGP5Yg9mbdEKosQ3OlBZZ8fI1wkiotbs4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\basic.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?identifier=http://ignixa.io/testscript/suite/ms-param%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH KTdM/dRdhDNxO7MlKVTkiEFAHE7iVKZRz//SKH9TYN4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "80"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-search-parameter.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?identifier=http://ignixa.io/testscript/suite/token-idq-sys%7C",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE SearchParamId = 1013\n        AND SystemId = @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH YpC/KYflIvb+ghPmeW0GpynW16zn3bgL9sVPAWrUmFY= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "int",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "int",
+     "value": "108"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\token.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?name=Alex&name=Smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 1016\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1016\n        AND Text LIKE @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH P1fKebGQrJzvDAHJf6QGcg1ZKnQRT9w/lha93Ht7JQA= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Alex%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?name=Bea&name=Smith&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 1016\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1016\n        AND Text LIKE @p1\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 103 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH +HXBuFFZy7RpaF4Pm21k0RsMNJqfFLrLlY+5UiWr2Ig= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Bea%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?name=Doe,Smith&identifier=http://fhir262/test%7C&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 1016\n        AND ((Text LIKE @p0)\n        OR (Text LIKE @p1)) \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1013\n        AND SystemId = @p2\n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH D7B8npCg3OFsXcY9+QmyZKvpycrIj+ZRnahq1bK2/7U= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "nvarchar(256)",
+    "@p2": "int",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Doe%'"
+    },
+    "@p1": {
+     "type": "nvarchar(256)",
+     "value": "N'Smith%'"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "2"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\joins.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?name=Richard%5C,Muller&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.StringSearchParam\n    WHERE SearchParamId = 1016\n        AND Text LIKE @p0\n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH IfJE/yVzM/BbXvhFkVkkDh1H4XuJAd+ZxpaMO+NkF8k= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'Richard,Muller%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization.name=ACME%20Corp",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, refTarget.ResourceTypeId AS T2, refTarget.ResourceSurrogateId AS Sid2 \n    FROM dbo.ReferenceSearchParam refSource\n         JOIN dbo.Resource refTarget ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId AND refSource.ReferenceResourceId = refTarget.ResourceId\n    WHERE refSource.SearchParamId = 1017\n        AND refTarget.IsHistory = 0 \n        AND refTarget.IsDeleted = 0 \n        AND refSource.ResourceTypeId IN (103)\n        AND refSource.ReferenceResourceTypeId IN (100)\n        AND refSource.ResourceTypeId = 103\n)\n,cte1 AS\n(\n    SELECT T1, Sid1, ResourceTypeId AS T2, ResourceSurrogateId AS Sid2\n    FROM dbo.StringSearchParam\n         JOIN cte0 ON ResourceTypeId = T2 AND ResourceSurrogateId = Sid2\n    WHERE SearchParamId = 991\n        AND Text LIKE @p0\n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH EXUiz3JD4wUF7bVz+e8ma26DKRlFNCSE7henjI4Q/R4= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "nvarchar(256)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "nvarchar(256)",
+     "value": "N'ACME Corp%'"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\chaining.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?organization=Organization/ignixa-impsrch-ref-org&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceTypeId = 100\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH Wm9aINrBw5NSqx04+ByptkZqSarjHlCX1gXsRik1XFg= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-org"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?organization=Organization/ignixa-ref-ijk&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceTypeId = 100\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH pI6ija7FkLDpjwXdKNIrraaS2tnt72CKHgGyK0IqFDo= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-ijk"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization=Organization/ignixa-ref-org-1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceTypeId = 100\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH qo08o5xZgFxAxCync8L8mwAEHOkXyXV+5M/7d7GuGrY= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-org-1"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization=Organization/ignixa-ref-org-123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceTypeId = 100\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH AF2x0OSLTGSCxOwQMKs2hIsyZKqPQ1ts77BQb5k3O5E= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-org-123"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/Patient?organization=ignixa-impsrch-ref-org-untyped&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceId = @p0\n        AND ReferenceResourceTypeId = 100 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH JdFBdVe+KF9IfvWXVaLpapIs+IYsJi7JjNM28MfK+yI= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-impsrch-ref-org-untyped"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization=ignixa-ref-ijk&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceId = @p0\n        AND ReferenceResourceTypeId = 100 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH pI6ija7FkLDpjwXdKNIrraaS2tnt72CKHgGyK0IqFDo= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-ijk"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization=ignixa-ref-org-123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceId = @p0\n        AND ReferenceResourceTypeId = 100 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH AF2x0OSLTGSCxOwQMKs2hIsyZKqPQ1ts77BQb5k3O5E= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-ref-org-123"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Patient?organization=organization/ignixa-ref-org-123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1017\n        AND ReferenceResourceId = @p0\n        AND ReferenceResourceTypeId = 100 \n        AND ResourceTypeId = 103 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 103 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH EXudvfhO/NJKiM/+ZQp1vfFmLLJqzuTL30TlUMuO/n0= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "organization/ignixa-ref-org-123"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-ref-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\reference.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-active&active:not=false",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p1\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH nBBadQzXZgm0sny9xTC0lgP3JToXbxUokRkXg5CvBUI= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-active"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "false"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-active&active:not=false&location:missing=false",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1072 \n        AND ResourceTypeId = 109 \n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p1\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH nBBadQzXZgm0sny9xTC0lgP3JToXbxUokRkXg5CvBUI= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-active"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "false"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-active&active:not=true",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p1\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OYnLigphDj8pA5ZOv+5vbeoeo1cDocsTRgUyA+/ngfs= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-active"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "true"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-active,ignixa-not-pr-inactive&active:not=false",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ((ResourceId = @p0)\n        OR (ResourceId = @p1))  \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p2\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH nBBadQzXZgm0sny9xTC0lgP3JToXbxUokRkXg5CvBUI= params=@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(64)",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-active"
+    },
+    "@p1": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-inactive"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "false"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-inactive&active:not=false",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p1\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH nBBadQzXZgm0sny9xTC0lgP3JToXbxUokRkXg5CvBUI= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-inactive"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "false"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-inactive&active:not=true",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.TokenSearchParam\n        WHERE SearchParamId = 1068\n            AND Code = @p1\n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p2) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH OYnLigphDj8pA5ZOv+5vbeoeo1cDocsTRgUyA+/ngfs= params=@p1 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "varchar(256)",
+    "@p2": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-inactive"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "true"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-noloc&location:missing=false",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1072 \n        AND ResourceTypeId = 109 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-noloc"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/PractitionerRole?_id=ignixa-not-pr-noloc&location:missing=true",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n        AND ResourceId = @p0 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.Resource\n    WHERE IsHistory = 0 \n        AND IsDeleted = 0 \n        AND ResourceTypeId = 109\n)\n,cte2 AS\n(\n    SELECT T1, Sid1\n    FROM cte1\n    WHERE Sid1 NOT IN\n    (\n        SELECT ResourceSurrogateId\n        FROM dbo.ReferenceSearchParam\n        WHERE SearchParamId = 1072 \n            AND ResourceTypeId = 109 \n    )\n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "ignixa-not-pr-noloc"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Microsoft\\ms-not-expression.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/Provenance?target=Observation/f449504f-42c9-4fdb-b803-7c341c793948",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.ReferenceSearchParam\n    WHERE SearchParamId = 1097\n        AND ReferenceResourceTypeId = 96\n        AND ReferenceResourceId = @p0 \n        AND ResourceTypeId = 111 \n)\n,cte1 AS\n(\n    SELECT DISTINCT TOP (@p1) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte0\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 1uc/kWCTG1yWmyGX1qe7t/7FACjrkcOm7iWz/EFAGKQ= params=@p0 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte1 ON r.ResourceTypeId = cte1.T1 AND r.ResourceSurrogateId = cte1.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(64)",
+    "@p1": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(64)",
+     "value": "f449504f-42c9-4fdb-b803-7c341c793948"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "CRUD\\create.json"
+   ],
+   "corroboratingEvents": 8,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/RiskAssessment?probability=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH uUF8caOU3EvGYqkh2QjAd2lt7c+EM9qgodDr9KfxaZY= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 12,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CmUKDe+MzyzMy1kygWtgMR9Tnx79sUnGIkLq0T7HBiw= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/RiskAssessment?probability=eb5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue < @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND LowValue < @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=eq5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND SingleValue IS NOT NULL AND SingleValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue >= @p0\n        AND LowValue <= @p1 \n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CmUKDe+MzyzMy1kygWtgMR9Tnx79sUnGIkLq0T7HBiw= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/RiskAssessment?probability=ge5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue >= @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue >= @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH F9LxMMmN3RXHIkxRhK3nZB5hYUw2ojAdpr2Il+HUtG0= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue <= @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND LowValue <= @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH F9LxMMmN3RXHIkxRhK3nZB5hYUw2ojAdpr2Il+HUtG0= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue <= @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND LowValue <= @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=lt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue < @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND LowValue < @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND ((SingleValue IS NOT NULL AND SingleValue < @p0)\n        OR (SingleValue IS NOT NULL AND SingleValue > @p1)) \n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND ((LowValue < @p0)\n        OR (HighValue > @p1)) \n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH uUF8caOU3EvGYqkh2QjAd2lt7c+EM9qgodDr9KfxaZY= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND ((SingleValue IS NOT NULL AND SingleValue < @p0)\n        OR (SingleValue IS NOT NULL AND SingleValue > @p1)) \n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND ((LowValue < @p0)\n        OR (HighValue > @p1)) \n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH CmUKDe+MzyzMy1kygWtgMR9Tnx79sUnGIkLq0T7HBiw= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "decimal(36,18)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "4.5"
+    },
+    "@p1": {
+     "type": "decimal(36,18)",
+     "value": "5.5"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/RiskAssessment?probability=sa5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND SingleValue IS NOT NULL AND SingleValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte1 AS\n(\n    SELECT * FROM cte0\n    UNION ALL\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.NumberSearchParam\n    WHERE SearchParamId = 1223\n        AND HighValue > @p0\n        AND ResourceTypeId = 120 \n)\n,cte2 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 120 \n)\n,cte3 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte2\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 2gnXRzhQBdCxoHwu1yaapxMe5umDAEvjP04WVy2CN0M= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte3 ON r.ResourceTypeId = cte3.T1 AND r.ResourceSurrogateId = cte3.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "decimal(36,18)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "decimal(36,18)",
+     "value": "5"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-num-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Search\\number.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:above=http://ignixa-unrelated.example.com/x&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND @p0 LIKE Uri+'%'\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH U4m/ydLJfzk71E8RhQsYM4DPtJf/KL3E29vc4cPzvRs= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa-unrelated.example.com/x"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:above=http://ignixa.example.com/rdf%2354135-9-9-10&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND @p0 LIKE Uri+'%'\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH bo5BzX/tSShptow1DzjtwF5Hh1FFvGyPdqxThA5VNuU= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.example.com/rdf#54135-9-9-10"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:above=http://ignixa.example.com/test/system/123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND @p0 LIKE Uri+'%'\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 78/POfBW8xfdYayyCMKQHIF/3+5IveiLXizQIza6Ajs= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.example.com/test/system/123"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:above=http://somewhere.com/test/system/123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND @p0 LIKE Uri+'%'\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH t6ILOU3HKwcaZ5ktzl1Ua/gxEqyAh6V0lBsyK6TXzww= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://somewhere.com/test/system/123"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:below=http&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri LIKE @p0\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH +HXBuFFZy7RpaF4Pm21k0RsMNJqfFLrLlY+5UiWr2Ig= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http%"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:below=http://ignixa-unrelated.example.com&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri LIKE @p0\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH /byhb17VjMUCRybWVMwt9KJ3To46QjSkMhVnj7bGXvY= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa-unrelated.example.com%"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url:below=http://ignixa.example.com&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri LIKE @p0\n        AND Uri NOT  LIKE @p1 \n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p2\n        AND Code = @p3 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p4) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH Aq6684k4G+vr10elLeuRyuphzvHFvaFqVt8TIDwHti8= params=@p0,@p1,@p2,@p3 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "varchar(256)",
+    "@p2": "int",
+    "@p3": "varchar(256)",
+    "@p4": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.example.com%"
+    },
+    "@p1": {
+     "type": "varchar(256)",
+     "value": "urn:%"
+    },
+    "@p2": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p3": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p4": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url=http://ignixa.EXAMPLE.com/test/system&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri = @p0\n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH 5pHY5akp+s/Vdb3akgyFYEZqjrU/x1Rsnxmei2HGTDE= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.EXAMPLE.com/test/system"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url=http://ignixa.example.com/rdf%2354135-9&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri = @p0\n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH l8kTAFjJLuIxFsSYSfclDDBTKMlAQ+Gp56DuNCl67RU= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.example.com/rdf#54135-9"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 1
+  },
+  {
+   "url": "/ValueSet?url=http://ignixa.example.com/test/system&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri = @p0\n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH I5X2MLQSx8tILbLorVrru3gdZYrbAhr62wR+Q03owLM= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://ignixa.example.com/test/system"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-uri-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "11"
+    }
+   },
+   "sourceScripts": [
+    "Search\\uri.json"
+   ],
+   "corroboratingEvents": 4,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/ValueSet?url=http://somewhere.COM/test/system&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri = @p0\n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xXuSfZuz2n9T1vF6JP6fEn62z+dMMBLGN8O3n4RH/Fc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://somewhere.COM/test/system"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 5,
+   "rejectedVariants": 0
+  },
+  {
+   "url": "/ValueSet?url=http://somewhere.com/test/system&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100",
+   "legacySql": "DECLARE @FilteredData AS TABLE (T1 smallint, Sid1 bigint, IsMatch bit, IsPartial bit, Row int)\n;WITH\ncte0 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.UriSearchParam\n    WHERE SearchParamId = 312\n        AND Uri = @p0\n        AND ResourceTypeId = 144 \n)\n,cte1 AS\n(\n    SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n    FROM dbo.TokenSearchParam\n    WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)\n        AND SearchParamId = 1218\n        AND SystemId = @p1\n        AND Code = @p2 \n        AND ResourceTypeId = 144 \n)\n,cte2 AS\n(\n    SELECT DISTINCT TOP (@p3) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \n    FROM cte1\n    ORDER BY T1 ASC, Sid1 ASC\n)\n/* HASH xXuSfZuz2n9T1vF6JP6fEn62z+dMMBLGN8O3n4RH/Fc= params=@p0,@p1,@p2 */\nSELECT * FROM (SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\nFROM dbo.Resource r\n     JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1\nWHERE IsHistory = 0 \n    AND IsDeleted = 0 \n) AS t ORDER BY t.ResourceTypeId ASC, t.ResourceSurrogateId ASC",
+   "parameterTypes": {
+    "@p0": "varchar(256)",
+    "@p1": "int",
+    "@p2": "varchar(256)",
+    "@p3": "int"
+   },
+   "parameterValues": {
+    "@p0": {
+     "type": "varchar(256)",
+     "value": "http://somewhere.com/test/system"
+    },
+    "@p1": {
+     "type": "int",
+     "value": "74"
+    },
+    "@p2": {
+     "type": "varchar(256)",
+     "value": "ignixa-impsrch-suite"
+    },
+    "@p3": {
+     "type": "int",
+     "value": "101"
+    }
+   },
+   "sourceScripts": [
+    "Operations\\import-search-2.json"
+   ],
+   "corroboratingEvents": 6,
+   "rejectedVariants": 1
+  }
+ ]
+}

--- a/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
@@ -6,9 +6,9 @@
 
 | Verdict | Count |
 |---|---:|
-| NotCompiled | 4 |
+| NotCompiled | 3 |
 | Match | 69 |
-| CompilerDoesLess | 45 |
+| CompilerDoesLess | 46 |
 | CompilerDoesMore | 14 |
 | Divergent | 53 |
 
@@ -20,11 +20,6 @@
   - `/Patient?_id=ignixa-inc-pat1&_include=*`
   - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*`
   - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1`
-
-### Lower (1)
-
-- **1x** A resource-column predicate ('_id') reached the leaf/composite dispatch — only Lower.Run's top-level extraction pass (via ResourceColumnLoweringRule) handles these. Guarding here, at the dispatch choke point, covers every caller of Lower/LowerComposite structurally. Throwing rather than routing a resource column into an unrelated table, which would silently produce a wrong-scope or always-empty match.
-  - `/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100`
 
 ## Divergences -- compiled, but asks the database for something different
 
@@ -274,6 +269,37 @@ select0 = <-cte2  [order-by]
 cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:TextOverflow2 like @p  [distinct]
 cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
 cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceId = @p ResourceTypeId = <n>  [not,or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p ResourceId = @p  [correlate,correlate,inner-join,not,or,order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
 ```
 
 </details>

--- a/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
@@ -6,11 +6,11 @@
 
 | Verdict | Count |
 |---|---:|
-| NotCompiled | 11 |
+| NotCompiled | 8 |
 | Match | 69 |
-| CompilerDoesLess | 43 |
+| CompilerDoesLess | 44 |
 | CompilerDoesMore | 14 |
-| Divergent | 48 |
+| Divergent | 50 |
 
 ## Gaps -- queries the compiler cannot express
 
@@ -21,21 +21,17 @@
   - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$107%7Chttp://unitsofmeasure.org%7Cmm%5BHg%5D&identifier=http://ignixa.io/testscript/suite/composite%7C`
   - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$120%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
 
-### Lower (4)
-
-- **3x** Lower does not support NotReferencedExpression yet -- see this plan's scope notes.
-  - `/Patient?_not-referenced=*:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
-  - `/Patient?_not-referenced=Observation:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
-  - `/Patient?_not-referenced=Observation:subject&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
-- **1x** A resource-column predicate ('_id') reached the leaf/composite dispatch — only Lower.Run's top-level extraction pass (via ResourceColumnLoweringRule) handles these. Guarding here, at the dispatch choke point, covers every caller of Lower/LowerComposite structurally. Throwing rather than routing a resource column into an unrelated table, which would silently produce a wrong-scope or always-empty match.
-  - `/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100`
-
 ### build:InvalidSearchOperationException (3)
 
 - **3x** The _include search is missing the type to search.
   - `/Patient?_id=ignixa-inc-pat1&_include=*`
   - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*`
   - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1`
+
+### Lower (1)
+
+- **1x** A resource-column predicate ('_id') reached the leaf/composite dispatch — only Lower.Run's top-level extraction pass (via ResourceColumnLoweringRule) handles these. Guarding here, at the dispatch choke point, covers every caller of Lower/LowerComposite structurally. Throwing rather than routing a resource column into an unrelated table, which would silently produce a wrong-scope or always-empty match.
+  - `/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100`
 
 ## Divergences -- compiled, but asks the database for something different
 
@@ -778,6 +774,36 @@ cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,
 compiler:
 select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
 cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?_not-referenced=*:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+
+Only the shipping engine does:
+- `filter IsHistory = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p
+cte1 = Resource+sub:ReferenceSearchParam  <-cte0  IsDeleted = <n> IsHistory = <n> IsHistory = <n> ResourceTypeId = <n>  [correlate,correlate,correlate,correlate,exists,exists,not]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = Resource+sub:ReferenceSearchParam  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p  [correlate,correlate,exists,not]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
 ```
 
 </details>
@@ -3097,6 +3123,74 @@ cte2 = <-cte1  [distinct,order-by,top]
 compiler:
 select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
 cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Patient?_not-referenced=Observation:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+
+Only the shipping engine does:
+- `filter IsHistory = <v>`
+- `filter SourceResourceTypeId = <v>`
+
+Only the compiler does:
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p
+cte1 = Resource+sub:ReferenceSearchParam  <-cte0  IsDeleted = <n> IsHistory = <n> IsHistory = <n> ResourceTypeId = <n> sub:SourceResourceTypeId = <n>  [correlate,correlate,correlate,correlate,exists,exists,not]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = Resource+sub:ReferenceSearchParam  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p sub:ResourceTypeId = <n>  [correlate,correlate,exists,not]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?_not-referenced=Observation:subject&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+
+Only the shipping engine does:
+- `filter IsHistory = <v>`
+- `filter SourceResourceTypeId = <v>`
+
+Only the compiler does:
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p
+cte1 = Resource+sub:ReferenceSearchParam  <-cte0  IsDeleted = <n> IsHistory = <n> IsHistory = <n> ResourceTypeId = <n> sub:SearchParamId = <n> sub:SourceResourceTypeId = <n>  [correlate,correlate,correlate,correlate,exists,exists,not]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = Resource+sub:ReferenceSearchParam  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [correlate,correlate,exists,not]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
 ```
 
 </details>

--- a/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
@@ -1,0 +1,3834 @@
+﻿# Legacy SQL differential report
+
+185 captured searches, each compiled and compared against the SQL the shipping engine executed.
+
+## Summary
+
+| Verdict | Count |
+|---|---:|
+| NotCompiled | 11 |
+| Match | 69 |
+| CompilerDoesLess | 43 |
+| CompilerDoesMore | 14 |
+| Divergent | 48 |
+
+## Gaps -- queries the compiler cannot express
+
+### build:BadSearchRequestException (4)
+
+- **4x** Only one token separator can be specified.
+  - `/Observation?code-value-quantity=http://loinc.org%7C8310-5$gt38%7Chttp://unitsofmeasure.org%7CCel&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+  - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$107%7Chttp://unitsofmeasure.org%7Cmm%5BHg%5D&identifier=http://ignixa.io/testscript/suite/composite%7C`
+  - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$120%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+### Lower (4)
+
+- **3x** Lower does not support NotReferencedExpression yet -- see this plan's scope notes.
+  - `/Patient?_not-referenced=*:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+  - `/Patient?_not-referenced=Observation:*&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+  - `/Patient?_not-referenced=Observation:subject&identifier=http://ignixa.io/testscript/suite/ms-not-referenced%7C&_count=100`
+- **1x** A resource-column predicate ('_id') reached the leaf/composite dispatch — only Lower.Run's top-level extraction pass (via ResourceColumnLoweringRule) handles these. Guarding here, at the dispatch choke point, covers every caller of Lower/LowerComposite structurally. Throwing rather than routing a resource column into an unrelated table, which would silently produce a wrong-scope or always-empty match.
+  - `/Observation?identifier=http://ignixa.io/testscript/suite/token%7C&_id:not=ignixa-tok-o1,ignixa-tok-o2&_count=100`
+
+### build:InvalidSearchOperationException (3)
+
+- **3x** The _include search is missing the type to search.
+  - `/Patient?_id=ignixa-inc-pat1&_include=*`
+  - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*`
+  - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1`
+
+## Divergences -- compiled, but asks the database for something different
+
+### CompilerDoesLess: `/DocumentReference/$docref?patient=ignixa-docref-pat0`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x4)`
+- `filter col:ReferenceResourceTypeId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op inner-join`
+- `legacy: op or (x4)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte1  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null  [or,or,or,or]
+cte1 = <-cte0  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/DocumentReference/$docref?patient=ignixa-docref-pat0&type=http://loinc.org%7C55107-7`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x4)`
+- `filter col:ReferenceResourceTypeId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or (x4)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null  [or,or,or,or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/DocumentReference/$docref?patient=ignixa-docref-pat0&unknown=unknownvalue`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x4)`
+- `filter col:ReferenceResourceTypeId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op inner-join`
+- `legacy: op or (x4)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte1  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null  [or,or,or,or]
+cte1 = <-cte0  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/HealthcareService?_id=ignixa-id-b&active=true`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/HealthcareService?_id=ignixa-id-c&active=true`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?code-value-string=162806009$Lorem%20ipsum%20dolor%20sit%20amet%20consectetur%20adipiscing%20elit.%20Ut%20eget%20ultricies%20justo.%20Maecenas%20bibendum%20convallis%20sodales.%20Vestibulum%20quis%20molestie%20dui.%20Nulla%20porta%20elementum%20tristique.%20Aenean%20neque%20libero%20convallis%20sit%20amet%20dui%20ullamcorper%20congue%20lacinia%20erat.%20Sed%20finibus%20ex%20ac%20massa%20tincidunt%20tristique.%20In%20sed%20auctor%20massa.%20Proin%20cursus%20porttitor%20arcu.%20Maecenas%20a%20leo%20nunc.%20Sed%20pretium%20porta%20volutpat.%20In%20aliquet%20tempor%20sapien%20vitae%20laoreet%20nisl%20tempor%20ac.%20Vestibulum%20lacus%20leo%20luctus%20vitae%20pharetra%20at%20tempus%20ac%20diam.%20Integer%20at%20dui%20eu%20dolor%20gravida%20vehicula.%20Phasellus%20malesuada%20elit%20orci%20quis%20maximus%20purus%20consectetur%20ac.%20In%20semper%20consequat%20augue%20sit%20amet%20ultricies.&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the shipping engine does:
+- `filter col:Text2 like <v>`
+- `filter col:TextOverflow2 is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:Text2 like @p col:TextOverflow2 is-not-null col:TextOverflow2 like @p
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:TextOverflow2 like @p  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?code-value-string=162806009$Lorem%20ipsum%20dolor%20sit%20amet%20consectetur%20adipiscing%20elit.%20Ut%20eget%20ultricies%20justo.%20Maecenas%20bibendum%20convallis%20sodales.%20Vestibulum%20quis%20molestie%20dui.%20Nulla%20porta%20elementum%20tristique.%20Aenean%20neque%20libero%20convallis%20sit%20amet%20dui%20ullamcorper%20congue%20lacinia%20erat.%20Sed%20finibus%20ex%20ac%20massa%20tincidunt%20tristique.%20In%20sed%20auctor%20massa.%20Proin%20cursus%20porttitor%20arcu.%20Maecenas%20a%20leo%20nunc.%20Sed%20pretium%20porta%20volutpat.%20In%20aliquet%20tempor%20sapien%20vitae%20laoreet%20nisl%20tempor%20ac.%20Vestibulum%20lacus%20leo%20luctus%20vitae%20pharetra%20at%20tempus%20ac%20diam.%20Integer%20at%20dui%20eu%20dolor%20gravida%20vehicula.%20Phasellus%20malesuada%20elit%20orci%20quis%20maximus%20purus%20consectetur%20ac.%20In%20semper%20consequat%20augue%20sit%20amet%20ultriciesNot&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the shipping engine does:
+- `filter col:Text2 like <v>`
+- `filter col:TextOverflow2 is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:Text2 like @p col:TextOverflow2 is-not-null col:TextOverflow2 like @p
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:TextOverflow2 like @p  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=ge5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue >= @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=gt4.9&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=lt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?value-quantity=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p SingleValue > @p col:SingleValue is-not-null col:SingleValue is-not-null  [or]
+cte1 = QuantitySearchParam  <-cte0  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [or,union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient/ignixa-cmp-pat1/Observation?_include=Observation:performer:Practitioner&performer=Practitioner/ignixa-cmp-prac1`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x3)`
+- `table Resource`
+- `filter IsHistory = <v>`
+- `filter ReferenceResourceId = <v> (x2)`
+- `filter ReferenceResourceTypeId = <v> (x13)`
+- `filter ResourceTypeId = <v> (x3)`
+- `filter Row < <v>`
+- `filter SearchParamId = <v> (x4)`
+- `filter col:ReferenceResourceTypeId is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x12)`
+- `legacy: op count-big`
+- `legacy: op distinct (x4)`
+- `legacy: op exists (x2)`
+- `legacy: op in`
+- `legacy: op inner-join (x4)`
+- `legacy: op not`
+- `legacy: op or (x11)`
+- `legacy: op order-by`
+- `legacy: op row-number`
+- `legacy: op top (x3)`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null col:ReferenceResourceTypeId is-null  [or,or,or,or,or,or,or,or,or,or,or]
+cte1 = <-cte0
+cte2 = Resource  <-cte1  IsHistory = <n> ResourceTypeId = <n>  [correlate,correlate,inner-join]
+cte3 = ReferenceSearchParam  <-cte2  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,inner-join]
+cte4 = <-cte3  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte7  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte4 = 
+cte5 = ReferenceSearchParam+Resource  <-cte4  IsDeleted = <n> IsHistory = <n> ReferenceResourceTypeId = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte6 = <-cte5  [count-big,distinct,top]
+cte7 = <-cte4,cte6  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient/ignixa-evx-pat/$everything?_count=100&foo=bar`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `table Resource (x2)`
+- `filter IsDeleted = <v> (x2)`
+- `filter IsHistory = <v> (x2)`
+- `filter ResourceId = <v>`
+- `filter Row < <v> (x2)`
+- `filter SearchParamId = <v> (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x14)`
+- `legacy: op count-big (x2)`
+- `legacy: op distinct (x6)`
+- `legacy: op exists (x4)`
+- `legacy: op in (x2)`
+- `legacy: op inner-join (x3)`
+- `legacy: op not (x2)`
+- `legacy: op order-by`
+- `legacy: op row-number`
+- `legacy: op top (x5)`
+- `legacy: op union-all (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient/ignixa-evx-pat/$everything?_since=3000`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `table Resource (x2)`
+- `filter IsDeleted = <v> (x2)`
+- `filter IsHistory = <v> (x2)`
+- `filter ResourceId = <v>`
+- `filter Row < <v> (x2)`
+- `filter SearchParamId = <v> (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x14)`
+- `legacy: op count-big (x2)`
+- `legacy: op distinct (x6)`
+- `legacy: op exists (x4)`
+- `legacy: op in (x2)`
+- `legacy: op inner-join (x3)`
+- `legacy: op not (x2)`
+- `legacy: op order-by`
+- `legacy: op row-number`
+- `legacy: op top (x5)`
+- `legacy: op union-all (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient/ignixa-evx-pat/$everything?_type=foo`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `table Resource (x2)`
+- `filter IsDeleted = <v> (x2)`
+- `filter IsHistory = <v> (x2)`
+- `filter ResourceId = <v>`
+- `filter Row < <v> (x2)`
+- `filter SearchParamId = <v> (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x14)`
+- `legacy: op count-big (x2)`
+- `legacy: op distinct (x6)`
+- `legacy: op exists (x4)`
+- `legacy: op in (x2)`
+- `legacy: op inner-join (x3)`
+- `legacy: op not (x2)`
+- `legacy: op order-by`
+- `legacy: op row-number`
+- `legacy: op top (x5)`
+- `legacy: op union-all (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?_expiryDate=gt2025&identifier=http://ignixa.io/testscript/suite/ms-param%7C&_count=100`
+
+Only the shipping engine does:
+- `table DateTimeSearchParam`
+- `filter EndDateTime > <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x4)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op inner-join`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = DateTimeSearchParam  EndDateTime > @p ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?_expiryDate=lt2025&identifier=http://ignixa.io/testscript/suite/ms-param%7C&_count=100`
+
+Only the shipping engine does:
+- `table DateTimeSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter StartDateTime < <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x4)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op inner-join`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = DateTimeSearchParam  ResourceTypeId = <n> SearchParamId = <n> StartDateTime < @p
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?_id=e04c1b8a-fe84-4111-8b44-34135571d0ec,512ffdc7-8292-4acb-a9e4-94f664dc30b4,cad0864f-c442-49e1-a0a0-a7554e334d02&_sort=-birthdate`
+
+Only the shipping engine does:
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op inner-join`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceId = @p ResourceId = @p ResourceTypeId = <n>  [or,or]
+cte1 = DateTimeSearchParam  <-cte0  IsMax = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = DateTimeSearchParam+Resource  <-cte0  IsMax = <n> ResourceId = @p ResourceId = @p ResourceId = @p SearchParamId = <n>  [correlate,correlate,correlate,correlate,inner-join,inner-join,or,or,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?_id=ignixa-inco-p1`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `table Resource (x2)`
+- `filter IsDeleted = <v> (x2)`
+- `filter IsHistory = <v> (x2)`
+- `filter Row < <v>`
+- `filter SearchParamId = <v> (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x12)`
+- `legacy: op count-big (x2)`
+- `legacy: op distinct (x6)`
+- `legacy: op exists (x4)`
+- `legacy: op in (x2)`
+- `legacy: op inner-join (x2)`
+- `legacy: op not (x2)`
+- `legacy: op order-by`
+- `legacy: op row-number`
+- `legacy: op top (x5)`
+- `legacy: op union-all (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte3  IsDeleted = <n> IsHistory = <n> SearchParamId = <n>  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?general-practitioner=ignixa-impsrch-ref-pract-untyped&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x3)`
+- `filter col:ReferenceResourceTypeId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or (x3)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null  [or,or,or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?general-practitioner=ignixa-ref-p2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x3)`
+- `filter col:ReferenceResourceTypeId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or (x3)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null  [or,or,or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?organization=ignixa-impsrch-ref-org-untyped&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?organization=ignixa-ref-ijk&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?organization=ignixa-ref-org-123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/Patient?organization=organization/ignixa-ref-org-123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-ref-suite&_count=100`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-active&active:not=false`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-active&active:not=false&location:missing=false`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = ReferenceSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = ReferenceSearchParam  ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-active&active:not=true`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-active,ignixa-not-pr-inactive&active:not=false`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceId = @p ResourceTypeId = <n>  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p ResourceId = @p  [correlate,correlate,inner-join,or,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-inactive&active:not=false`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-inactive&active:not=true`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n>  [correlate,correlate,exists]
+cte2 = sub:TokenSearchParam  <-cte1  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-noloc&location:missing=false`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = ReferenceSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = ReferenceSearchParam  ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/PractitionerRole?_id=ignixa-not-pr-noloc&location:missing=true`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceTypeId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op correlate (x2)`
+- `compiler: op exists`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n>
+cte2 = sub:ReferenceSearchParam  <-cte1  sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = ReferenceSearchParam  ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=ge5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue >= @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=gt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=le5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=lt5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter col:SingleValue is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p SingleValue > @p col:SingleValue is-not-null col:SingleValue is-not-null  [or]
+cte1 = NumberSearchParam  <-cte0  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [or,union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesLess: `/RiskAssessment?probability=ne5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p SingleValue > @p col:SingleValue is-not-null col:SingleValue is-not-null  [or]
+cte1 = NumberSearchParam  <-cte0  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [or,union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue > @p LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/AllergyIntolerance?category=medication,biologic&identifier=http://fhir262/test%7C&_count=100`
+
+Only the compiler does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p Code = @p ResourceTypeId = <n> SearchParamId = <n>  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/HealthcareService?active:not=false&name:missing=false&_has:PractitionerRole:service:active=true&identifier=http://ignixa.io/testscript/suite/escape%7C&_count=100`
+
+Only the compiler does:
+- `filter ReferenceResourceTypeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op in (x2)`
+- `legacy: op inner-join`
+- `legacy: op not-in`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct (x3)`
+- `compiler: op exists`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte5  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam+Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,in,in,inner-join]
+cte1 = TokenSearchParam  <-cte0  Code = @p SearchParamId = <n>  [correlate,correlate,inner-join]
+cte2 = TokenSearchParam  <-cte1  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,inner-join]
+cte3 = StringSearchParam  <-cte2  ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,inner-join]
+cte4 = sub:TokenSearchParam  <-cte3  sub:Code = @p sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte5 = <-cte4  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte7  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,inner-join,inner-join]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte0,cte2  [correlate,correlate,inner-join]
+cte5 = <-cte3,cte4  [correlate,correlate,inner-join]
+cte6 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte7 = <-cte5,cte6  [correlate,correlate,exists,not]
+```
+
+</details>
+
+### CompilerDoesMore: `/Observation?code-value-string=162806009$Lorem,162806009$blue&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the compiler does:
+- `table TokenStringCompositeSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:Text2 like @p col:Text2 like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:Text2 like @p  [distinct]
+cte1 = TokenStringCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> col:Text2 like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Observation?code=code1,http://ignixa.io/testscript/suite/token-sys-b%7Ccode2&identifier=http://ignixa.io/testscript/suite/token%7C&_count=100`
+
+Only the compiler does:
+- `table TokenSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Observation?code=ignixa-date-test&date=gt1980-05-10&date=lt1980-05-12`
+
+Only the compiler does:
+- `table DateTimeSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op inner-join`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>
+cte1 = DateTimeSearchParam  <-cte0  EndDateTime > @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime < @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = DateTimeSearchParam  EndDateTime > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte2 = DateTimeSearchParam  ResourceTypeId = <n> SearchParamId = <n> StartDateTime < @p  [distinct]
+cte3 = <-cte0,cte1  [correlate,correlate,inner-join]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Observation?combo-code-value-concept=http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6722-8,http://snomed.info/sct%7C249227004$http://loinc.org/la%7CLA6724-4&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the compiler does:
+- `table TokenTokenCompositeSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenTokenCompositeSearchParam  Code1 = @p Code1 = @p Code2 = @p Code2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId1 = @p SystemId2 = @p SystemId2 = @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = TokenTokenCompositeSearchParam  Code1 = @p Code2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte1 = TokenTokenCompositeSearchParam  Code1 = @p Code2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Observation?subject:Patient.family=Smith&identifier=http://fhir262/test%7C&_count=100`
+
+Only the compiler does:
+- `filter ReferenceResourceTypeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op in (x2)`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam+Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,in,in,inner-join]
+cte1 = StringSearchParam  <-cte0  SearchParamId = <n> col:Text like @p  [correlate,correlate,inner-join]
+cte2 = TokenSearchParam  <-cte1  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte3  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = ReferenceSearchParam+Resource  <-cte0  IsDeleted = <n> IsHistory = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,inner-join,inner-join]
+cte2 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte3 = <-cte1,cte2  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Organization?_id=ignixa-inc-org-a&_include:iterate=Organization:partof`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x2)`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x3)`
+- `legacy: op in`
+- `legacy: op row-number`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n>  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = <-cte1,cte3  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim  [correlate,correlate,exists,not,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?family=Smith,Anderson&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:Text like @p  [or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?family=Zephyr,Jones&identifier=http://ignixa.io/testscript/suite/escape%7C&_count=100`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:Text like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?given=Alex,Bob&family=Smith&identifier=http://fhir262/test%7C&_count=100`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists (x2)`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct (x2)`
+- `compiler: op inner-join`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:Text like @p  [or]
+cte1 = StringSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [correlate,correlate,exists]
+cte2 = TokenSearchParam  <-cte1  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte6  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte4 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte5 = <-cte2,cte3  [correlate,correlate,inner-join]
+cte6 = <-cte4,cte5  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?given=Alex,Carol&identifier=http://fhir262/test%7C&_count=100`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:Text like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?name=Doe,Smith&identifier=http://fhir262/test%7C&_count=100`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:Text like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### CompilerDoesMore: `/Patient?organization.name=ACME%20Corp`
+
+Only the compiler does:
+- `filter ReferenceResourceTypeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op in (x2)`
+- `legacy: op inner-join`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam+Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,in,in,inner-join]
+cte1 = StringSearchParam  <-cte0  SearchParamId = <n> col:Text like @p  [correlate,correlate,inner-join]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte1  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p  [distinct]
+cte1 = ReferenceSearchParam+Resource  <-cte0  IsDeleted = <n> IsHistory = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,inner-join,inner-join]
+```
+
+</details>
+
+### Divergent: `/DiagnosticReport?specimen:missing=true&_id=ignixa-inc-dr1&_include=DiagnosticReport:result`
+
+Only the shipping engine does:
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter Row < <v>`
+
+Only the compiler does:
+- `filter ResourceTypeId = <v>`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x2)`
+- `legacy: op in`
+- `legacy: op not-in`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op correlate (x2)`
+- `compiler: op exists`
+- `compiler: op not`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n>
+cte2 = sub:ReferenceSearchParam  <-cte1  sub:ResourceTypeId = <n> sub:SearchParamId = <n>  [not-in]
+cte3 = <-cte2  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte3 = 
+cte4 = ReferenceSearchParam+Resource  <-cte3  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte3,cte5  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim  [correlate,correlate,exists,not,union-all]
+cte0 = ReferenceSearchParam  ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cte2 = <-cte0,cte1  [correlate,correlate,exists,not]
+cteMatchPage = Resource  <-cte2  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/DocumentReference/$docref?patient=ignixa-docref-pat0,ignixa-docref-pat1`
+
+Only the shipping engine does:
+- `filter ReferenceResourceTypeId = <v> (x8)`
+- `filter col:ReferenceResourceTypeId is-null (x2)`
+
+Only the compiler does:
+- `table ReferenceSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op inner-join`
+- `legacy: op or (x9)`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte1  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null col:ReferenceResourceTypeId is-null  [or,or,or,or,or,or,or,or,or]
+cte1 = <-cte0  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = ReferenceSearchParam  ReferenceResourceId = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte2 = <-cte0,cte1  [union]
+```
+
+</details>
+
+### Divergent: `/HealthcareService?_id=ignixa-id-a,ignixa-id-b,ignixa-id-c&_count=100`
+
+Only the shipping engine does:
+- `table TokenSearchParam`
+- `filter Code = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+
+Only the compiler does:
+- `filter ResourceId = <v> (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op or (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p ResourceId = @p ResourceId = @p  [correlate,correlate,inner-join,or,or,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Location?_id=ignixa-inc-loc-self&_include=Location:partof`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x2)`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x3)`
+- `legacy: op in`
+- `legacy: op row-number`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = <-cte1,cte3  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim  [correlate,correlate,exists,not,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/MedicationDispense?_id=ignixa-inco-md1&_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:subject&_includesCount=1`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x5)`
+- `filter col:BaseUri is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x4)`
+- `legacy: op in (x2)`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op or`
+- `compiler: op order-by (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte3  IsDeleted = <n> IsHistory = <n> SearchParamId = <n>  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim,inc1lim  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+inc1 = ReferenceSearchParam+Resource  <-inc0lim  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,order-by,top]
+inc1lim = <-inc1  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Observation?_id=ignixa-inc-obs1&_include=Observation:performer`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x7)`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x3)`
+- `legacy: op in`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op or (x5)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = <-cte1,cte3  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim  [correlate,correlate,exists,not,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Observation?_id=ignixa-inc-obs1&_include=Observation:subject&_include:iterate=Patient:general-practitioner`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x9)`
+- `filter col:BaseUri is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x4)`
+- `legacy: op in (x2)`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op or (x5)`
+- `compiler: op order-by (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte3  IsDeleted = <n> IsHistory = <n> SearchParamId = <n>  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim,inc1lim  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+inc1 = ReferenceSearchParam+Resource  <-inc0lim  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,order-by,top]
+inc1lim = <-inc1  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Observation?_id=ignixa-inc-obs1&_include=Observation:subject&_include:iterate=Patient:organization`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x7)`
+- `filter col:BaseUri is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x4)`
+- `legacy: op in (x2)`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op or (x3)`
+- `compiler: op order-by (x2)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> SearchParamId = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte3  IsDeleted = <n> IsHistory = <n> SearchParamId = <n>  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim,inc1lim  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+inc1 = ReferenceSearchParam+Resource  <-inc0lim  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top]
+inc1lim = <-inc1  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Observation?code=ignixa-date-test&date=1980-05-16T16:32:15.500Z`
+
+Only the shipping engine does:
+- `filter EndDateTime >= <v>`
+- `filter StartDateTime <= <v>`
+
+Only the compiler does:
+- `filter EndDateTime <= <v>`
+- `filter StartDateTime >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>
+cte1 = DateTimeSearchParam  <-cte0  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime <= @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = DateTimeSearchParam  EndDateTime <= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime >= @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$60&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the shipping engine does:
+- `table TokenQuantityCompositeSearchParam`
+- `filter Code1 = <v>`
+- `filter HighValue2 >= <v>`
+- `filter LowValue2 <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue2 <= <v>`
+- `filter SingleValue2 >= <v>`
+- `filter SystemId1 = <v>`
+- `filter col:SingleValue2 is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue2 <= <v>`
+- `filter LowValue2 >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue2 <= @p SingleValue2 >= @p SystemId1 = @p col:SingleValue2 is-not-null col:SingleValue2 is-not-null
+cte1 = TokenQuantityCompositeSearchParam  <-cte0  Code1 = @p HighValue2 >= @p LowValue2 <= @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 <= @p LowValue2 >= @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?date=1980&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter EndDateTime >= <v>`
+- `filter StartDateTime <= <v>`
+
+Only the compiler does:
+- `filter EndDateTime <= <v>`
+- `filter StartDateTime >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = DateTimeSearchParam  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime <= @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = DateTimeSearchParam  EndDateTime <= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime >= @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?date=1980-05-11&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter EndDateTime >= <v>`
+- `filter StartDateTime <= <v>`
+
+Only the compiler does:
+- `filter EndDateTime <= <v>`
+- `filter StartDateTime >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = DateTimeSearchParam  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime <= @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = DateTimeSearchParam  EndDateTime <= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime >= @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=2e-3&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5%7C%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter QuantityCodeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+- `filter col:SystemId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> col:SystemId is-null  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5%7C%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter QuantityCodeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+- `filter col:SystemId is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> col:SystemId is-null  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5%7Csystem1%7Cunit2&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter QuantityCodeId = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter SystemId = <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p SystemId = @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p QuantityCodeId = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5%7Csystem1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter SystemId = <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p SystemId = @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5%7Csystem1&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter SystemId = <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p SystemId = @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=eb5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter LowValue < <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter col:SingleValue is-not-null`
+
+Only the compiler does:
+- `filter HighValue < <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=eq5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?value-quantity=sa5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-qty-suite&_count=100`
+
+Only the shipping engine does:
+- `table QuantitySearchParam`
+- `filter HighValue > <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Only the compiler does:
+- `filter LowValue > <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = QuantitySearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = QuantitySearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = QuantitySearchParam  LowValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient/ignixa-cmp-pat1/Observation?performer=Practitioner/ignixa-cmp-prac-other`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `filter ReferenceResourceId = <v> (x2)`
+- `filter ReferenceResourceTypeId = <v> (x12)`
+- `filter ResourceTypeId = <v> (x3)`
+- `filter SearchParamId = <v> (x3)`
+- `filter col:ReferenceResourceTypeId is-null (x2)`
+
+Only the compiler does:
+- `filter IsDeleted = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x6)`
+- `legacy: op distinct (x2)`
+- `legacy: op exists`
+- `legacy: op inner-join (x2)`
+- `legacy: op or (x11)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null col:ReferenceResourceTypeId is-null  [or,or,or,or,or,or,or,or,or,or,or]
+cte1 = <-cte0
+cte2 = Resource  <-cte1  IsHistory = <n> ResourceTypeId = <n>  [correlate,correlate,inner-join]
+cte3 = ReferenceSearchParam  <-cte2  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte4 = <-cte3  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Patient/ignixa-cmp-pat1/Observation?performer=Practitioner/ignixa-cmp-prac1`
+
+Only the shipping engine does:
+- `table ReferenceSearchParam (x2)`
+- `filter ReferenceResourceId = <v> (x2)`
+- `filter ReferenceResourceTypeId = <v> (x12)`
+- `filter ResourceTypeId = <v> (x3)`
+- `filter SearchParamId = <v> (x3)`
+- `filter col:ReferenceResourceTypeId is-null (x2)`
+
+Only the compiler does:
+- `filter IsDeleted = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x6)`
+- `legacy: op distinct (x2)`
+- `legacy: op exists`
+- `legacy: op inner-join (x2)`
+- `legacy: op or (x11)`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = ReferenceSearchParam  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ReferenceResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n> SearchParamId = <n> col:ReferenceResourceTypeId is-null col:ReferenceResourceTypeId is-null  [or,or,or,or,or,or,or,or,or,or,or]
+cte1 = <-cte0
+cte2 = Resource  <-cte1  IsHistory = <n> ResourceTypeId = <n>  [correlate,correlate,inner-join]
+cte3 = ReferenceSearchParam  <-cte2  ReferenceResourceId = @p ReferenceResourceTypeId = <n> ResourceTypeId = <n> SearchParamId = <n>  [correlate,correlate,exists]
+cte4 = <-cte3  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte0  [order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Patient?_id=880fb2d8-f23b-47a5-a398-0939a79a9c5e,63220610-3dac-4eff-af3f-a179f187758b,b0ac0bcb-9599-48d8-b688-c7612377c558,38bfef7f-1475-48f7-812f-35c31261fc46&birthdate=ge1980-01-01&birthdate=lt2000-01-01`
+
+Only the shipping engine does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+
+Only the compiler does:
+- `table DateTimeSearchParam`
+- `filter SearchParamId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op inner-join`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceId = @p ResourceId = @p ResourceId = @p ResourceTypeId = <n>  [or,or,or]
+cte1 = DateTimeSearchParam  <-cte0  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n> StartDateTime < @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte2  ResourceId = @p ResourceId = @p ResourceId = @p ResourceId = @p  [correlate,correlate,inner-join,or,or,or,order-by]
+cte0 = DateTimeSearchParam  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = DateTimeSearchParam  ResourceTypeId = <n> SearchParamId = <n> StartDateTime < @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?_id=e5ec00b6-1167-49b3-a754-c2f8d57ab7cb`
+
+Only the shipping engine does:
+- `table DateTimeSearchParam`
+- `table TokenSearchParam`
+- `filter EndDateTime >= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v> (x2)`
+- `filter SystemId = <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter IsDeleted = <v>`
+- `filter IsHistory = <v>`
+- `filter ResourceId = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op distinct (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = DateTimeSearchParam  EndDateTime >= @p ResourceTypeId = <n> SearchParamId = <n>
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Patient?address-city:contains=Vestibulum&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter col:TextOverflow is-not-null`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-not-null col:TextOverflow like @p  [or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-null col:TextOverflow like @p  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?address-city:contains=att&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter col:TextOverflow is-not-null`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-not-null col:TextOverflow like @p  [or]
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-null col:TextOverflow like @p  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?address-city:exact=Seattle&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter Text = <v>`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p Text = @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?address-city:exact=seattle&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter Text = <v>`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p Text = @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?family:contains=SON&identifier=http://fhir262/test%7C&_count=100`
+
+Only the shipping engine does:
+- `filter col:TextOverflow is-not-null`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-not-null col:TextOverflow like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-null col:TextOverflow like @p  [distinct,or]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?family:contains=son&identifier=http://fhir262/test%7C&_count=100`
+
+Only the shipping engine does:
+- `filter col:TextOverflow is-not-null`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-not-null col:TextOverflow like @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Text like @p col:TextOverflow is-null col:TextOverflow like @p  [distinct,or]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?family:exact=Smith&identifier=http://fhir262/test%7C&_count=100`
+
+Only the shipping engine does:
+- `filter Text = <v>`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p Text = @p
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?family:exact=smith&identifier=http://fhir262/test%7C&_count=100`
+
+Only the shipping engine does:
+- `filter Text = <v>`
+
+Only the compiler does:
+- `filter col:TextOverflow is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p Text = @p
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Patient?given:exact=Alex,Carol&identifier=http://fhir262/test%7C&_count=100`
+
+Only the shipping engine does:
+- `filter Text = <v> (x2)`
+
+Only the compiler does:
+- `table StringSearchParam`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter col:TextOverflow is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op or`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op distinct`
+- `compiler: op union`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p Text = @p Text = @p Text = @p  [or]
+cte1 = TokenSearchParam  <-cte0  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte4  [order-by]
+cte0 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte1 = StringSearchParam  ResourceTypeId = <n> SearchParamId = <n> Text = @p col:TextOverflow is-null  [distinct]
+cte2 = <-cte0,cte1  [union]
+cte3 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte4 = <-cte2,cte3  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/RiskAssessment?probability=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/RiskAssessment?probability=5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/RiskAssessment?probability=eb5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter LowValue < <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue < <v>`
+- `filter col:SingleValue is-not-null`
+
+Only the compiler does:
+- `filter HighValue < <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue < @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  LowValue < @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue < @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/RiskAssessment?probability=eq5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter HighValue >= <v>`
+- `filter LowValue <= <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue <= <v>`
+- `filter SingleValue >= <v>`
+- `filter col:SingleValue is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue <= <v>`
+- `filter LowValue >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue <= @p SingleValue >= @p col:SingleValue is-not-null col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue >= @p LowValue <= @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  HighValue <= @p LowValue >= @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/RiskAssessment?probability=sa5&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-num-suite&_count=100`
+
+Only the shipping engine does:
+- `table NumberSearchParam`
+- `filter HighValue > <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue > <v>`
+- `filter col:SingleValue is-not-null`
+
+Only the compiler does:
+- `filter LowValue > <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = NumberSearchParam  ResourceTypeId = <n> SearchParamId = <n> SingleValue > @p col:SingleValue is-not-null
+cte1 = NumberSearchParam  <-cte0  HighValue > @p ResourceTypeId = <n> SearchParamId = <n>  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = NumberSearchParam  LowValue > @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:above=http://ignixa-unrelated.example.com/x&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite`
+
+Only the shipping engine does:
+- `filter <v> like (col:Uri op <s>)`
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter <expr> = col:Uri`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  @p like (col:Uri op <s>) ResourceTypeId = <n> SearchParamId = <n> col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  <expr> = col:Uri ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:above=http://ignixa.example.com/rdf%2354135-9-9-10&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite`
+
+Only the shipping engine does:
+- `filter <v> like (col:Uri op <s>)`
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter <expr> = col:Uri`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  @p like (col:Uri op <s>) ResourceTypeId = <n> SearchParamId = <n> col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  <expr> = col:Uri ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:above=http://ignixa.example.com/test/system/123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite`
+
+Only the shipping engine does:
+- `filter <v> like (col:Uri op <s>)`
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter <expr> = col:Uri`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  @p like (col:Uri op <s>) ResourceTypeId = <n> SearchParamId = <n> col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  <expr> = col:Uri ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:above=http://somewhere.com/test/system/123&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter <v> like (col:Uri op <s>)`
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter <expr> = col:Uri`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  @p like (col:Uri op <s>) ResourceTypeId = <n> SearchParamId = <n> col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  <expr> = col:Uri ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:below=http&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter Uri = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op or`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Uri like @p col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> Uri = @p col:Uri like @p  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:below=http://ignixa-unrelated.example.com&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite`
+
+Only the shipping engine does:
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter Uri = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op or`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Uri like @p col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> Uri = @p col:Uri like @p  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/ValueSet?url:below=http://ignixa.example.com&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-uri-suite`
+
+Only the shipping engine does:
+- `filter col:Uri not-like <v>`
+
+Only the compiler does:
+- `filter Uri = <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `compiler: op or`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte2  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> col:Uri like @p col:Uri not-like @p
+cte1 = TokenSearchParam  <-cte0  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte2 = <-cte1  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = UriSearchParam  ResourceTypeId = <n> SearchParamId = <n> Uri = @p col:Uri like @p  [distinct,or]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+

--- a/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
@@ -6,20 +6,13 @@
 
 | Verdict | Count |
 |---|---:|
-| NotCompiled | 8 |
+| NotCompiled | 4 |
 | Match | 69 |
-| CompilerDoesLess | 44 |
+| CompilerDoesLess | 45 |
 | CompilerDoesMore | 14 |
-| Divergent | 50 |
+| Divergent | 53 |
 
 ## Gaps -- queries the compiler cannot express
-
-### build:BadSearchRequestException (4)
-
-- **4x** Only one token separator can be specified.
-  - `/Observation?code-value-quantity=http://loinc.org%7C8310-5$gt38%7Chttp://unitsofmeasure.org%7CCel&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
-  - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$107%7Chttp://unitsofmeasure.org%7Cmm%5BHg%5D&identifier=http://ignixa.io/testscript/suite/composite%7C`
-  - `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$120%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
 
 ### build:InvalidSearchOperationException (3)
 
@@ -182,6 +175,45 @@ cte2 = <-cte1  [distinct,order-by,top]
 compiler:
 select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
 cte0 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n>  [distinct]
+```
+
+</details>
+
+### CompilerDoesLess: `/Observation?code-value-quantity=http://loinc.org%7C8310-5$gt38%7Chttp://unitsofmeasure.org%7CCel&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table TokenQuantityCompositeSearchParam`
+- `filter Code1 = <v>`
+- `filter QuantityCodeId2 = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue2 > <v>`
+- `filter SystemId1 = <v>`
+- `filter SystemId2 = <v>`
+- `filter col:SingleValue2 is-not-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue2 > @p SystemId1 = @p SystemId2 = @p col:SingleValue2 is-not-null
+cte1 = TokenQuantityCompositeSearchParam  <-cte0  Code1 = @p HighValue2 > @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 > @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
 ```
 
 </details>
@@ -2397,6 +2429,98 @@ cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
 
 </details>
 
+### Divergent: `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$107%7Chttp://unitsofmeasure.org%7Cmm%5BHg%5D&identifier=http://ignixa.io/testscript/suite/composite%7C`
+
+Only the shipping engine does:
+- `table TokenQuantityCompositeSearchParam`
+- `filter Code1 = <v>`
+- `filter HighValue2 >= <v>`
+- `filter LowValue2 <= <v>`
+- `filter QuantityCodeId2 = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue2 <= <v>`
+- `filter SingleValue2 >= <v>`
+- `filter SystemId1 = <v>`
+- `filter SystemId2 = <v>`
+- `filter col:SingleValue2 is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue2 <= <v>`
+- `filter LowValue2 >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue2 <= @p SingleValue2 >= @p SystemId1 = @p SystemId2 = @p col:SingleValue2 is-not-null col:SingleValue2 is-not-null
+cte1 = TokenQuantityCompositeSearchParam  <-cte0  Code1 = @p HighValue2 >= @p LowValue2 <= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 <= @p LowValue2 >= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$120%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table TokenQuantityCompositeSearchParam`
+- `filter Code1 = <v>`
+- `filter HighValue2 >= <v>`
+- `filter LowValue2 <= <v>`
+- `filter QuantityCodeId2 = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue2 <= <v>`
+- `filter SingleValue2 >= <v>`
+- `filter SystemId1 = <v>`
+- `filter SystemId2 = <v>`
+- `filter col:SingleValue2 is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue2 <= <v>`
+- `filter LowValue2 >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue2 <= @p SingleValue2 >= @p SystemId1 = @p SystemId2 = @p col:SingleValue2 is-not-null col:SingleValue2 is-not-null
+cte1 = TokenQuantityCompositeSearchParam  <-cte0  Code1 = @p HighValue2 >= @p LowValue2 <= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 <= @p LowValue2 >= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
 ### Divergent: `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$60&identifier=http://ignixa.io/testscript/suite/composite%7C`
 
 Only the shipping engine does:
@@ -2436,6 +2560,52 @@ compiler:
 select0 = <-cte2  [order-by]
 cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 <= @p LowValue2 >= @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p  [distinct]
 cte1 = TokenSearchParam  ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
+cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
+```
+
+</details>
+
+### Divergent: `/Observation?combo-code-value-quantity=http://loinc.org%7C8480-6$80%7Chttp://unitsofmeasure.org%7CmmHg&_tag=http://ignixa.io/testscript/suite/test%7Cignixa-impsrch-suite&_count=100`
+
+Only the shipping engine does:
+- `table TokenQuantityCompositeSearchParam`
+- `filter Code1 = <v>`
+- `filter HighValue2 >= <v>`
+- `filter LowValue2 <= <v>`
+- `filter QuantityCodeId2 = <v>`
+- `filter ResourceTypeId = <v>`
+- `filter SearchParamId = <v>`
+- `filter SingleValue2 <= <v>`
+- `filter SingleValue2 >= <v>`
+- `filter SystemId1 = <v>`
+- `filter SystemId2 = <v>`
+- `filter col:SingleValue2 is-not-null (x2)`
+
+Only the compiler does:
+- `filter HighValue2 <= <v>`
+- `filter LowValue2 >= <v>`
+
+Operator differences (encoding, not semantics):
+- `legacy: op correlate (x2)`
+- `legacy: op exists`
+- `legacy: op order-by`
+- `legacy: op top`
+- `legacy: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+select0 = Resource  <-cte3  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SingleValue2 <= @p SingleValue2 >= @p SystemId1 = @p SystemId2 = @p col:SingleValue2 is-not-null col:SingleValue2 is-not-null
+cte1 = TokenQuantityCompositeSearchParam  <-cte0  Code1 = @p HighValue2 >= @p LowValue2 <= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [union-all]
+cte2 = TokenSearchParam  <-cte1  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [correlate,correlate,exists]
+cte3 = <-cte2  [distinct,order-by,top]
+
+compiler:
+select0 = <-cte2  [order-by]
+cte0 = TokenQuantityCompositeSearchParam  Code1 = @p HighValue2 <= @p LowValue2 >= @p QuantityCodeId2 = @p ResourceTypeId = <n> SearchParamId = <n> SystemId1 = @p SystemId2 = @p  [distinct]
+cte1 = TokenSearchParam  Code = @p ResourceTypeId = <n> SearchParamId = <n> SystemId = @p  [distinct]
 cte2 = <-cte0,cte1  [correlate,correlate,inner-join]
 ```
 

--- a/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/reports/differential-report.md
@@ -6,20 +6,15 @@
 
 | Verdict | Count |
 |---|---:|
-| NotCompiled | 3 |
+| NotCompiled | 0 |
 | Match | 69 |
 | CompilerDoesLess | 46 |
 | CompilerDoesMore | 14 |
-| Divergent | 53 |
+| Divergent | 56 |
 
 ## Gaps -- queries the compiler cannot express
 
-### build:InvalidSearchOperationException (3)
-
-- **3x** The _include search is missing the type to search.
-  - `/Patient?_id=ignixa-inc-pat1&_include=*`
-  - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*`
-  - `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1`
+None.
 
 ## Divergences -- compiled, but asks the database for something different
 
@@ -3319,6 +3314,137 @@ cte2 = <-cte1  [distinct,order-by,top]
 compiler:
 select0 = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join,order-by]
 cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+```
+
+</details>
+
+### Divergent: `/Patient?_id=ignixa-inc-pat1&_include=*`
+
+Only the shipping engine does:
+- `filter Row < <v>`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x6)`
+- `filter col:BaseUri is-null`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x3)`
+- `legacy: op in`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op or (x5)`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte4  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = <-cte1,cte3  [correlate,correlate,exists,not,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim  [correlate,correlate,exists,not,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*`
+
+Only the shipping engine does:
+- `filter Row < <v> (x2)`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x7)`
+- `filter col:BaseUri is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x4)`
+- `legacy: op in (x2)`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op correlate (x2)`
+- `compiler: op or (x5)`
+- `compiler: op order-by (x2)`
+- `compiler: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim,inc1lim  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+inc1 = ReferenceSearchParam+Resource  <-cteMatchPage,inc0lim  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top,union-all]
+inc1lim = <-inc1  [count-big,order-by,top]
+```
+
+</details>
+
+### Divergent: `/Patient?_id=ignixa-inco-p1&_include=*&_revinclude=*&_includesCount=1`
+
+Only the shipping engine does:
+- `filter Row < <v> (x2)`
+
+Only the compiler does:
+- `table Resource`
+- `filter ResourceTypeId = <v> (x7)`
+- `filter col:BaseUri is-null (x2)`
+
+Operator differences (encoding, not semantics):
+- `legacy: op distinct (x4)`
+- `legacy: op in (x2)`
+- `legacy: op row-number`
+- `legacy: op top`
+- `compiler: op correlate (x2)`
+- `compiler: op or (x5)`
+- `compiler: op order-by (x2)`
+- `compiler: op union-all`
+
+<details><summary>shapes</summary>
+
+```
+legacy:
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceId = @p ResourceTypeId = <n>
+cte1 = <-cte0  [distinct,order-by,row-number,top]
+select0 = Resource  <-cte6  IsDeleted = <n> IsHistory = <n>  [correlate,correlate,distinct,inner-join,order-by]
+cte1 = 
+cte2 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte3 = <-cte2  [count-big,distinct,top]
+cte4 = ReferenceSearchParam+Resource  <-cte1  IsDeleted = <n> IsHistory = <n> sub:Row < @p  [correlate,correlate,correlate,correlate,distinct,exists,in,inner-join,top]
+cte5 = <-cte4  [count-big,distinct,top]
+cte6 = <-cte1,cte3,cte5  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+
+compiler:
+select0 = <-cteMatchPage,inc0lim,inc1lim  [correlate,correlate,correlate,correlate,exists,exists,not,not,union-all,union-all]
+cte0 = Resource  IsDeleted = <n> IsHistory = <n> ResourceTypeId = @p
+cteMatchPage = Resource  <-cte0  ResourceId = @p  [correlate,correlate,inner-join]
+inc0 = ReferenceSearchParam+Resource  <-cteMatchPage  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> ResourceTypeId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,distinct,exists,inner-join,or,or,or,or,or,order-by,top]
+inc0lim = <-inc0  [count-big,order-by,top]
+inc1 = ReferenceSearchParam+Resource  <-cteMatchPage,inc0lim  IsDeleted = <n> IsHistory = <n> ResourceTypeId = <n> col:BaseUri is-null  [correlate,correlate,correlate,correlate,correlate,correlate,distinct,exists,inner-join,order-by,top,union-all]
+inc1lim = <-inc1  [count-big,order-by,top]
 ```
 
 </details>

--- a/test/Ignixa.Search.Sql.Tests/Corpus/tools/extract-corpus.py
+++ b/test/Ignixa.Search.Sql.Tests/Corpus/tools/extract-corpus.py
@@ -1,0 +1,164 @@
+"""Extracts the slim legacy-SQL corpus consumed by the differential tests.
+
+Input is an ignixa-sql-capture artifact directory (the TestScript run that recorded, per HTTP
+request, the SQL the shipping search engine actually executed). Output is
+``../legacy-sql-corpus.json`` -- one entry per distinct search URL.
+
+Correlation in the capture is timestamp-windowed, so a single request can pick up SQL text that
+belongs to an adjacent request. Every SQL event correlated to a request carries the *batch* text,
+so the genuine query appears on several events of the same request while a leaked neighbour
+appears on one. The modal SQL text per URL is therefore the request's own query; entries whose
+mode is not corroborated by at least two events are marked low-confidence and excluded by default.
+
+Usage:
+    python extract-corpus.py <capture-artifact-dir> [--include-low-confidence]
+"""
+
+import argparse
+import collections
+import csv
+import json
+import os
+import re
+import sys
+
+CSV_NAME = "passing-test-sql.csv"
+OUTPUT_NAME = "legacy-sql-corpus.json"
+
+DECLARE_RE = re.compile(r"^DECLARE (@p\d+) (?:AS )?([A-Za-z]+(?:\([\w, ]+\))?) = (.*)$")
+DECLARATION_RE = re.compile(r"(@p\d+) ([A-Za-z]+(?:\([\w, ]+\))?)")
+
+
+def split_batch_prefix(sql):
+    """Splits `(@p0 varchar(256),@p1 int)<body>` into (declarations, body).
+
+    The prefix cannot be matched with a naive `\\([^)]*\\)` because parameter types carry their own
+    parentheses (`varchar(256)`, `decimal(18,6)`); depth counting is what actually terminates it.
+    """
+    if not sql.startswith("(@p"):
+        return "", sql
+    depth = 0
+    for index, character in enumerate(sql):
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[1:index], sql[index + 1:]
+    return "", sql
+
+
+def read_rows(capture_dir):
+    path = os.path.join(capture_dir, CSV_NAME)
+    if not os.path.exists(path):
+        sys.exit(f"not a capture artifact directory (no {CSV_NAME}): {capture_dir}")
+    csv.field_size_limit(10**9)
+    with open(path, encoding="utf-8-sig", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def is_search_batch(sql):
+    return sql.startswith("(@p") and ";WITH" in sql
+
+
+def unwrap_log_event(sql):
+    """Returns the inner SQL of a `exec dbo.LogEvent ... @Text=N'<sql>'` wrapper, or None."""
+    if not sql.startswith("exec dbo.LogEvent"):
+        return None
+    marker = "@Text=N'"
+    start = sql.find(marker)
+    if start < 0:
+        return None
+    return sql[start + len(marker):].rstrip("'").replace("''", "'")
+
+
+def parameter_values(log_event_sql):
+    """Pulls the `DECLARE @p0 varchar(64) = 'value'` preamble the LogEvent variant carries."""
+    values = {}
+    for line in log_event_sql.splitlines():
+        match = DECLARE_RE.match(line.strip())
+        if not match:
+            continue
+        name, sql_type, literal = match.groups()
+        literal = literal.strip()
+        if literal.startswith("'") and literal.endswith("'"):
+            literal = literal[1:-1]
+        values[name] = {"type": sql_type, "value": literal}
+    return values
+
+
+def parameter_types(sql):
+    declarations, _ = split_batch_prefix(sql)
+    return {name: sql_type for name, sql_type in DECLARATION_RE.findall(declarations)}
+
+
+def strip_batch_prefix(sql):
+    """Drops the sp_executesql parameter prefix and the SET STATISTICS preamble."""
+    _, body = split_batch_prefix(sql)
+    lines = [
+        line for line in body.splitlines()
+        if not line.startswith("SET STATISTICS")
+    ]
+    return "\n".join(lines).strip()
+
+
+def build_entries(rows, include_low_confidence):
+    batches = collections.defaultdict(collections.Counter)
+    log_events = {}
+    provenance = collections.defaultdict(set)
+
+    for row in rows:
+        if row["Method"] != "GET" or not row["SearchQuery"]:
+            continue
+        url, sql = row["RequestUrl"], row["RawSql"]
+        if is_search_batch(sql):
+            batches[url][sql] += 1
+            provenance[url].add((row["ScriptRelativePath"], row["TestName"]))
+            continue
+        inner = unwrap_log_event(sql)
+        if inner and ";WITH" in inner:
+            log_events.setdefault(url, inner)
+
+    entries = []
+    for url, counter in sorted(batches.items()):
+        sql, occurrences = counter.most_common(1)[0]
+        confident = occurrences >= 2
+        if not confident and not include_low_confidence:
+            continue
+        scripts = sorted({script for script, _ in provenance[url]})
+        entries.append({
+            "url": url,
+            "legacySql": strip_batch_prefix(sql),
+            "parameterTypes": parameter_types(sql),
+            "parameterValues": parameter_values(log_events.get(url, "")),
+            "sourceScripts": scripts,
+            "corroboratingEvents": occurrences,
+            "rejectedVariants": len(counter) - 1,
+        })
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture_dir")
+    parser.add_argument("--include-low-confidence", action="store_true")
+    args = parser.parse_args()
+
+    rows = read_rows(args.capture_dir)
+    entries = build_entries(rows, args.include_low_confidence)
+
+    output = {
+        "captureRunId": rows[0]["RunId"] if rows else None,
+        "entryCount": len(entries),
+        "entries": entries,
+    }
+    destination = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", OUTPUT_NAME)
+    with open(os.path.normpath(destination), "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(output, handle, indent=1)
+        handle.write("\n")
+
+    print(f"wrote {len(entries)} entries to {os.path.normpath(destination)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -462,15 +462,16 @@ public class EndToEndCompilationTests
         var plan = Lower.Run(tree, symbolTable, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
         var emitted = SqlBuilder.Run(plan);
 
-        // Assert -- one CTE for `active`, a Union of the two Smith/Jones alternatives, ResourceSource, Except, then an outer Intersect
+        // Assert -- one CTE for `active`, a Union of the two Smith/Jones alternatives, then a single
+        // Except subtracting that Union from `active`. There is deliberately no ResourceSource here:
+        // anchoring the negation on one would read every Patient in the partition purely to subtract
+        // from it, when the `active` sibling is already the smaller anchor and yields the same set.
         plan.Explain().ShouldBe(
             "cte0 = TokenSearchParam[103,44]  Code = @p0\n" +
             "cte1 = StringSearchParam[103,202]  Text LIKE @p1 (StartsWith) collate CI_AI\n" +
             "cte2 = StringSearchParam[103,202]  Text LIKE @p2 (StartsWith) collate CI_AI\n" +
             "cte3 = Union(cte1, cte2)\n" +
-            "cte4 = ResourceSource[103]\n" +
-            "cte5 = Except(cte4, cte3)\n" +
-            "root = Intersect(cte0, cte5)");
+            "root = Except(cte0, cte3)");
         emitted.Sql.ShouldNotContain("Smith");
         emitted.Sql.ShouldNotContain("Jones");
         emitted.Sql.ShouldNotContain("true");

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -558,15 +558,13 @@ public class EndToEndCompilationTests
     }
 
     [Fact]
-    public async Task GivenAMultiValueIdNotQuery_WhenCompiled_ThenThrowsRatherThanSilentlyRoutingIntoTokenSearchParam()
+    public async Task GivenAMultiValueIdNotQuery_WhenCompiled_ThenLiftsANegatedOrIntoTheOuterWhere()
     {
         // Arrange -- Patient?_id:not=1,2 (comma-separated, so the binder wraps it as
-        // SearchParameterExpression(idParam, NotExpression(Or([pred("1", Modifier:null), pred("2", Modifier:null)])))
-        // -- the top-level extraction pass only recognizes a BARE SearchParameterPredicateExpression, so this
-        // shape is never extracted; each Or alternative reaches StructuralContext.Lower's dispatch choke point
-        // directly, where it must throw (a resource column has no TokenSearchParam row to match) rather than
-        // silently routing "_id" into TokenSearchParam via the generic Token dispatch, which would silently
-        // produce an always-empty (or always-true, once Except negates it) match instead of a loud failure.
+        // SearchParameterExpression(idParam, NotExpression(Or([pred("1", Modifier:null), pred("2", Modifier:null)])))).
+        // The extraction pass lifts the whole negated Or into the outer WHERE as NOT (ResourceId = @p OR
+        // ResourceId = @p) -- the same shape the shipping engine emits -- rather than routing "_id" into
+        // TokenSearchParam or dropping the negation.
         var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
         var tree = new SearchParameterExpression(
             idParam,
@@ -579,9 +577,18 @@ public class EndToEndCompilationTests
         var resolver = new FakeSymbolResolver();
         resolver.ResourceTypeIds["Patient"] = 103;
 
-        // Act & Assert
+        // Act
         var symbolTable = (await Resolve.RunAsync(tree, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None)).Symbols;
-        Should.Throw<NotSupportedException>(() => Lower.Run(tree, symbolTable, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null));
+        var plan = Lower.Run(tree, symbolTable, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- a single ResourceSource, negation lifted into the outer WHERE, values never inlined
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        not.Operand.ShouldBeOfType<Predicate.Or>();
+        emitted.Sql.ShouldContain("NOT ((ResourceId = @p1 OR ResourceId = @p2))");
+        emitted.Sql.ShouldNotContain("TokenSearchParam");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(object)(short)103, "1", "2"]);
     }
 
     [Fact]

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -114,7 +114,7 @@ public class EndToEndCompilationTests
         // Assert
         plan.Explain().ShouldBe(
             "cte0 = DateTimeSearchParam[104,203]  EndDateTime >= @p0\n" +
-            "cte1 = QuantitySearchParam[104,204]  LowValue > @p1\n" +
+            "cte1 = QuantitySearchParam[104,204]  HighValue > @p1\n" +
             "root = Intersect(cte0, cte1)");
         emitted.Sql.ShouldNotContain("2023");
         emitted.Parameters.ShouldContain(p => p.Value.Equals(dateValue.Start));
@@ -215,7 +215,7 @@ public class EndToEndCompilationTests
         var emitted = SqlBuilder.Run(plan);
 
         // Assert
-        plan.Explain().ShouldBe("root = TokenNumberNumberCompositeSearchParam[104,302]  Code1 = @p0 AND LowValue2 >= @p1 AND HighValue3 <= @p2");
+        plan.Explain().ShouldBe("root = TokenNumberNumberCompositeSearchParam[104,302]  Code1 = @p0 AND HighValue2 >= @p1 AND LowValue3 <= @p2");
         emitted.Sql.ShouldNotContain("8480-6");
         emitted.Parameters.Select(p => (p.Name, p.Value)).ShouldBe([("@p0", (object)"8480-6"), ("@p1", 5m), ("@p2", 10m)]);
     }
@@ -324,7 +324,7 @@ public class EndToEndCompilationTests
         var emitted = SqlBuilder.Run(plan);
 
         // Assert -- Ge (not Eq) so the raw value is used directly, no precision-widening bounds to compute
-        plan.Explain().ShouldBe("root = TokenQuantityCompositeSearchParam[104,402]  Code1 = @p0 AND LowValue2 >= @p1");
+        plan.Explain().ShouldBe("root = TokenQuantityCompositeSearchParam[104,402]  Code1 = @p0 AND HighValue2 >= @p1");
         emitted.Sql.ShouldNotContain("8480-6");
         emitted.Parameters.ShouldContain(p => p.Value.Equals(120m));
     }
@@ -1741,12 +1741,12 @@ public class EndToEndCompilationTests
         var emitted = SqlBuilder.Run(plan);
 
         // Assert -- Ge: raw value used (no precision-widening bounds); SystemId and QuantityCodeId appended in that order
-        plan.Explain().ShouldBe("root = QuantitySearchParam[104,204]  LowValue >= @p0 AND SystemId = @p1 AND QuantityCodeId = @p2");
+        plan.Explain().ShouldBe("root = QuantitySearchParam[104,204]  HighValue >= @p0 AND SystemId = @p1 AND QuantityCodeId = @p2");
         emitted.Sql.ShouldBe(
             ";WITH cte0 AS (\n" +
             "    SELECT DISTINCT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n" +
             "    FROM dbo.QuantitySearchParam\n" +
-            "    WHERE ResourceTypeId = 104 AND SearchParamId = 204 AND ((LowValue >= @p0 AND SystemId = @p1) AND QuantityCodeId = @p2)\n" +
+            "    WHERE ResourceTypeId = 104 AND SearchParamId = 204 AND ((HighValue >= @p0 AND SystemId = @p1) AND QuantityCodeId = @p2)\n" +
             ")\n" +
             "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
             "ORDER BY m.T1 ASC, m.Sid1 ASC");

--- a/test/Ignixa.Search.Sql.Tests/Ignixa.Search.Sql.Tests.csproj
+++ b/test/Ignixa.Search.Sql.Tests/Ignixa.Search.Sql.Tests.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\..\src\Core\Ignixa.Search.Sql\Ignixa.Search.Sql.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Corpus\legacy-sql-corpus.json" CopyToOutputDirectory="PreserveNewest" Link="Corpus\legacy-sql-corpus.json" />
+  </ItemGroup>
+
 </Project>

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -817,4 +817,31 @@ public class LowerTests
         // Assert
         plan.Ctes.Count.ShouldBe(1);
     }
+
+    [Fact]
+    public void GivenAMultiValuedIdParameter_WhenLowered_ThenLiftsTheWholeOrIntoTheOuterWhere()
+    {
+        // Arrange -- Patient?_id=a,b,c. A comma list binds to one SearchParameterExpression wrapping an
+        // Or of predicates, not a bare predicate, so the single-predicate shape the extraction pass
+        // recognised let it fall through to CTE lowering -- where the leaf dispatcher throws on purpose
+        // rather than route a resource column into an unrelated search-param table.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var alternatives = Expression.Or(
+        [
+            new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "a", text: null)),
+            new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "b", text: null)),
+            new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "c", text: null)),
+        ]);
+        var tree = new SearchParameterExpression(idParam, alternatives);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Patient"] = 103 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert -- no search-param CTE is needed for a query that only filters resource columns
+        plan.OuterPredicate.ShouldNotBeNull();
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
 }

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -819,6 +819,54 @@ public class LowerTests
     }
 
     [Fact]
+    public void GivenANegatedPredicateAndedWithAPositiveOne_WhenLowered_ThenSubtractsFromThePositiveRatherThanScanningEveryResource()
+    {
+        // Arrange -- Patient?name=Smith&active:not=true. Anchoring the negation on a ResourceSource makes
+        // the plan read every resource of the type just to subtract from it; the positive sibling is
+        // already a strictly smaller set and (A and not B) is (A except B), so it is the better anchor.
+        var nameParam = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));
+        var activeParam = new SearchParameterInfo("active", "active", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-active"));
+        var name = new SearchParameterPredicateExpression(nameParam, SearchComparator.Eq, modifier: null, new StringSearchValue("Smith"));
+        var notActive = new SearchParameterExpression(
+            activeParam,
+            new SearchParameterPredicateExpression(activeParam, SearchComparator.Eq, new SearchModifier(SearchModifierCode.Not), new TokenSearchValue(system: null, code: "true", text: null)));
+        var tree = new MultiaryExpression(MultiaryOperator.And, [name, notActive]);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [nameParam.Url.ToString()] = 202, [activeParam.Url.ToString()] = 44 },
+            new Dictionary<string, short> { ["Patient"] = 103 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        plan.Ctes.ShouldNotContain(cte => cte is CteDefinition.ResourceSource);
+        var except = plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Except>();
+        plan.Ctes[except.Left.Index].ShouldBeOfType<CteDefinition.ParamSource>().SearchParamId.ShouldBe((short)202);
+        plan.Ctes[except.Right.Index].ShouldBeOfType<CteDefinition.ParamSource>().SearchParamId.ShouldBe((short)44);
+    }
+
+    [Fact]
+    public void GivenANegatedPredicateWithNoPositiveSibling_WhenLowered_ThenStillAnchorsOnTheResourceSource()
+    {
+        // Arrange -- Patient?active:not=true. There is no smaller set to subtract from, so the full
+        // resource set remains the only correct anchor.
+        var activeParam = new SearchParameterInfo("active", "active", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-active"));
+        var tree = new SearchParameterExpression(
+            activeParam,
+            new SearchParameterPredicateExpression(activeParam, SearchComparator.Eq, new SearchModifier(SearchModifierCode.Not), new TokenSearchValue(system: null, code: "true", text: null)));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [activeParam.Url.ToString()] = 44 },
+            new Dictionary<string, short> { ["Patient"] = 103 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        plan.Ctes.ShouldContain(cte => cte is CteDefinition.ResourceSource);
+        plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Except>();
+    }
+
+    [Fact]
     public void GivenAMultiValuedIdParameter_WhenLowered_ThenLiftsTheWholeOrIntoTheOuterWhere()
     {
         // Arrange -- Patient?_id=a,b,c. A comma list binds to one SearchParameterExpression wrapping an

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -892,4 +892,92 @@ public class LowerTests
         plan.OuterPredicate.ShouldNotBeNull();
         plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
     }
+
+    [Fact]
+    public void GivenANotReferencedSourceAndPath_WhenLowered_ThenProducesANotReferencedSourceCteWithResolvedIds()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject.
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Observation-subject"));
+        var tree = new NotReferencedExpression("Observation", "subject");
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [subjectParam.Url.ToString()] = 969 },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Observation"] = 96 },
+            notReferencedPaths: new Dictionary<(string, string), SearchParameterInfo> { [("Observation", "subject")] = subjectParam });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.NotReferencedSource>();
+        source.TargetResourceTypeId.ShouldBe((short)103);
+        source.SourceResourceTypeId.ShouldBe((short)96);
+        source.ReferenceSearchParamId.ShouldBe((short)969);
+    }
+
+    [Fact]
+    public void GivenAFullWildcardNotReferenced_WhenLowered_ThenNeitherSourceNorPathIsSet()
+    {
+        // Arrange -- Patient?_not-referenced=*:*.
+        var tree = new NotReferencedExpression(sourceResourceType: null, referencePath: null);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Patient"] = 103 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.NotReferencedSource>();
+        source.TargetResourceTypeId.ShouldBe((short)103);
+        source.SourceResourceTypeId.ShouldBeNull();
+        source.ReferenceSearchParamId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenAPathWildcardNotReferenced_WhenLowered_ThenSourceIsSetButPathIsNot()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:* -- source type narrows the anti-join, but no
+        // single reference path does.
+        var tree = new NotReferencedExpression("Observation", referencePath: null);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Patient"] = 103, ["Observation"] = 96 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.NotReferencedSource>();
+        source.SourceResourceTypeId.ShouldBe((short)96);
+        source.ReferenceSearchParamId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenANotReferencedAndedWithAnIdentifier_WhenLowered_ThenIntersectsTheAntiJoinWithTheParamSource()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject&identifier=... -- the anti-join composes
+        // with an ordinary predicate the same way any two leaves do.
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Observation-subject"));
+        var identifierParam = new SearchParameterInfo("identifier", "identifier", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-identifier"));
+        var tree = new MultiaryExpression(MultiaryOperator.And,
+        [
+            new NotReferencedExpression("Observation", "subject"),
+            new SearchParameterExpression(
+                identifierParam,
+                new SearchParameterPredicateExpression(identifierParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: "http://ignixa.io/testscript/suite/ms-not-referenced", code: null, text: null))),
+        ]);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [subjectParam.Url.ToString()] = 969, [identifierParam.Url.ToString()] = 1013 },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Observation"] = 96 },
+            notReferencedPaths: new Dictionary<(string, string), SearchParameterInfo> { [("Observation", "subject")] = subjectParam },
+            systemIds: new Dictionary<string, int?> { ["http://ignixa.io/testscript/suite/ms-not-referenced"] = 5 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var intersect = plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        plan.Ctes[intersect.Left.Index].ShouldBeOfType<CteDefinition.NotReferencedSource>();
+        plan.Ctes[intersect.Right.Index].ShouldBeOfType<CteDefinition.ParamSource>();
+    }
 }

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -894,6 +894,36 @@ public class LowerTests
     }
 
     [Fact]
+    public void GivenANegatedMultiValuedIdParameter_WhenLowered_ThenLiftsANegatedOrIntoTheOuterWhere()
+    {
+        // Arrange -- Observation?_id:not=a,b. The binder wraps a negated comma list as
+        // NotExpression(Or([_id=a, _id=b])), each alternative losing its own modifier. It must lift into
+        // the outer WHERE as NOT (ResourceId = @p0 OR ResourceId = @p1), not fall through to CTE lowering
+        // where the leaf dispatcher rejects resource columns.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var tree = new SearchParameterExpression(
+            idParam,
+            new NotExpression(Expression.Or(
+            [
+                new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "a", text: null)),
+                new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "b", text: null)),
+            ])));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Observation"] = 96 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        var or = not.Operand.ShouldBeOfType<Predicate.Or>();
+        or.Left.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceId");
+        or.Right.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceId");
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
+
+    [Fact]
     public void GivenANotReferencedSourceAndPath_WhenLowered_ThenProducesANotReferencedSourceCteWithResolvedIds()
     {
         // Arrange -- Patient?_not-referenced=Observation:subject.

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -924,6 +924,33 @@ public class LowerTests
     }
 
     [Fact]
+    public void GivenASingleValuedNegatedIdParameter_WhenLowered_ThenLiftsABarePredicateUnderNotIntoTheOuterWhere()
+    {
+        // Arrange -- Patient?_id:not=a. The binder still wraps a single value as NotExpression(Or([_id=a])),
+        // so the outer predicate is Not(Equal) directly (a bare predicate under Not), a distinct shape from
+        // the multi-value Not(Or(...)) case. Pins that the one-element Or collapses to the equality without
+        // a spurious Or wrapper.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var tree = new SearchParameterExpression(
+            idParam,
+            new NotExpression(Expression.Or(
+            [
+                new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "a", text: null)),
+            ])));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Patient"] = 103 });
+
+        // Act
+        var plan = Lower.Run(tree, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        not.Operand.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceId");
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
+
+    [Fact]
     public void GivenANotReferencedSourceAndPath_WhenLowered_ThenProducesANotReferencedSourceCteWithResolvedIds()
     {
         // Arrange -- Patient?_not-referenced=Observation:subject.

--- a/test/Ignixa.Search.Sql.Tests/Lowering/NumberLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/NumberLoweringRuleTests.cs
@@ -65,7 +65,7 @@ public class NumberLoweringRuleTests
     }
 
     [Fact]
-    public void GivenGeComparator_WhenLowered_ThenComparesLowValueOnly()
+    public void GivenGeComparator_WhenLowered_ThenComparesHighValue()
     {
         // Arrange
         var parameter = Parameter();
@@ -77,12 +77,12 @@ public class NumberLoweringRuleTests
         // Assert
         cte.ResourceTypeId.ShouldBe((short)103);
         var ge = cte.Predicate.ShouldBeOfType<Predicate.GreaterThanOrEqual>();
-        ge.Column.Column.ShouldBe("LowValue");
+        ge.Column.Column.ShouldBe("HighValue");
         ge.Value.Value.ShouldBe(5.4m);
     }
 
     [Fact]
-    public void GivenGtComparator_WhenLowered_ThenComparesLowValueOnly()
+    public void GivenGtComparator_WhenLowered_ThenComparesHighValue()
     {
         // Arrange
         var parameter = Parameter();
@@ -94,12 +94,12 @@ public class NumberLoweringRuleTests
         // Assert
         cte.ResourceTypeId.ShouldBe((short)103);
         var gt = cte.Predicate.ShouldBeOfType<Predicate.GreaterThan>();
-        gt.Column.Column.ShouldBe("LowValue");
+        gt.Column.Column.ShouldBe("HighValue");
         gt.Value.Value.ShouldBe(5.4m);
     }
 
     [Fact]
-    public void GivenSaComparator_WhenLowered_ThenComparesLowValueOnlySameAsGt()
+    public void GivenSaComparator_WhenLowered_ThenComparesLowValueUnlikeGt()
     {
         // Arrange
         var parameter = Parameter();
@@ -116,7 +116,7 @@ public class NumberLoweringRuleTests
     }
 
     [Fact]
-    public void GivenLeComparator_WhenLowered_ThenComparesHighValueOnly()
+    public void GivenLeComparator_WhenLowered_ThenComparesLowValue()
     {
         // Arrange
         var parameter = Parameter();
@@ -128,12 +128,12 @@ public class NumberLoweringRuleTests
         // Assert
         cte.ResourceTypeId.ShouldBe((short)103);
         var le = cte.Predicate.ShouldBeOfType<Predicate.LessThanOrEqual>();
-        le.Column.Column.ShouldBe("HighValue");
+        le.Column.Column.ShouldBe("LowValue");
         le.Value.Value.ShouldBe(5.4m);
     }
 
     [Fact]
-    public void GivenLtComparator_WhenLowered_ThenComparesHighValueOnly()
+    public void GivenLtComparator_WhenLowered_ThenComparesLowValue()
     {
         // Arrange
         var parameter = Parameter();
@@ -145,12 +145,12 @@ public class NumberLoweringRuleTests
         // Assert
         cte.ResourceTypeId.ShouldBe((short)103);
         var lt = cte.Predicate.ShouldBeOfType<Predicate.LessThan>();
-        lt.Column.Column.ShouldBe("HighValue");
+        lt.Column.Column.ShouldBe("LowValue");
         lt.Value.Value.ShouldBe(5.4m);
     }
 
     [Fact]
-    public void GivenEbComparator_WhenLowered_ThenComparesHighValueOnlySameAsLt()
+    public void GivenEbComparator_WhenLowered_ThenComparesHighValueUnlikeLt()
     {
         // Arrange
         var parameter = Parameter();

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenNumberNumberLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenNumberNumberLoweringRuleTests.cs
@@ -58,10 +58,12 @@ public class TokenNumberNumberLoweringRuleTests
         var tokenPredicate = inner.Left.ShouldBeOfType<Predicate.Equal>();
         tokenPredicate.Column.Column.ShouldBe("Code1");
         tokenPredicate.Value.Value.ShouldBe("8480-6");
+        // ge constrains the upper bound and le the lower one -- the spec's intersection test names the
+        // bound opposite the operator's direction (see NumericRangeComparison).
         var number1Predicate = inner.Right.ShouldBeOfType<Predicate.GreaterThanOrEqual>();
-        number1Predicate.Column.Column.ShouldBe("LowValue2");
+        number1Predicate.Column.Column.ShouldBe("HighValue2");
         var number2Predicate = outer.Right.ShouldBeOfType<Predicate.LessThanOrEqual>();
-        number2Predicate.Column.Column.ShouldBe("HighValue3");
+        number2Predicate.Column.Column.ShouldBe("LowValue3");
     }
 
     [Fact]
@@ -111,7 +113,7 @@ public class TokenNumberNumberLoweringRuleTests
         // Act
         var cte = TokenNumberNumberLoweringRule.Lower(composite, components, ContextResolving(composite, 302), 104);
 
-        // Assert — And(And(tokenPredicate, And(Le(LowValue2,5.94), Ge(HighValue2,4.86))), Ge(LowValue3,10))
+        // Assert — And(And(tokenPredicate, And(Le(LowValue2,5.94), Ge(HighValue2,4.86))), Ge(HighValue3,10))
         var outer = cte.Predicate.ShouldBeOfType<Predicate.And>();
         var inner = outer.Left.ShouldBeOfType<Predicate.And>();
         var tokenPredicate = inner.Left.ShouldBeOfType<Predicate.Equal>();
@@ -124,17 +126,17 @@ public class TokenNumberNumberLoweringRuleTests
         number1Ge.Column.Column.ShouldBe("HighValue2");
         number1Ge.Value.Value.ShouldBe(4.86m);
         var number2Predicate = outer.Right.ShouldBeOfType<Predicate.GreaterThanOrEqual>();
-        number2Predicate.Column.Column.ShouldBe("LowValue3");
+        number2Predicate.Column.Column.ShouldBe("HighValue3");
         number2Predicate.Value.Value.ShouldBe(10m);
 
         // Assert — complete emitted SQL and ordered parameters: token, widened upper, widened lower,
-        // then the non-Ap second numeric slot (@p0 Code1, @p1 LowValue2 upper, @p2 HighValue2 lower, @p3 LowValue3).
+        // then the non-Ap second numeric slot (@p0 Code1, @p1 LowValue2 upper, @p2 HighValue2 lower, @p3 HighValue3).
         var emitted = EmitSql(cte);
         emitted.Sql.ShouldBe(
             ";WITH cte0 AS (\n" +
             "    SELECT DISTINCT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n" +
             "    FROM dbo.TokenNumberNumberCompositeSearchParam\n" +
-            "    WHERE ResourceTypeId = 104 AND SearchParamId = 302 AND ((Code1 = @p0 AND (LowValue2 <= @p1 AND HighValue2 >= @p2)) AND LowValue3 >= @p3)\n" +
+            "    WHERE ResourceTypeId = 104 AND SearchParamId = 302 AND ((Code1 = @p0 AND (LowValue2 <= @p1 AND HighValue2 >= @p2)) AND HighValue3 >= @p3)\n" +
             ")\n" +
             "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
             "ORDER BY m.T1 ASC, m.Sid1 ASC");
@@ -163,13 +165,13 @@ public class TokenNumberNumberLoweringRuleTests
         // Act
         var cte = TokenNumberNumberLoweringRule.Lower(composite, components, ContextResolving(composite, 302), 104);
 
-        // Assert — And(And(tokenPredicate, Ge(LowValue2,10)), And(Le(LowValue3,5.94), Ge(HighValue3,4.86)))
+        // Assert — And(And(tokenPredicate, Ge(HighValue2,10)), And(Le(LowValue3,5.94), Ge(HighValue3,4.86)))
         var outer = cte.Predicate.ShouldBeOfType<Predicate.And>();
         var inner = outer.Left.ShouldBeOfType<Predicate.And>();
         var tokenPredicate = inner.Left.ShouldBeOfType<Predicate.Equal>();
         tokenPredicate.Column.Column.ShouldBe("Code1");
         var number1Predicate = inner.Right.ShouldBeOfType<Predicate.GreaterThanOrEqual>();
-        number1Predicate.Column.Column.ShouldBe("LowValue2");
+        number1Predicate.Column.Column.ShouldBe("HighValue2");
         number1Predicate.Value.Value.ShouldBe(10m);
         var number2Range = outer.Right.ShouldBeOfType<Predicate.And>();
         var number2Le = number2Range.Left.ShouldBeOfType<Predicate.LessThanOrEqual>();
@@ -180,13 +182,13 @@ public class TokenNumberNumberLoweringRuleTests
         number2Ge.Value.Value.ShouldBe(4.86m);
 
         // Assert — complete emitted SQL and ordered parameters: token, non-Ap first numeric, then the
-        // mirrored approximate upper/lower on the second slot (@p0 Code1, @p1 LowValue2, @p2 LowValue3 upper, @p3 HighValue3 lower).
+        // mirrored approximate upper/lower on the second slot (@p0 Code1, @p1 HighValue2, @p2 LowValue3 upper, @p3 HighValue3 lower).
         var emitted = EmitSql(cte);
         emitted.Sql.ShouldBe(
             ";WITH cte0 AS (\n" +
             "    SELECT DISTINCT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n" +
             "    FROM dbo.TokenNumberNumberCompositeSearchParam\n" +
-            "    WHERE ResourceTypeId = 104 AND SearchParamId = 302 AND ((Code1 = @p0 AND LowValue2 >= @p1) AND (LowValue3 <= @p2 AND HighValue3 >= @p3))\n" +
+            "    WHERE ResourceTypeId = 104 AND SearchParamId = 302 AND ((Code1 = @p0 AND HighValue2 >= @p1) AND (LowValue3 <= @p2 AND HighValue3 >= @p3))\n" +
             ")\n" +
             "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
             "ORDER BY m.T1 ASC, m.Sid1 ASC");

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenTextLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenTextLoweringRuleTests.cs
@@ -1,0 +1,64 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Specification.ValueSets.Normative;
+
+namespace Ignixa.Search.Sql.Tests.Lowering;
+
+public class TokenTextLoweringRuleTests
+{
+    private static SearchParameterInfo CodeParameter()
+        => new("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-code"));
+
+    private static SymbolTable Symbols(SearchParameterInfo parameter)
+        => new(
+            new Dictionary<string, short> { [parameter.Url.ToString()] = 202 },
+            new Dictionary<string, short> { ["Observation"] = 96 });
+
+    [Fact]
+    public void GivenATextModifiedToken_WhenLowered_ThenReadsTokenTextRatherThanTokenSearchParam()
+    {
+        // Arrange -- Observation?code:text=aux. The binder turns a :text modifier into a StringExpression
+        // over FieldName.TokenText, which is stored in its own dbo.TokenText table, not in the token
+        // table's Code column.
+        var parameter = CodeParameter();
+        var tree = new SearchParameterExpression(
+            parameter,
+            new StringExpression(StringOperator.StartsWith, FieldName.TokenText, componentIndex: null, "aux", ignoreCase: true));
+
+        // Act
+        var plan = Lower.Run(tree, Symbols(parameter), targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ParamSource>();
+        source.Table.TableName.ShouldBe("TokenText");
+        source.SearchParamId.ShouldBe((short)202);
+        source.ResourceTypeId.ShouldBe((short)96);
+        source.Predicate.ShouldBeOfType<Predicate.Like>().Match.ShouldBe(LikeMatch.StartsWith);
+    }
+
+    [Fact]
+    public void GivenATextModifiedToken_WhenEmitted_ThenExcludesHistoryRowsAndBindsTheValue()
+    {
+        // Arrange -- unlike every other leaf table, dbo.TokenText carries its own IsHistory column, so a
+        // query against it that does not filter history would match superseded versions of a resource.
+        var parameter = CodeParameter();
+        var tree = new SearchParameterExpression(
+            parameter,
+            new StringExpression(StringOperator.StartsWith, FieldName.TokenText, componentIndex: null, "aux", ignoreCase: true));
+        var plan = Lower.Run(tree, Symbols(parameter), targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain("FROM dbo.TokenText");
+        emitted.Sql.ShouldContain("IsHistory = 0");
+        emitted.Sql.ShouldNotContain("aux");
+        // The prefix wildcard belongs in the bound value, not the SQL text -- same as every other LIKE.
+        emitted.Parameters.ShouldHaveSingleItem().Value.ShouldBe("aux%");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenTextLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenTextLoweringRuleTests.cs
@@ -41,6 +41,45 @@ public class TokenTextLoweringRuleTests
     }
 
     [Fact]
+    public void GivenAContainsTextModifiedToken_WhenLowered_ThenUsesAContainsLikeMatch()
+    {
+        // Arrange -- Observation?code:text:contains=aux binds to a StringExpression with StringOperator.Contains.
+        // The Contains arm of the operator switch is distinct from StartsWith and would silently regress if
+        // mis-mapped, so it is pinned separately.
+        var parameter = CodeParameter();
+        var tree = new SearchParameterExpression(
+            parameter,
+            new StringExpression(StringOperator.Contains, FieldName.TokenText, componentIndex: null, "aux", ignoreCase: true));
+
+        // Act
+        var plan = Lower.Run(tree, Symbols(parameter), targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ParamSource>();
+        source.Table.TableName.ShouldBe("TokenText");
+        source.Predicate.ShouldBeOfType<Predicate.Like>().Match.ShouldBe(LikeMatch.Contains);
+    }
+
+    [Fact]
+    public void GivenATextModifiedToken_WhenEmitted_ThenEmitsNoCollateBecauseTheColumnIsAlreadyCaseInsensitive()
+    {
+        // Arrange -- dbo.TokenText.Text is declared Latin1_General_CI_AI, so :text gets its case- and
+        // accent-insensitive match from the column's own collation. Forcing a COLLATE would make the
+        // predicate non-sargable against that table's index, so the rule deliberately emits none.
+        var parameter = CodeParameter();
+        var tree = new SearchParameterExpression(
+            parameter,
+            new StringExpression(StringOperator.StartsWith, FieldName.TokenText, componentIndex: null, "aux", ignoreCase: true));
+        var plan = Lower.Run(tree, Symbols(parameter), targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null).Plan;
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldNotContain("COLLATE");
+    }
+
+    [Fact]
     public void GivenATextModifiedToken_WhenEmitted_ThenExcludesHistoryRowsAndBindsTheValue()
     {
         // Arrange -- unlike every other leaf table, dbo.TokenText carries its own IsHistory column, so a

--- a/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
@@ -485,6 +485,40 @@ public class ResolveTests
         symbolTable.ResourceTypeId("Observation").ShouldBe((short)96);
     }
 
+    [Fact]
+    public async Task GivenANotReferencedPathButNoDefinitionManager_WhenResolved_ThenThrowsRatherThanSilentlyWidening()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject with no ISearchParameterDefinitionManager.
+        // The path cannot be resolved, so omitting it would widen the anti-join to path-agnostic and return
+        // more resources than asked. That is a missing-dependency programmer error, not an unresolvable
+        // path, so Resolve throws -- the same contract as compartment membership.
+        var expression = new NotReferencedExpression("Observation", "subject");
+        var resolver = new FakeSymbolResolver();
+        resolver.ResourceTypeIds["Patient"] = 103;
+        resolver.ResourceTypeIds["Observation"] = 96;
+
+        // Act & Assert -- no searchParameterDefinitionManager supplied
+        await Should.ThrowAsync<InvalidOperationException>(() => Resolve.RunAsync(
+            expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GivenAFullWildcardNotReferencedAndNoDefinitionManager_WhenResolved_ThenDoesNotThrow()
+    {
+        // Arrange -- Patient?_not-referenced=*:* needs no path resolution (no Type:path pair is collected),
+        // so a missing definition manager is harmless here and must not trip the guard.
+        var expression = new NotReferencedExpression(sourceResourceType: null, referencePath: null);
+        var resolver = new FakeSymbolResolver();
+        resolver.ResourceTypeIds["Patient"] = 103;
+
+        // Act
+        var symbolTable = (await Resolve.RunAsync(
+            expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None)).Symbols;
+
+        // Assert
+        symbolTable.ResourceTypeId("Patient").ShouldBe((short)103);
+    }
+
     /// <summary>
     /// An in-memory, dictionary-backed ICompartmentDefinitionManager test double -- not a mock,
     /// matching this file's existing FakeSymbolResolver philosophy.

--- a/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
@@ -428,6 +428,63 @@ public class ResolveTests
         Should.Throw<KeyNotFoundException>(() => symbolTable.SystemId("http://never-seen.example"));
     }
 
+    [Fact]
+    public async Task GivenANotReferencedPath_WhenResolved_ThenTheReferenceParameterIsResolvedAndStored()
+    {
+        // Arrange -- Patient?_not-referenced=Observation:subject. Resolve must look the (Observation,
+        // subject) pair up through the definition manager, then resolve that parameter's id like any other.
+        var subjectParam = new SearchParameterInfo(
+            "subject", "subject", SearchParamType.Reference,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-subject"));
+        var expression = new NotReferencedExpression("Observation", "subject");
+
+        var resolver = new FakeSymbolResolver();
+        resolver.SearchParamIds[subjectParam.Url!.ToString()] = 969;
+        resolver.ResourceTypeIds["Patient"] = 103;
+        resolver.ResourceTypeIds["Observation"] = 96;
+
+        var definitions = new FakeSearchParameterDefinitionManager();
+        definitions.Parameters[("Observation", "subject")] = subjectParam;
+
+        // Act
+        var symbolTable = (await Resolve.RunAsync(
+            expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None,
+            searchParameterDefinitionManager: definitions)).Symbols;
+
+        // Assert
+        var resolvedParam = symbolTable.NotReferencedPath("Observation", "subject");
+        resolvedParam.ShouldNotBeNull();
+        symbolTable.SearchParamId(resolvedParam).ShouldBe((short)969);
+        symbolTable.ResourceTypeId("Observation").ShouldBe((short)96);
+    }
+
+    [Fact]
+    public async Task GivenANotReferencedPathThatIsNotAReferenceParameter_WhenResolved_ThenItFallsBackToPathAgnostic()
+    {
+        // Arrange -- a non-reference parameter cannot anchor the anti-join, so Resolve records no path and
+        // Lower falls back to source-type-only filtering, matching the shipping engine.
+        var statusParam = new SearchParameterInfo(
+            "status", "status", SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        var expression = new NotReferencedExpression("Observation", "status");
+
+        var resolver = new FakeSymbolResolver();
+        resolver.ResourceTypeIds["Patient"] = 103;
+        resolver.ResourceTypeIds["Observation"] = 96;
+
+        var definitions = new FakeSearchParameterDefinitionManager();
+        definitions.Parameters[("Observation", "status")] = statusParam;
+
+        // Act
+        var symbolTable = (await Resolve.RunAsync(
+            expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None,
+            searchParameterDefinitionManager: definitions)).Symbols;
+
+        // Assert -- no reference path resolved, but the source type is still available
+        symbolTable.NotReferencedPath("Observation", "status").ShouldBeNull();
+        symbolTable.ResourceTypeId("Observation").ShouldBe((short)96);
+    }
+
     /// <summary>
     /// An in-memory, dictionary-backed ICompartmentDefinitionManager test double -- not a mock,
     /// matching this file's existing FakeSymbolResolver philosophy.


### PR DESCRIPTION
## What this is

Introduces a **differential corpus** — 185 real FHIR searches captured from a TestScript conformance run, each paired with the SQL the shipping search engine actually executed — and a harness that compiles every URL through `Ignixa.Search.Sql` and diffs what the two engines ask the database for. The report is triage, not a pass/fail gate: a divergence is a question, and some divergences are wins we keep.

Using that corpus as a to-do list, this branch closes **every real-world compile gap**: captured searches that fail to compile went from **18 → 0**, and semantically-matching output rose from **61 → 69**. Along the way the corpus surfaced a genuine results-changing correctness bug.

## Commits

**Harness**
- `test(search-sql)`: the legacy-SQL corpus + shape canonicalizer + differential report. Comparison runs on whole-query multisets of tables read and semantic filters applied, so the two dialects can differ in encoding (CTE boundaries, `EXISTS` vs `INNER JOIN`, `NOT IN` vs `NOT EXISTS`, bound vs inlined values) without registering as divergence. Only two things are asserted: every captured query still parses, and no fewer queries compile than a guarded baseline.

**Correctness**
- `fix(search-sql)`: **correct the bound each numeric range comparator constrains.** `gt/ge/lt/le` used the wrong `LowValue`/`HighValue` column — effectively `sa`/`eb` semantics. Coincides on point-valued rows (why conformance passed); wrong on genuine ranges and sentinel-bounded rows. Verified against the shipping SQL. This one changes results for range-valued data.
- `fix(search)`: **keep a quantity/number/date composite component its declared type.** A shared-parser heuristic read any `|` as a token separator, so a value-quantity carrying a full `system|code` was rejected with *"Only one token separator can be specified."* Fixed in both the active and frozen-oracle parsers so the rollback-parity tests stay valid.

**Feature gaps**
- `fix(search-sql)`: lift a comma-separated resource-column list (`_id=a,b,c`) into the outer WHERE.
- `feat(search-sql)`: compile `:text` against `dbo.TokenText`.
- `feat(search-sql)`: compile `_not-referenced` (orphan search) — a new `NotReferencedSource` CTE anti-joining on reference-target identity.
- `feat(search-sql)`: lift a negated resource-column filter (`_id:not=a,b`) into the outer WHERE via a new `Predicate.Not`.
- `feat(search)`: accept the bare `_include=*` / `_revinclude=*` wildcard (both parsers).

**Plan quality**
- `perf(search-sql)`: anchor a negation on its positive siblings instead of a full type-partition scan — drops a full scan on 14 captured searches.

## Notes

- Several SQL-design calls were reviewed by an independent pass against the shipping engine's rationale (keep-ours on the quantity `UNION ALL`; the negation-anchoring change validated). The remaining `Divergent` entries are those documented decisions plus canonicalizer artifacts.
- Still-open optimization/semantics work (include match-page materialization, `eq` bounded-seek, `_summary=count` history-join) is latent until the compiler is wired to an executor — noted, not a shipping bug.

## Verification

- `Ignixa.Search.Sql.Tests`: **505 passing**, net9.0 + net10.0.
- `Ignixa.Application.Tests`: **983 passing** (1 pre-existing skip), net10.0 — the shared-parser fixes touch a wide surface.
- The differential baseline is guarded, so a future change that narrows real-world coverage fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)