### PR TITLE
Type IsPartial as bit in the include limit stage

### DIFF
--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -348,9 +348,16 @@ public static class SqlBuilder
     /// Renders an include stage's limit-applying companion: the first Limit rows, plus an IsPartial flag set
     /// from the window count so the caller can tell a truncated stage from an exactly-full one.
     /// </summary>
+    /// <remarks>
+    /// The flag is cast to <c>bit</c> rather than left as the <c>int</c> the CASE naturally yields, because this
+    /// column is unioned with the match arm's <c>CAST(0 AS bit) AS IsPartial</c>. T-SQL type precedence promotes
+    /// a bit/int union to <c>int</c>, so leaving it untyped silently changed the result column's type based on
+    /// whether the plan happened to carry includes — and a caller reading the documented
+    /// (T1, Sid1, IsMatch, IsPartial) contract as a bit threw InvalidCastException on include rows only.
+    /// </remarks>
     private static string EmitIncludeLimitStage(IncludeStage stage, int index)
         => $"    SELECT TOP ({stage.Limit}) T1, Sid1,\n" +
-           $"           CASE WHEN COUNT_BIG(*) OVER() > {stage.Limit} THEN 1 ELSE 0 END AS IsPartial\n" +
+           $"           CAST(CASE WHEN COUNT_BIG(*) OVER() > {stage.Limit} THEN 1 ELSE 0 END AS bit) AS IsPartial\n" +
            $"    FROM {IncludeLabel(index)}\n" +
            $"    ORDER BY T1 ASC, Sid1 ASC";
 

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -337,7 +337,7 @@ public class EmitTests
             "),\n" +
             "inc0lim AS (\n" +
             "    SELECT TOP (1000) T1, Sid1,\n" +
-            "           CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS IsPartial\n" +
+            "           CAST(CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS bit) AS IsPartial\n" +
             "    FROM inc0\n" +
             "    ORDER BY T1 ASC, Sid1 ASC\n" +
             ")\n" +
@@ -401,7 +401,7 @@ public class EmitTests
             "),\n" +
             "inc0lim AS (\n" +
             "    SELECT TOP (1000) T1, Sid1,\n" +
-            "           CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS IsPartial\n" +
+            "           CAST(CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS bit) AS IsPartial\n" +
             "    FROM inc0\n" +
             "    ORDER BY T1 ASC, Sid1 ASC\n" +
             ")\n" +
@@ -2136,7 +2136,7 @@ public class EmitTests
             "),\n" +
             "inc0lim AS (\n" +
             "    SELECT TOP (1000) T1, Sid1,\n" +
-            "           CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS IsPartial\n" +
+            "           CAST(CASE WHEN COUNT_BIG(*) OVER() > 1000 THEN 1 ELSE 0 END AS bit) AS IsPartial\n" +
             "    FROM inc0\n" +
             "    ORDER BY T1 ASC, Sid1 ASC\n" +
             ")\n" +
@@ -2573,6 +2573,26 @@ public class EmitTests
     private static IncludeStage ForwardIncludeStage(short seedType, short outputType, int limit)
         => new(IncludeDirection.Forward, ReferenceSearchParamId: 210, SeedTypeIds: [seedType], OutputTypeIds: [outputType],
                SeedStages: [], SeedFromMatch: true, Iterate: false, Limit: limit);
+
+    [Fact]
+    public void GivenAPlanWithIncludes_WhenEmitted_ThenEveryUnionArmTypesIsPartialAsBit()
+    {
+        // Regression: the match arm emitted CAST(0 AS bit) AS IsPartial while the include arm's limit stage
+        // emitted a bare CASE ... THEN 1 ELSE 0 END, which is int. T-SQL union type precedence promotes a
+        // bit/int union to int, so the result column's type silently depended on whether the plan carried
+        // includes. A caller reading the documented (T1, Sid1, IsMatch, IsPartial) contract as a bit then threw
+        // InvalidCastException on include rows only -- the kind of defect that appears at execution against a
+        // real server and is invisible to a grammar check, since the SQL parses either way.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111, 10)]);
+
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        sql.ShouldContain("CAST(CASE WHEN COUNT_BIG(*) OVER() > 10 THEN 1 ELSE 0 END AS bit) AS IsPartial");
+        sql.ShouldNotContain("END AS IsPartial");
+    }
 
     [Fact]
     public void GivenAnIncludesOnlyPlan_WhenEmitted_ThenMatchRowsAreExcludedFromTheResult()


### PR DESCRIPTION
The match arm emits `CAST(0 AS bit) AS IsPartial`, but an include stage's limit companion emitted a bare `CASE ... THEN 1 ELSE 0 END`, which is `int`.

T-SQL union type precedence promotes a bit/int union to `int`, so the result column's type silently depended on whether the plan carried includes. A caller reading the documented `(T1, Sid1, IsMatch, IsPartial)` contract as a `bit` therefore threw `InvalidCastException` — **on include rows only**.

## How it was found

Executing emitted SQL against a real SQL Server while adopting this compiler in the Microsoft FHIR Server.

Worth noting *why* the existing suite missed it: the SQL parses fine either way, so `EmitSqlGrammarTests` (ScriptDom) passes, and the text assertions asserted the literal that was there. The type only resolves at execution. This is the class of defect the compiler's own tests structurally cannot catch, since nothing in this repo runs SQL.

## Fix

Cast the include arm's flag to `bit` so every union arm agrees, plus a regression test pinning the type contract.
