### PR TITLE
fix(search-sql): resolve $everything's expansion types only when the expansion is requested

### DIFF
--- a/docs/superpowers/specs/2026-07-25-patient-everything-results.md
+++ b/docs/superpowers/specs/2026-07-25-patient-everything-results.md
@@ -275,3 +275,38 @@ defect (a passing result there would itself be evidence something else is wrong)
 only in `Ignixa.DataLayer.SqlServer` and so cannot compile or run here.
 
 Do not read the compiler-level verification above as end-to-end validation. It is not.
+
+## Addendum, 2026-07-26: what execution found
+
+Branch A rebased onto this work and ran it against a database. The caveat above held, and it mattered:
+the first execution found a defect that every layer of verification recorded in this document had missed.
+
+**`$everything?_type=X` threw `RequestNotValidException: SymbolTable has no ResourceTypeId for
+'Practitioner'`.** `SymbolCollectingVisitor.VisitPatientEverything` collects the four expansion types only
+when `IncludeReferencedResources` is set, and `LowerPatientEverything` originally resolved them under the
+same condition. The `_type` intersection recorded above as Task 5's fix hoisted that resolve *out* of the
+guard, so it could use `expansionTypeIds.Count` in the condition — which left the lowerer resolving
+symbols the collector deliberately never gathered. The handler sets the flag false exactly when `_type` is
+present (`includeReferencedResources = request.Types is null or { Count: 0 }`), so the broken shape is the
+one a caller reaches by filtering. Fixed by moving the resolve back inside the guard, keeping the
+intersection.
+
+**Why nothing here caught it.** `PatientEverythingLoweringTests.BuildSymbols` registers all four expansion
+types unconditionally, which made the missing-symbol case unreachable from any lowering test; and the
+corpus verdicts key off the tables/filters multiset, not symbol resolution. Both facts are visible in this
+document's own verification section, and neither was recognised as a coverage hole until execution
+produced the exception. A green suite and zero corpus drift were consistent with a broken operation.
+
+**What execution confirmed.** The seed fix (Task 2) is proven at row level: a Practitioner and an
+Organization referenced by the patient row and by nothing else are returned, which the pre-fix traversal —
+seeded from the compartment alone — could not have done. `_since` over the ordinary write path returns no
+compartment member, confirming the `CreateOrUpdateAsync` transaction-commit defect is real and executable
+rather than inferred from reading.
+
+`Ignixa.DataLayer.SqlServer.IntegrationTests`: **135 passed, 0 failed** (126 pre-existing, the 6 gate
+tests adopted, 3 added for the paths above).
+
+**Two numbers in this document are wrong.** `Ignixa.Search.Sql.Tests` is reported above as 812; main's
+baseline after the post-merge fixes landed with the #365 squash is **817**, and 818 with the regression
+test added by the fix. `Ignixa.Application.Tests` is reported as 1052; it measures **1125** on branch A
+after the merge. The corpus distribution (75/37/14/59) is unchanged and still accurate.

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -540,15 +540,25 @@ public sealed class StructuralContext
         }
 
         var unionParts = new List<CteRef> { patientItselfRef, compartmentRef };
-        var expansionTypeIds = ResolveReferencedTypeIds(expression);
-        if (expression.IncludeReferencedResources && expansionTypeIds.Count > 0)
+
+        // Resolve the expansion's types only when the expansion is actually requested. SymbolCollectingVisitor
+        // .VisitPatientEverything collects them under the same condition, so hoisting this out of the guard
+        // makes the lowerer resolve symbols the collector deliberately never gathered, and ResourceTypeId
+        // throws on the miss. That is not hypothetical: includeReferencedResources is false exactly when
+        // _type is present, so $everything?_type=X failed outright.
+        if (expression.IncludeReferencedResources)
         {
-            // The seed patient is not a member of its own compartment -- no ReferenceSearchParam row points
-            // from the patient at itself -- so seeding the expansion from compartmentRef alone misses the
-            // patient's own generalPractitioner/managingOrganization unless some compartment member happens
-            // to reference them too. Union in patientItselfRef so those two are found even in isolation.
-            var expansionSeed = Union([patientItselfRef, compartmentRef]);
-            unionParts.Add(ReferencedTypeExpansionRef(expansionSeed, expansionTypeIds));
+            var expansionTypeIds = ResolveReferencedTypeIds(expression);
+            if (expansionTypeIds.Count > 0)
+            {
+                // The seed patient is not a member of its own compartment -- no ReferenceSearchParam row
+                // points from the patient at itself -- so seeding the expansion from compartmentRef alone
+                // misses the patient's own generalPractitioner/managingOrganization unless some compartment
+                // member happens to reference them too. Union in patientItselfRef so those two are found
+                // even in isolation.
+                var expansionSeed = Union([patientItselfRef, compartmentRef]);
+                unionParts.Add(ReferencedTypeExpansionRef(expansionSeed, expansionTypeIds));
+            }
         }
 
         return Union(unionParts);

