### PR TITLE
fix(search-sql): record CTE provenance for the :missing modifier

### DIFF
--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -318,7 +318,7 @@ public static class Lower
     /// <summary>Lowers a :missing search to the parameter's presence set, negated when :missing=true.</summary>
     private static CteRef LowerMissing(MissingSearchParameterExpression missing, StructuralContext context, string? resourceType)
     {
-        var presence = context.LowerParameterPresence(missing.Parameter, resourceType);
+        var presence = context.LowerParameterPresence(missing.Parameter, resourceType, provenanceNode: missing);
         return missing.IsMissing ? context.LowerNot(presence, resourceType) : presence;
     }
 

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -134,7 +134,7 @@ public sealed class StructuralContext
         return new CteRef(index);
     }
 
-    public CteRef LowerParameterPresence(SearchParameterInfo parameter, string? resourceType)
+    public CteRef LowerParameterPresence(SearchParameterInfo parameter, string? resourceType, Expression provenanceNode)
     {
         RejectResourceColumnCode(parameter.Code);
 
@@ -144,7 +144,9 @@ public sealed class StructuralContext
 
         var cte = new CteDefinition.ParamSource(table, resourceTypeId, searchParamId);
         _ctes.Add(cte);
-        return new CteRef(_ctes.Count - 1);
+        var index = _ctes.Count - 1;
+        _origins.Add(new CteOrigin(index, provenanceNode));
+        return new CteRef(index);
     }
 
     /// <summary>

--- a/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/CteProvenance.cs
@@ -3,7 +3,7 @@ using Ignixa.Search.Expressions;
 namespace Ignixa.Search.Sql.Tracing;
 
 /// <summary>One CTE's link back to the parameter that produced it. Null ordinal where exempt —
-/// :missing, compartment, and structural CTEs have no source text.</summary>
+/// compartment and structural CTEs have no single owning parameter.</summary>
 /// <remarks>
 /// <see cref="ParameterOrdinal"/> is set only when the CTE was lowered from a node inside exactly one
 /// parameter's IR. A structural CTE (Intersect, Union, Except, ChainJoin) combines other CTEs by

--- a/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
+++ b/src/Core/Ignixa.Search.Sql/Tracing/SearchCompiler.cs
@@ -496,7 +496,7 @@ public static class SearchCompiler
         _ => null,
     };
 
-    /// <summary>Builds the plan trace, mapping each CTE origin to its owning parameter by reference identity against every trace's IR subtree. Origins with no owner (:missing, compartment, structural CTEs) keep a null ordinal.</summary>
+    /// <summary>Builds the plan trace, mapping each CTE origin to its owning parameter by reference identity against every trace's IR subtree. Origins with no owner (compartment, structural CTEs) keep a null ordinal.</summary>
     private static QueryPlanTrace BuildPlanTrace(LoweredPlan lowered, IReadOnlyList<ParameterTrace> outcomes)
     {
         var rows = PlanExplainer.Describe(lowered.Plan);

--- a/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Tracing/SearchTraceTests.cs
@@ -17,7 +17,7 @@ public class SearchTraceTests
         data.Add("include", SearchTraceFixtures.TracePatientActiveWithIncludeAsync, [0]);
         data.Add("sort", SearchTraceFixtures.TracePatientActiveWithSortAsync, [0]);
         data.Add(":not", SearchTraceFixtures.TracePatientNameNotAsync, [0]);
-        data.Add(":missing", SearchTraceFixtures.TracePatientNameMissingAsync, []);
+        data.Add(":missing", SearchTraceFixtures.TracePatientNameMissingAsync, [0]);
         return data;
     }
 
@@ -65,6 +65,25 @@ public class SearchTraceTests
 
             trace.Sql!.Ranges.ShouldContain(r => r.Label == SqlLabels.CteLabel(i), $"{scenario}: {SqlLabels.CteLabel(i)} has no SQL text range");
         }
+    }
+
+    [Fact]
+    public async Task GivenAMissingModifierSearch_WhenTraced_ThenTheNegationClosesOverTheMissingParametersOrdinal()
+    {
+        // LowerParameterPresence used to build its ParamSource CTE with no CteOrigin at all, so :missing's
+        // presence-check CTE -- and, transitively, the Except CTE that negates it -- carried no link back to
+        // the "name:missing=true" parameter that produced them. ContributingOrdinals is the one a consumer
+        // asks "which parameters does this structural CTE draw from" through, so it is the one that matters
+        // here, not just the leaf's own ParameterOrdinal.
+        var trace = await SearchTraceFixtures.TracePatientNameMissingAsync();
+        var parameter = trace.Parameters.ShouldHaveSingleItem();
+
+        trace.Plan.ShouldNotBeNull();
+        var presenceCte = trace.Plan!.Ctes.Single(c => c.ParameterOrdinal == parameter.Ordinal);
+        presenceCte.ContributingOrdinals.ShouldBe([parameter.Ordinal]);
+
+        var negation = trace.Plan.Ctes.Single(c => c.ParameterOrdinal is null && c.ContributingOrdinals.Contains(parameter.Ordinal));
+        negation.ContributingOrdinals.ShouldBe([parameter.Ordinal]);
     }
 
     private static IEnumerable<Expression> Flatten(Expression node)


### PR DESCRIPTION
## Summary

`StructuralContext.LowerParameterPresence` was the only leaf-lowering method that never recorded a `CteOrigin`. Every other leaf path (`Lower`, `LowerTokenText`, `LowerComposite`) does. The effect: a `:missing` search's presence-check CTE — and transitively the `Except` CTE that negates it for `:missing=true` — carried no link back to the parameter that produced them (`ParameterOrdinal` null, `ContributingOrdinals` empty), even though the parameter has real key/value spans and every other modifier gets attributed correctly.

Found downstream in a consumer (a search-trace bench UI built on `SearchCompiler.CompileAsync`) whose click-to-trace lineage silently had nothing to highlight for `:missing` — traced it back to the raw `plan.ctes[]` JSON, confirmed against the actual leaf-lowering code, not just the symptom.

Two doc comments described this as intentional ("`:missing`... have no source text"), which isn't accurate — that's true for compartment scoping (which genuinely has no parameter to attribute to, since it arrives via `operationExpression` rather than the parameter list) but not for `:missing`. Corrected both.

## Changes

- `StructuralContext.LowerParameterPresence`: added a `provenanceNode` parameter, records a `CteOrigin` — same pattern as every sibling leaf method.
- `Lower.LowerMissing`: passes `provenanceNode: missing` at the one call site.
- `CteProvenance.cs` / `SearchCompiler.cs`: corrected the two doc comments that described the gap as by-design.
- `SearchTraceTests.cs`: the `:missing` theory case asserted `expectedOrdinalIndices: []` — i.e. the test codified the bug as expected behavior. Changed to `[0]`. Added a new regression test asserting both the presence CTE's own `ParameterOrdinal` *and* the `Except` node's `ContributingOrdinals` include the `:missing` parameter's ordinal — the exact thing that was silently missing before.

## Verification

- Reverted the fix locally, confirmed the new test fails with `Sequence contains no matching element`; restored and confirmed it passes.
- `Ignixa.Search.Sql.Tests`: 820/820 passing on both net9.0 and net10.0.
- Confirmed via repo-wide grep that `LowerParameterPresence` has exactly one production call site (the one updated here) — no other callers to update.
- Could not run a full solution build locally: this checkout's installed SDK (10.0.100) is older than `global.json`'s pin (10.0.302), which isn't installed here. Verified the affected project + its test project directly instead; CI should be treated as the authoritative full-solution check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)