--- a/test/Ignixa.Search.Sql.Tests/Lowering/PatientEverythingLoweringTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/PatientEverythingLoweringTests.cs
@@ -120,6 +120,41 @@ public class PatientEverythingLoweringTests
     }
 
     [Fact]
+    public void GivenTheExpansionIsNotRequested_WhenLowered_ThenTheExpansionTypesAreNeverResolved()
+    {
+        // BuildSymbols above registers all four expansion types, which is what every other test here needs
+        // and exactly why this case escaped until it was executed. SymbolCollectingVisitor.VisitPatientEverything
+        // only collects those types when IncludeReferencedResources is set, so the real symbol table for a
+        // non-expanding $everything does NOT contain them -- reproduced here by omitting them. Lowering must
+        // not resolve what the collector did not collect: doing so threw RequestNotValidException for
+        // $everything?_type=X, which is the request shape that turns the flag off.
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>
+            {
+                [SubjectParam.Url!.ToString()] = SubjectParamId,
+                [StatusParam.Url!.ToString()] = StatusParamId,
+            },
+            new Dictionary<string, short>
+            {
+                ["Patient"] = PatientTypeId,
+                ["Observation"] = ObservationTypeId,
+            },
+            compartmentMembership: new Dictionary<string, IReadOnlyList<(SearchParameterInfo Parameter, IReadOnlyList<string> ResourceTypes)>>
+            {
+                ["Patient"] = new List<(SearchParameterInfo, IReadOnlyList<string>)>
+                {
+                    (SubjectParam, ["Observation"]),
+                },
+            });
+
+        var expression = new PatientEverythingExpression("pat-1", includeReferencedResources: false);
+
+        var plan = Should.NotThrow(() => Lowered(expression, symbols));
+
+        plan.Explain().ShouldNotContain("ReferencedTypeExpansion(");
+    }
+
+    [Fact]
     public void GivenAPatientEverythingSearchWithoutReferencedResources_WhenLowered_ThenNoExpansionIsAdded()
     {
         var symbols = BuildSymbols();


### PR DESCRIPTION
## The bug

`Patient/$everything?_type=X` throws `RequestNotValidException: SymbolTable has no ResourceTypeId for 'Practitioner'` on the compiled path.

The handler sets the flag that turns the expansion off *exactly* when `_type` is present:

```csharp
var includeReferencedResources = request.Types == null || request.Types.Count == 0;
```

So the failing shape is the one a caller reaches by filtering.

## Root cause

`SymbolCollectingVisitor.VisitPatientEverything` collects the four expansion types (`Practitioner`/`Organization`/`Location`/`Medication`) **only when `IncludeReferencedResources` is set**. `LowerPatientEverything` used to resolve them under the same condition.

Adding the `_type` intersection hoisted the resolve *out* of the guard, so it could use `expansionTypeIds.Count` as part of the condition:

```csharp
var expansionTypeIds = ResolveReferencedTypeIds(expression);   // runs unconditionally
if (expression.IncludeReferencedResources && expansionTypeIds.Count > 0)
```

That makes the lowerer resolve symbols the collector deliberately never gathered, and `ResourceTypeId` throws on the miss. This PR moves it back inside the guard, keeping the `_type` intersection.

## Why nothing caught it

- `PatientEverythingLoweringTests.BuildSymbols` registers all four expansion types unconditionally — correct for the tests that need them, and it made the missing-symbol case unreachable.
- Corpus verdicts key off the tables/filters multiset, not symbol resolution.

Nothing short of executing against a real symbol table could see it. It was found by the first execution of this code against a database, while rebasing the SQL Server data layer onto main.

## Impact

Not currently shipping — production still resolves `ISearchService` to the EF implementation, and `Ignixa.Search.Sql` is reachable only through `SearchCompiler`. The data-layer branch that migrates the read path onto the compiler would ship it.

## Test

The regression test builds the symbol table `SymbolCollectingVisitor` would actually produce for a non-expanding `$everything` — omitting those four types — and asserts lowering does not throw.

Verified non-vacuous on this branch: reverting the fix gives `Failed: 1, Passed: 817` with the original exception; with it, `818/818` on both TFMs.