### PR TITLE
Fix six FML parser defects and add the official HL7 transform oracle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,6 +358,7 @@ bundle-*.json
 
 # Downloaded FHIR test cases
 test/Ignixa.FhirPath.Tests/TestData/
+test/Ignixa.FhirMappingLanguage.Tests/TestData/
 
 # AI assistant scripts
 kimi.ps1

--- a/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
+++ b/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
@@ -176,6 +176,20 @@ closed; each has regression tests plus a corpus ratchet as its acceptance test.
 Defects 5 and 6 were both surfaced *by the corpus gate itself* rather than by inspection, which is the
 main argument for keeping the gate.
 
+Fixing defect 4 **tightens** the accepted input surface, which is the one behaviour change on this branch
+that could affect previously-valid maps: a `///` line used to lex as an ordinary `//` comment and be
+ignored, and now must be a well-formed `/// key = value` metadata declaration or the parse fails. A map
+using `///` decoratively (`/// ----`, `/// TODO`) parsed before and does not now. This is deliberate — the
+official HL7 grammar defines `METADATA_PREFIX` as `'/// '` and `LINE_COMMENT` as `'//' ~[/]`, so `///` is
+the metadata production, not a comment — and it is covered by dedicated malformed-input tests. Everything
+else on this branch is strictly more permissive.
+
+One further defect was found by the final review and deferred: `StructureMapParser.ParseGroups` never
+propagates `typeMode` when reading a StructureMap **resource** back into FML, so the reverse direction of
+the round-trip silently loses `<<types>>` / `<<type+>>`. The FML-text direction and the
+FML → StructureMap direction are both correct and tested; only StructureMap-JSON → FML is lossy, and no
+oracle case exercises it. Tracked as [#377](https://github.com/brendankowitz/ignixa-fhir/issues/377).
+
 Still open, deliberately: nested function calls as a transform argument (`evaluate(src, iif(...))`) — the
 one remaining parse failure; wildcard imports (`imports "…/*3to4"` *parses*, but `ImportResolver` has no
 glob semantics, so the group closure is never resolved); and unit-bearing date arithmetic (`%value + 5 days`

--- a/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
+++ b/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
@@ -1,7 +1,7 @@
 # Investigation: FML Oracle Conformance Corpus
 
 **Feature**: structuremap
-**Status**: In Progress
+**Status**: Approved
 **Created**: 2026-07-28
 
 ## Approach
@@ -76,17 +76,31 @@ behavioural oracles. They are large, real-world, adversarially-broad **grammar c
 A throwaway probe was run against the real `MappingParser` (net9.0, this branch), feeding every `.fml`/`.map`
 file through `parser.Parse()`:
 
-| Corpus | Files | Parsed | Failed |
+| Corpus | Files | Parsed (before) | Parsed (after) |
 |---|---:|---:|---:|
-| `FHIR/fhir-test-cases` `r5` + `r4b` `structure-mapping` (`.map`) | 27 | **0** | 27 |
-| `brianpos/fhir-r6-maps` (`.fml`) | 355 | **0** | 355 |
+| `FHIR/fhir-test-cases` `r5` `structure-mapping` (`.map`) | 15 | **0** | **14** |
+| `FHIR/fhir-test-cases` `r4b` `structure-mapping` (`.map`) | 12 | **0** | **11** |
+| `FHIR/fhir-test-cases` `validator` (`.fml`) | 2 | **0** | **2** |
+| `brianpos/fhir-r6-maps` (`.fml`) | 355 | **0** | *not re-measured* |
 
-This is not a "the harness is hard to build" result — it is a **language-coverage result**. The current
-parser handles the hand-written dialect used in `test/Ignixa.FhirMappingLanguage.Tests` and
+The "after" figures are the ratchets asserted by `FmlCorpusParseTests` and `FmlValidatorCorpusParseTests`
+against vendored release **1.7.46**, not estimates. The `brianpos` corpus was deliberately **not** vendored:
+it is a non-HL7-governed staging area with no expected outputs, so re-measuring it was left to the Phase 1
+Tier C work rather than inflating this branch's scope. Its baseline is retained above only as the original
+evidence that motivated the parser work.
+
+This was not a "the harness is hard to build" result — it was a **language-coverage result**. The parser as
+found handled the hand-written dialect used in `test/Ignixa.FhirMappingLanguage.Tests` and
 `src/Core/Ignixa.FhirMappingLanguage/README.md` (single-quoted strings, `map 'url' = 'name'` header) and
 nothing that the wild actually ships.
 
-### Root causes — four concrete parser defects, all reproduced
+The single remaining parse failure is `qr2cda-eval.map` (present in both versions), which uses a nested
+function call as a transform: `evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad"))`.
+The greedy `FhirPathExpression` fallback cannot expand the inner `iif()` safely because the `RightParen`
+that closes it is not in the fallback terminator set. This is explicitly deferred: the file produces CDA
+XML output and is excluded from the behavioural oracle regardless.
+
+### Root causes — four concrete parser defects, all reproduced (all now fixed)
 
 **1. Double-quoted string literals are not string literals** (21 of 27 official cases)
 
@@ -145,6 +159,93 @@ Patient_4to6.fml /// url = 'http://hl7.org/fhir/uv/xver/StructureMap/Patient4to6
   map; `ImportResolver` needs glob semantics.
 - Date arithmetic with units: `%value + 5 days`.
 
+### Defect closure
+
+Two further defects were found while implementing the fixes above, bringing the total to six. All six are
+closed; each has regression tests plus a corpus ratchet as its acceptance test.
+
+| # | Defect | Found | Status |
+|---|---|---|---|
+| 1 | Double-quoted string literals lexed as `DelimitedIdentifier` | investigation | **Fixed** |
+| 2 | Group type-mode `<<types>>` / `<<type+>>` unsupported | investigation | **Fixed** |
+| 3 | `%constant` / operator tokens (`+ - % / \| & <= >=`) absent from the tokenizer | investigation | **Fixed** |
+| 4 | `///` metadata declarations swallowed as comments; `map` header mandatory | investigation | **Fixed** |
+| 5 | Embedded FHIRPath re-serialised from tokens, gluing them together and corrupting the expression | planning | **Fixed** — grammar now reconstructs from source text spans |
+| 6 | Parenthesized FHIRPath transforms `-> tgt.x = ('a' + b.lower())` rejected | Task 8 gate | **Fixed** |
+
+Defects 5 and 6 were both surfaced *by the corpus gate itself* rather than by inspection, which is the
+main argument for keeping the gate.
+
+Still open, deliberately: nested function calls as a transform argument (`evaluate(src, iif(...))`) — the
+one remaining parse failure; wildcard imports (`imports "…/*3to4"` *parses*, but `ImportResolver` has no
+glob semantics, so the group closure is never resolved); and unit-bearing date arithmetic (`%value + 5 days`
+parses but does not evaluate).
+
+### Measured outcome: the behavioural oracle
+
+`FmlTransformOracleTests` loads both `<fml-tests>` manifests, executes each in-scope case end-to-end
+(`MappingParser` → `MappingEvaluator` → JSON) and compares against the reference-produced output using
+canonical JSON comparison.
+
+| Metric | Value |
+|---|---:|
+| Manifest cases (r5 + r4b) | 20 |
+| Excluded — CDA/XML output, outside supported scope | 8 |
+| **In scope, executed and compared** | **12** |
+| Producing matching output | **2** |
+| Executed but ratcheted as known evaluator gaps | **10** |
+
+The two passing cases are `qr2patassignment` in each version. The remaining ten reduce to **five distinct
+evaluator defects**, each appearing once per version:
+
+| Case | Defect | Issue |
+|---|---|---|
+| `qr2patgender` | Target alias binds to the source element, not the target resource — output is the QuestionnaireResponse tree under a `patient` key | [#372](https://github.com/brendankowitz/ignixa-fhir/issues/372) |
+| `qr2pathumannametwice` | Nested/recursive `then` groups are not evaluated | [#373](https://github.com/brendankowitz/ignixa-fhir/issues/373) |
+| `qr2pathumannameshared` | `share` combined with nested `then` groups is not evaluated | [#373](https://github.com/brendankowitz/ignixa-fhir/issues/373) |
+| `reference` | `create()` / `reference()` throw `TARGET_RESOURCE_NOT_FOUND` for the `'ext'` target | [#374](https://github.com/brendankowitz/ignixa-fhir/issues/374) |
+| `qr2pat-gender-conformstoqr` | FHIRPath `conformsTo()` is a declared capability gap (needs profile-validation infrastructure) | [#375](https://github.com/brendankowitz/ignixa-fhir/issues/375) |
+
+These are **ratcheted, not skipped**. `FmlKnownEvaluatorGaps` asserts each is *still broken*: the moment one
+starts producing matching output, its test fails and demands the entry be deleted. That is deliberately the
+opposite polarity from `FmlOracleExclusions`, which covers cases that cannot be compared at all. Keeping the
+two lists separate prevents the usual failure mode where a hard-but-comparable case quietly migrates onto
+the exclusion list to make the number go up.
+
+Supporting counts, measured on both `net9.0` and `net10.0`: `Ignixa.FhirMappingLanguage.Tests` went from
+546 to **656 passing, 0 failing, 1 skipped**.
+
+### Tier B is not reachable as a diagnostic oracle
+
+The plan assumed the two official FML validator cases were "near-free" — add them to
+`ValidatorConformanceRunner`'s filter and let the existing machinery grade them. That premise was measured
+false on four independent counts:
+
+1. **Scope.** `ConformanceCaseAnalysis.IsR4CleanBase` requires `version == "4.0"` *and* a `.json` input.
+   Both FML entries omit `version` (absent means current R5, matching their `R5.*` outcome filenames) and
+   carry `.fml` inputs. They are excluded twice over, by design.
+2. **Engine.** `ValidatorConformanceRunner.TryValidate` calls `JsonNode.Parse` on the input. FML text throws
+   `JsonException`, which the runner deliberately scores as `Invalid` — so the cases would appear to pass
+   *because JSON parsing failed*. A textbook pass-for-the-wrong-reason.
+3. **Grading model.** The runner reduces each case to binary valid/invalid on error count. These outcomes
+   are line/column-anchored diagnostics (test1: 2 errors + 2 warnings; test2: 3 errors + 2 information).
+4. **Capability.** Reproducing those diagnostics needs StructureMap *semantic* validation Ignixa does not
+   have: cross-map group resolution through `imports` (including the wildcard `*4to3` form), cross-version
+   **R3** StructureDefinition resolution, element-path validation, default-rule inference, and source/target
+   mode cross-checking.
+
+That is multi-week work spanning FML → Specification → Validation, and it grades **2 cases**; the five
+evaluator defects above unblock **10**. Tier B was therefore reduced on this branch to what it can honestly
+support today — a **parse ratchet** (`FmlValidatorCorpusParseTests`) asserting both files parse and that
+their distinguishing constructs survive: `extends Element <<type+>>`, wildcard `imports`, the `map` header,
+the `+` operator, and `('urn:uuid:' + r.lower())`. That construct set overlaps the `structure-mapping`
+corpus (`ActivityDefinition.map` uses wildcard `imports` and `extends … <<type+>>`; `syntax.map` uses the
+parenthesized-FHIRPath transform), so the ratchet is redundant coverage rather than unique coverage — but
+it is the only assertion that keeps these two official files from silently rotting, and it costs 4 tests.
+
+The full semantic-validation work is tracked as
+[#376](https://github.com/brendankowitz/ignixa-fhir/issues/376), explicitly gated behind #372–#375.
+
 ### Scope notes for Tier 1
 
 Of the 10 R5 manifest cases, 4 produce CDA XML (`qr2cda`, `qr2cdaxsi`, `qr2cd-eval-json`, `qr2cd-eval-fml`)
@@ -185,16 +286,21 @@ Caveat on `ahdis/*`: not an HL7-governed repo (it is Matchbox's authors), but th
 correspond 1:1 to the published spec tutorial and all expected outputs were produced by the reference
 engine. Treat as authoritative-by-derivation, not authoritative-by-governance.
 
-### Tier B — FML validation oracle (already wired in this repo)
+### Tier B — FML validation oracle (not reachable as a diagnostic oracle)
 
 | Corpus | Content | Manifest |
 |---|---|---|
 | **`FHIR/fhir-test-cases` `validator/map-general-test{,2}.fml`** | 2 FML files | `validator/manifest.json` → `validator/outcomes/java/R5.map-general-test{,2}-base.json` |
 
 These grade **FML validation diagnostics** (does Ignixa emit the same `OperationOutcome` as the Java
-validator for a malformed/edge-case map), not transform output. Critically, `ValidatorConformanceRunner`
-in `test/Ignixa.Validation.Tests/Conformance/` **already consumes this exact manifest** — these 2 cases
-are near-free once the parser can read the files.
+validator for a malformed/edge-case map), not transform output. `ValidatorConformanceRunner` in
+`test/Ignixa.Validation.Tests/Conformance/` consumes this same manifest, which made these 2 cases look
+near-free.
+
+**They are not** — see *Tier B is not reachable as a diagnostic oracle* above. Both cases are excluded from
+that runner by design, and its JSON-only, binary-graded model would score them green for the wrong reason.
+They are covered here as a parse ratchet instead; the diagnostic oracle is tracked as
+[#376](https://github.com/brendankowitz/ignixa-fhir/issues/376).
 
 ### Tier C — official FML grammar corpora (no expected outputs)
 
@@ -233,7 +339,7 @@ same test), plus `r{4,4b,5}/examples/structuremap-example.json` and `r5/narrativ
 
 | Grading capability | Cases available |
 |---|---:|
-| Transform behaviour (true oracle) | **~130** (16 manifest + 36 tutorial + 75 careconnect + misc) |
+| Transform behaviour (true oracle) | **~130** (20 manifest + 36 tutorial + 75 careconnect + misc) |
 | FML validation diagnostics | 2 |
 | Serialization round-trip vs reference artefacts | ~25 map triples |
 | Grammar / parse / structural resolution | **~1,560 `.fml`** (1,201 HL7 + 355 brianpos) |
@@ -243,40 +349,70 @@ R5 cases", and it changes the Phase 2 value case substantially.
 
 ## Verdict
 
-*Pending evaluation.* Preliminary read:
+**Partially viable — proven, and the sequencing was inverted from the question asked.**
 
-**Yes, and it's more valuable than expected — but the sequencing is inverted from the question asked.**
+The question was "can we use these maps to build oracle tests?" The measurement said the maps could not be
+*read*, so the first deliverable was not a test harness but six parser fixes. Both halves are now built and
+measured.
 
-The question was "can we use these maps to build oracle tests?" The measurement says the maps cannot be
-*read* yet, so the first deliverable is not a test harness, it is four parser fixes. Recommended phasing:
+**What was delivered**
 
-1. **Phase 0 — parser conformance (blocking).** Fix double-quoted strings, `<<typeMode>>`, `%constant`,
-   `///` metadata headers. Each is small and independently testable. Target: `fhir-test-cases` parse rate
-   0/27 → 27/27; `fhir-r6-maps` 0/355 → ≥90%.
-2. **Phase 1 — Tier C parse + Tier D round-trip gate.** Cheap, no execution needed. Point it at
-   `HL7/fhir-cross-version` (1,201 files, HL7-governed) rather than the brianpos staging repo, and add the
-   `.map`/`.json`/`.xml` triple comparison from the tutorial corpus. Land alongside Phase 0 as its
-   acceptance test.
-3. **Phase 2 — Tier A behavioural oracle.** Two runners: `manifest.xml`-driven for `fhir-test-cases`
-   (r5 + r4b), convention-driven for the tutorial + careconnect corpora. ~130 graded cases. CDA-output
-   cases on a frozen exclusion list per ADR-2607.
-4. **Phase 2b — Tier B, near-free.** Add `map-general-test{,2}.fml` to the existing
-   `ValidatorConformanceRunner` case set; the manifest and outcome files are already the ones it reads.
-5. **Phase 3 (optional) — cross-version execution.** Wire `R6CoreSchemaProvider` and run the cross-version
-   maps over `fhir-test-cases` R4/R5 examples. No oracle exists for the output, so grade on *invariants*
-   (no exceptions, result validates against the target version, no data silently dropped) rather than
-   equality. The bundled `ConceptMap`s in `HL7/fhir-cross-version` make this the only realistic way to
-   exercise `TranslateTransform` at scale.
+- **Parser conformance.** All six defects closed. Official corpus parse rate **0/27 → 25/27**
+  (r5 14/15, r4b 11/12), plus **2/2** on the validator FML files. The single failure, `qr2cda-eval.map`,
+  is deferred with a written reason and produces CDA XML that the oracle excludes anyway.
+- **Tier A behavioural oracle.** Manifest-driven runner over r5 + r4b. **12 in-scope cases**, of which
+  **2 produce output matching the reference implementation** and **10 are ratcheted known evaluator gaps**
+  reducing to five distinct defects ([#372](https://github.com/brendankowitz/ignixa-fhir/issues/372)–[#375](https://github.com/brendankowitz/ignixa-fhir/issues/375)).
+- **Tier B.** Reduced to a parse ratchet; the diagnostic oracle is infeasible against the existing runner
+  and is tracked as [#376](https://github.com/brendankowitz/ignixa-fhir/issues/376).
 
-Open question for Phase 3: generating expected outputs with the Java validator or Firely SDK would turn
-Tier 2 into a true oracle, but introduces a build dependency on a reference implementation and risks
+**Why "partially" and not "viable"**
+
+A 2/12 behavioural pass rate is not a success metric — it is a *baseline*. The honest reading is that the
+harness works and the corpus is a good oracle; what it exposed is that `MappingEvaluator` is substantially
+less complete than `MappingParser` now is. The value delivered is that those five defects are now
+reproducible, named, ratcheted, and individually tracked, instead of unknown. Any of the five can be fixed
+independently and the harness will tell you immediately.
+
+**Exclusions, in full**
+
+| Case (both versions) | Rationale |
+|---|---|
+| `qr2cda` | Targets the CDA logical model and produces XML; Ignixa's transform pipeline emits FHIR JSON only. |
+| `qr2cdaxsi` | CDA logical model with `xsi:type` discrimination; XML output out of scope. |
+| `qr2cd-eval-json` | CDA logical model target; XML output out of scope. (Also the only case whose `map` is a JSON StructureMap rather than FML.) |
+| `qr2cd-eval-fml` | CDA logical model target; XML output out of scope. |
+
+Four cases × two versions = 8 excluded of 20. No case with JSON output is excluded, and a guard test
+asserts exactly that — an excluded case must have an XML output file — so the list cannot be used to make
+a hard-but-comparable case disappear.
+
+**Remaining phasing**
+
+1. **Evaluator conformance (next).** Fix #372–#375. Each removal from `FmlKnownEvaluatorGaps` is a
+   measurable step; the ceiling is 12/12.
+2. **Tier C parse gate.** Point at `HL7/fhir-cross-version` (1,201 files, HL7-governed) rather than the
+   brianpos staging repo. Cheap: no execution, and the parser is now in a state where it is worth running.
+3. **Tier D round-trip.** `.map` / `.json` / `.xml` triple comparison from the tutorial corpus, grading
+   `StructureMapParser`, `StructureMapBuilder`, and `FmlSerializer`.
+4. **Tier A expansion.** Tutorial + careconnect corpora (~130 graded cases), convention-driven discovery.
+   Do this only after #372–#375, or it just multiplies the same five failures.
+5. **StructureMap semantic validation** (#376) — gated behind the above.
+6. **Cross-version execution (optional).** Wire `R6CoreSchemaProvider` and run the cross-version maps over
+   R4/R5 examples. No oracle exists for the output, so grade on *invariants* (no exceptions, result
+   validates against the target version, no data silently dropped) rather than equality.
+
+Open question for step 6: generating expected outputs with the Java validator or Firely SDK would turn
+Tier C into a true oracle, but introduces a build dependency on a reference implementation and risks
 encoding another engine's bugs as our spec. Recommend against it initially — invariant-grading is honest
 about what it proves.
 
 ## Related investigation candidates
 
-- **`fml-r6-grammar-support`** — the Phase 0 work as its own investigation: R6 metadata declarations,
-  type-mode annotations, `%` constants, wildcard imports, arithmetic in embedded FHIRPath.
+- **`fml-evaluator-conformance`** — closing the five ratcheted evaluator gaps (#372–#375). The highest-value
+  follow-up: it is the only work that moves the 2/12 oracle number.
+- **`fml-grammar-remainder`** — what Phase 0 did *not* close: nested function calls as transform arguments,
+  wildcard imports (`imports "…/*4to6"`), and unit-bearing date arithmetic (`%value + 5 days`).
 - **`cross-version-transform-pipeline`** — using the R4↔R6 maps as the actual conversion engine for the
   `fhir-compatibility` feature, not just as test data.
 - **`fml-differential-testing`** — property-based/differential testing against a second FML engine

--- a/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
+++ b/docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md
@@ -1,0 +1,283 @@
+# Investigation: FML Oracle Conformance Corpus
+
+**Feature**: structuremap
+**Status**: In Progress
+**Created**: 2026-07-28
+
+## Approach
+
+Stand up a **two-tier oracle harness** for `Ignixa.FhirMappingLanguage`, following the pattern already
+proven by `OfficialTestSuiteRunner` (FHIRPath), `ValidatorConformanceRunner` (Validation), and
+`ShippedSnapshotOracleTests` (snapshot generation): vendor an external corpus authored by someone else,
+grade against *their* recorded expectations, and freeze an explicit exclusion list rather than chasing a
+raw percentage.
+
+### Tier 1 — behavioural oracle (HL7 `fhir-test-cases`)
+
+`FHIR/fhir-test-cases` ships `r5/structure-mapping/` and `r4b/structure-mapping/`, each with a
+`manifest.xml` in the exact shape an oracle runner needs:
+
+```xml
+<fml-tests>
+  <test name="…/qr2patgender" source="qr.json" map="qr2pat-gender.map" output="qr2pat-gender-res.json" />
+  …
+</fml-tests>
+```
+
+Source instance + map + **expected output produced by the HL7 reference implementation**. That is a
+genuine oracle: parse the map, execute it against `source`, compare the produced resource to `output`.
+
+The corpus is already vendored infrastructure-wise — `test/Ignixa.FhirPath.Tests/Ignixa.FhirPath.Tests.csproj`
+downloads and unzips `testcases.zip` (pinned `FhirTestCasesVersion` 1.7.46) via an MSBuild target. The
+same target can be lifted into `Ignixa.FhirMappingLanguage.Tests`.
+
+### Tier 2 — grammar/round-trip oracle (cross-version maps)
+
+`brianpos/fhir-r6-maps` contains **355 `.fml` files** (`R4_R6/maps/StructureMaps` and `R5_R6/maps/StructureMaps`)
+— the machine-generated R4→R6 and R5→R6 cross-version maps, destined for
+[HL7/fhir-cross-version](https://github.com/HL7/fhir-cross-version). Its HL7-governed destination,
+`HL7/fhir-cross-version`, already holds **1,201 `.fml`** (R2↔R3, R3↔R4, R4↔R5, R4B↔R5) and is the better
+target — see the Corpus inventory below.
+
+Critically: **neither repo contains source instances or expected outputs.** They are therefore *not*
+behavioural oracles. They are large, real-world, adversarially-broad **grammar corpora**, gradeable on:
+
+1. **Parse**: every file parses without error.
+2. **Round-trip**: `parse → FmlSerializer → parse` yields an equal AST (extends the existing `RoundTripTests`
+   from hand-written snippets to 355 real files).
+3. **Structural resolution**: every `then <Group>(…)` and `extends <Group>` resolves within the file or its
+   `imports` closure — a cheap static check that needs no expected output.
+
+## Tradeoffs
+
+| Pros | Cons |
+|------|------|
+| Tier 1 is a *true* oracle — expected outputs recorded by the reference implementation, not by us | Tier 1 is small: 10 R5 cases + 10 R4B cases, and 4 of the R5 cases target CDA (a non-FHIR logical model) |
+| Corpus vendoring already solved — the `DownloadFhirTestCases` MSBuild target is copy-pasteable, pinned by version, offline after first restore | Adds a network-dependent first build to a second test project |
+| Tier 2 gives 355 files of grammar coverage for zero authoring effort, and is exactly the corpus Ignixa would need for real R4↔R6 conversion | Tier 2 can only grade *parsing*, not *transform semantics* — no fixtures exist |
+| Grading is deterministic and offline: no terminology server, no live endpoints | Tier 1 output comparison needs a canonical JSON/XML diff (element ordering, `id` churn, whitespace) — a real chunk of harness work |
+| Consistent with ADR-2607's "declare supported scope, freeze exclusions" discipline | Risk of the exclusion list becoming a dumping ground if not policed |
+| Failures are diagnostic: each is a named language feature, not a vague score | R4→R6 execution needs `R6CoreSchemaProvider` wiring; there are no `Ignixa.Models.R6` typed models yet (untyped `IElement` path only) |
+
+## Alignment
+
+- [x] Follows architectural layering rules — test-only; `Ignixa.FhirMappingLanguage.Tests` already references
+      `Ignixa.FhirMappingLanguage`. Tier 1 execution additionally needs `Ignixa.Specification` (schema provider),
+      mirroring `Ignixa.FhirPath.Tests`.
+- [x] Developer Experience — `dotnet test` only; corpus auto-downloads once, then offline. No manual fixture curation.
+- [x] Specification compliance — this *is* the compliance measurement. Grading against HL7's own recorded outputs.
+- [x] Consistent with existing patterns — three precedents in-repo (FHIRPath official suite, validator conformance,
+      shipped-snapshot oracle) plus ADR-2607 for how to declare the result honestly.
+
+## Evidence
+
+### Measured baseline: both corpora currently fail to parse, 100%
+
+A throwaway probe was run against the real `MappingParser` (net9.0, this branch), feeding every `.fml`/`.map`
+file through `parser.Parse()`:
+
+| Corpus | Files | Parsed | Failed |
+|---|---:|---:|---:|
+| `FHIR/fhir-test-cases` `r5` + `r4b` `structure-mapping` (`.map`) | 27 | **0** | 27 |
+| `brianpos/fhir-r6-maps` (`.fml`) | 355 | **0** | 355 |
+
+This is not a "the harness is hard to build" result — it is a **language-coverage result**. The current
+parser handles the hand-written dialect used in `test/Ignixa.FhirMappingLanguage.Tests` and
+`src/Core/Ignixa.FhirMappingLanguage/README.md` (single-quoted strings, `map 'url' = 'name'` header) and
+nothing that the wild actually ships.
+
+### Root causes — four concrete parser defects, all reproduced
+
+**1. Double-quoted string literals are not string literals** (21 of 27 official cases)
+
+`MappingTokenizer.cs:69,73` matches `QuotedString.SqlStyle` (single-quote) as `StringLiteral`, and
+`"…"` as `DelimitedIdentifier`. `MappingGrammar.Map` (line 512) requires `StringLiteral`:
+
+```
+cast.map:1  map "http://ahdis.ch/matchbox/fml/cast" = "cast"
+→ Failed to parse … at line 1, column 5: unexpected delimitedidentifier `"h…
+```
+
+The spec grammar treats `"…"` and `'…'` interchangeably for FML string values. Ignixa accepts only one.
+This single defect accounts for ~78% of official-suite parse failures.
+
+**2. Group type-mode annotation `<<type+>>` / `<<types>>` unsupported**
+
+`MappingGrammar.Group` (lines 488–507) goes straight from `extends` to `{`. `LeftAngle`/`RightAngle` tokens
+exist in `MappingTokenKind` but are never consumed by the grammar, and there is no `Plus` token at all:
+
+```
+ActivityDefinition.map:8   group ActivityDefinition(source src : …, target tgt : …) extends DomainResource <<type+>> {
+syntaxshort.map:10         group string(source src : string, target tgt : string) <<type+>> {
+Patient_4to6.fml:12        group Patient(source src : PatientR4, target tgt : PatientR6) extends DomainResource <<type+>> {
+→ Syntax error (line 12, column 91): unexpected `+`.
+```
+
+`<<type+>>` is how the entire cross-version map set declares type-conversion groups. It is unavoidable for
+the 355-file corpus.
+
+**3. `%constant` / variable references unsupported**
+
+No `Percent` token kind exists:
+
+```
+qr2patfordates.map:9   ext.value as value -> tgt.birthDate = (%value + 5 days) "plus";
+→ Syntax error (line 9, column 43): unexpected `%`.
+```
+
+**4. R6 `///` metadata header, and `map` header treated as mandatory**
+
+`MappingGrammar.Map` (line 511) requires a leading `map` token. The R6 form replaces it with metadata
+declarations, which the tokenizer currently swallows as `LineComment`, leaving no header at all:
+
+```
+syntax.map:1     /// url = "http://github.com/FHIR/fhir-test-cases/r5/fml/syntax"
+Patient_4to6.fml /// url = 'http://hl7.org/fhir/uv/xver/StructureMap/Patient4to6'
+→ Failed to parse … at line 6, column 1: unexpected uses `uses`, expected map
+```
+
+### Secondary gaps observed in the corpora (not yet parse-blocking, will be)
+
+- Arithmetic/concatenation inside target FHIRPath: `ext.system = ('urn:uuid:' + r.lower())` (`syntax.map:17`)
+  — the FML tokenizer has no `+`, so embedded FHIRPath containing operators dies at the FML layer before
+  `Ignixa.FhirPath` ever sees it.
+- Wildcard imports: `imports "http://hl7.org/fhir/uv/xver/StructureMap/*4to6"` — used by every cross-version
+  map; `ImportResolver` needs glob semantics.
+- Date arithmetic with units: `%value + 5 days`.
+
+### Scope notes for Tier 1
+
+Of the 10 R5 manifest cases, 4 produce CDA XML (`qr2cda`, `qr2cdaxsi`, `qr2cd-eval-json`, `qr2cd-eval-fml`)
+— transformation into a non-FHIR logical model with `xsi:type` handling. Following ADR-2607's precedent,
+these belong on a **frozen exclusion list with rationale** rather than being counted as failures. That
+leaves **6 in-scope R5 cases** (all `qr.json` → Patient JSON) plus the R4B set as the initial scored slice.
+
+`qr2cda-eval.json` is notable: the same test is expressed as both `.map` (FML text) and `.json`
+(StructureMap resource), which incidentally exercises `StructureMapParser` and `StructureMapBuilder` against
+the same expected output.
+
+### Prior art in-repo
+
+| Precedent | Mechanism to reuse |
+|---|---|
+| `test/Ignixa.FhirPath.Tests/Ignixa.FhirPath.Tests.csproj` | `DownloadFhirTestCases` MSBuild target — pinned version, race-safe across TFMs, `.downloaded` marker |
+| `test/Ignixa.Validation.Tests/Conformance/ConformanceCaseLoader.cs` + `ValidatorConformanceRunner.cs` | manifest-driven case loading, categorised outcome reporting |
+| `test/Ignixa.PackageManagement.Tests/Snapshot/ShippedSnapshotOracleTests.cs` | facet-based comparison instead of raw equality — the right shape for output diffing |
+| `docs/adr/adr-2607-validation-oracle-conformance.md` | how to declare the result: supported-scope pass rate + frozen exclusion list |
+
+## Corpus inventory
+
+An exhaustive survey of available FML/StructureMap corpora, classified by **what they can actually
+grade**. The distinction that matters is whether a corpus ships *expected outputs produced by a reference
+implementation* — without those, a corpus grades grammar, not semantics.
+
+### Tier A — true transform oracles (map + source + reference-produced expected output)
+
+| Corpus | Content | Manifest | Notes |
+|---|---|---|---|
+| **`FHIR/fhir-test-cases` `r5/structure-mapping/`** | 10 cases, 16 `.map` + fixtures | `manifest.xml` `<fml-tests>` | **The** official oracle. Drives the Java reference validator's own FML suite. 6 FHIR-output cases, 4 CDA-output. |
+| **`FHIR/fhir-test-cases` `r4b/structure-mapping/`** | 10 cases, 12 `.map` + fixtures | `manifest.xml` `<fml-tests>` | Same shape, R4B slice. |
+| **`ahdis/fhir-mapping-tutorial` `maptutorial/step1..13`** | 25 `.map`, 18 source instances, **36 expected results**, 28 logical `StructureDefinition`s | convention: `map/{m}.map` + `source/{s}.json` → `result/{m}.{s}.json` | Fixtures for the **official spec tutorial** (`hl7.org/fhir/R5/mapping-tutorial.html`, steps 1–13). Filename convention encodes the map × source cross-product, so a runner is trivial. |
+| **`ahdis/fhir-mapping-tutorial` `careconnect-to-ukcore/`** | 8 maps, **75 input / 75 expected** pairs | convention: `maps/`, `input/`, `expected/` | Real-world STU3 CareConnect → UK Core extension conversion. Highest-volume behavioural oracle available. |
+| **`ahdis/fhir-mapping-tutorial`** misc (`qrtopat`, `qrextract`, `unioncollection`, `rum-example`, `condition`, `csv`, `xml`, `tests/`) | 13 further `.map` | mixed | `tests/` includes `cast.map`, `memberof.map`, `quantity.map`, `stringtocoding*.map` — targeted transform-function cases. |
+
+Caveat on `ahdis/*`: not an HL7-governed repo (it is Matchbox's authors), but the `maptutorial` fixtures
+correspond 1:1 to the published spec tutorial and all expected outputs were produced by the reference
+engine. Treat as authoritative-by-derivation, not authoritative-by-governance.
+
+### Tier B — FML validation oracle (already wired in this repo)
+
+| Corpus | Content | Manifest |
+|---|---|---|
+| **`FHIR/fhir-test-cases` `validator/map-general-test{,2}.fml`** | 2 FML files | `validator/manifest.json` → `validator/outcomes/java/R5.map-general-test{,2}-base.json` |
+
+These grade **FML validation diagnostics** (does Ignixa emit the same `OperationOutcome` as the Java
+validator for a malformed/edge-case map), not transform output. Critically, `ValidatorConformanceRunner`
+in `test/Ignixa.Validation.Tests/Conformance/` **already consumes this exact manifest** — these 2 cases
+are near-free once the parser can read the files.
+
+### Tier C — official FML grammar corpora (no expected outputs)
+
+| Corpus | Content | Grades |
+|---|---|---|
+| **`HL7/fhir-cross-version`** | **1,201 `.fml`** across `R2toR3`, `R3toR2`, `R3toR4`, `R4toR3`, `R4toR5`, `R5toR4`, `R4BtoR5`, `R5toR4B`; plus ~2,230 supporting `ConceptMap`s (2,200 code maps, 13 type maps, 10 resource maps, 6 search-param maps) | parse, round-trip, group/import resolution, ConceptMap `translate()` wiring |
+| **`brianpos/fhir-r6-maps`** | 355 `.fml` (R4→R6, R5→R6) | same; staging area destined for `HL7/fhir-cross-version` |
+
+`HL7/fhir-cross-version` is the **HL7-governed** home and is 3.4× larger than the brianpos repo — it is the
+better Tier C target, and its bundled ConceptMaps additionally exercise `ConceptMapResolver` /
+`TranslateTransform`, which no other corpus does at scale.
+
+### Tier D — serialization oracles (form-equivalence, no execution needed)
+
+`ahdis/fhir-mapping-tutorial` ships each tutorial map in **three forms**: `.map` (FML text), `.json`
+(StructureMap resource), `.xml` (StructureMap resource) — 25 / 24 / 25 files respectively, all
+reference-produced. That is a direct oracle for `StructureMapBuilder`, `StructureMapParser`, and
+`FmlSerializer`:
+
+- `parse(.map)` → build StructureMap → must equal shipped `.json`
+- shipped `.json` → `FmlSerializer` → must re-parse to the same AST
+
+`fhir-test-cases` offers one instance of the same idea (`qr2cda-eval.map` and `qr2cda-eval.json` are the
+same test), plus `r{4,4b,5}/examples/structuremap-example.json` and `r5/narrative/sm.fml`.
+
+### What does not exist
+
+- No official corpus pairs the **cross-version maps** (Tier C) with source/expected instances. Any R4↔R5 or
+  R4↔R6 execution testing must be invariant-graded or self-generated.
+- No `<fml-tests>`-style manifest outside `FHIR/fhir-test-cases` (verified by code search) — Tier A
+  entries 3–5 need convention-based discovery, not manifest parsing.
+- No FML corpus in `HL7/fhir` spec source itself; the tutorial artefacts live only as HTML prose on
+  `mapping-tutorial.html`, which is why the `ahdis` fixture repo matters.
+
+### Revised corpus scale
+
+| Grading capability | Cases available |
+|---|---:|
+| Transform behaviour (true oracle) | **~130** (16 manifest + 36 tutorial + 75 careconnect + misc) |
+| FML validation diagnostics | 2 |
+| Serialization round-trip vs reference artefacts | ~25 map triples |
+| Grammar / parse / structural resolution | **~1,560 `.fml`** (1,201 HL7 + 355 brianpos) |
+
+This is roughly an order of magnitude more behavioural coverage than the first-pass estimate of "6 in-scope
+R5 cases", and it changes the Phase 2 value case substantially.
+
+## Verdict
+
+*Pending evaluation.* Preliminary read:
+
+**Yes, and it's more valuable than expected — but the sequencing is inverted from the question asked.**
+
+The question was "can we use these maps to build oracle tests?" The measurement says the maps cannot be
+*read* yet, so the first deliverable is not a test harness, it is four parser fixes. Recommended phasing:
+
+1. **Phase 0 — parser conformance (blocking).** Fix double-quoted strings, `<<typeMode>>`, `%constant`,
+   `///` metadata headers. Each is small and independently testable. Target: `fhir-test-cases` parse rate
+   0/27 → 27/27; `fhir-r6-maps` 0/355 → ≥90%.
+2. **Phase 1 — Tier C parse + Tier D round-trip gate.** Cheap, no execution needed. Point it at
+   `HL7/fhir-cross-version` (1,201 files, HL7-governed) rather than the brianpos staging repo, and add the
+   `.map`/`.json`/`.xml` triple comparison from the tutorial corpus. Land alongside Phase 0 as its
+   acceptance test.
+3. **Phase 2 — Tier A behavioural oracle.** Two runners: `manifest.xml`-driven for `fhir-test-cases`
+   (r5 + r4b), convention-driven for the tutorial + careconnect corpora. ~130 graded cases. CDA-output
+   cases on a frozen exclusion list per ADR-2607.
+4. **Phase 2b — Tier B, near-free.** Add `map-general-test{,2}.fml` to the existing
+   `ValidatorConformanceRunner` case set; the manifest and outcome files are already the ones it reads.
+5. **Phase 3 (optional) — cross-version execution.** Wire `R6CoreSchemaProvider` and run the cross-version
+   maps over `fhir-test-cases` R4/R5 examples. No oracle exists for the output, so grade on *invariants*
+   (no exceptions, result validates against the target version, no data silently dropped) rather than
+   equality. The bundled `ConceptMap`s in `HL7/fhir-cross-version` make this the only realistic way to
+   exercise `TranslateTransform` at scale.
+
+Open question for Phase 3: generating expected outputs with the Java validator or Firely SDK would turn
+Tier 2 into a true oracle, but introduces a build dependency on a reference implementation and risks
+encoding another engine's bugs as our spec. Recommend against it initially — invariant-grading is honest
+about what it proves.
+
+## Related investigation candidates
+
+- **`fml-r6-grammar-support`** — the Phase 0 work as its own investigation: R6 metadata declarations,
+  type-mode annotations, `%` constants, wildcard imports, arithmetic in embedded FHIRPath.
+- **`cross-version-transform-pipeline`** — using the R4↔R6 maps as the actual conversion engine for the
+  `fhir-compatibility` feature, not just as test data.
+- **`fml-differential-testing`** — property-based/differential testing against a second FML engine
+  (Matchbox, `brianpos/fml-processor`) instead of a static corpus.

--- a/docs/features/structuremap/readme.md
+++ b/docs/features/structuremap/readme.md
@@ -17,7 +17,7 @@ This feature implements the FHIR $transform operation for StructureMap-based dat
 | [Implementation Summary](investigations/implementation-summary.md) | Approved | 2025-11-29 | Summary of StructureMap transform implementation approach |
 | [Operation Integration](investigations/operation-integration.md) | Approved | 2025-11-29 | Integration of $transform operation into the FHIR server |
 | [Mutation Strategy](investigations/mutation-strategy.md) | Approved | 2025-11-30 | Strategy for handling in-place vs copy-on-write transformations |
-| [FML Oracle Conformance Corpus](investigations/fml-oracle-conformance-corpus.md) | In Progress | 2026-07-28 | Grading the FML engine against HL7 `fhir-test-cases` structure-mapping and the R4/R5→R6 cross-version maps |
+| [FML Oracle Conformance Corpus](investigations/fml-oracle-conformance-corpus.md) | Approved | 2026-07-28 | Grading the FML engine against HL7 `fhir-test-cases` structure-mapping and the R4/R5→R6 cross-version maps |
 
 ## Key Components
 

--- a/docs/features/structuremap/readme.md
+++ b/docs/features/structuremap/readme.md
@@ -17,6 +17,7 @@ This feature implements the FHIR $transform operation for StructureMap-based dat
 | [Implementation Summary](investigations/implementation-summary.md) | Approved | 2025-11-29 | Summary of StructureMap transform implementation approach |
 | [Operation Integration](investigations/operation-integration.md) | Approved | 2025-11-29 | Integration of $transform operation into the FHIR server |
 | [Mutation Strategy](investigations/mutation-strategy.md) | Approved | 2025-11-30 | Strategy for handling in-place vs copy-on-write transformations |
+| [FML Oracle Conformance Corpus](investigations/fml-oracle-conformance-corpus.md) | In Progress | 2026-07-28 | Grading the FML engine against HL7 `fhir-test-cases` structure-mapping and the R4/R5→R6 cross-version maps |
 
 ## Key Components
 

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -847,13 +847,20 @@ public enum GroupTypeMode
     /// <summary>No annotation present. The group is only invoked by explicit reference.</summary>
     None = 0,
 
-    /// <summary>Declared &lt;&lt;types&gt;&gt;: the group is a candidate for type-based dispatch.</summary>
+    /// <summary>
+    /// Declared &lt;&lt;types&gt;&gt;: the default mapping group for the specified types
+    /// and for the primary source type.
+    /// </summary>
     Types,
 
-    /// <summary>Declared &lt;&lt;type+&gt;&gt;: the group is the default for type-based dispatch.</summary>
+    /// <summary>
+    /// Declared &lt;&lt;type+&gt;&gt;: the default mapping group for the specified types.
+    /// </summary>
     TypeAndTypes
 }
 ```
+
+Wording follows the official code system `http://hl7.org/fhir/map-group-type-mode`. Note `types` is the **broader** of the two despite the shorter name — do not paraphrase these into "candidate" vs "default", which inverts the meaning.
 
 `None = 0` is deliberate — it makes `.OptionalOrDefault()` yield the right value for groups with no annotation.
 
@@ -886,8 +893,8 @@ In `MappingGrammar.cs`, define this parser immediately **above** the `Group` par
         from open2 in Token.EqualTo(MappingTokenKind.LeftAngle)
         from mode in Token.EqualTo(MappingTokenKind.Types).Value(GroupTypeMode.Types)
             .Or(from typeToken in Token.EqualTo(MappingTokenKind.Type)
-                from plus in Token.EqualTo(MappingTokenKind.Plus).Optional()
-                select plus.HasValue ? GroupTypeMode.TypeAndTypes : GroupTypeMode.Types)
+                from plus in Token.EqualTo(MappingTokenKind.Plus)
+                select GroupTypeMode.TypeAndTypes)
         from close1 in Token.EqualTo(MappingTokenKind.RightAngle)
         from close2 in Token.EqualTo(MappingTokenKind.RightAngle)
         select mode;
@@ -902,6 +909,16 @@ Then, in the `Group` parser (lines 488-507), insert between the optional `extend
 and pass `typeMode` as the new trailing argument to the `GroupExpression` constructor in that parser's `select`.
 
 **Lexer note:** `Span.Regex(@"\btype\b")` still matches inside `type+` because `+` is a non-word character, and `\btypes\b` is registered before `\btype\b`, so `types` is never split. Task 1 supplied the `Plus` token this rule needs.
+
+**The `Plus` is mandatory, not optional.** The official production is closed:
+
+```
+groupTypeMode : 'types' | 'type+' ;
+```
+
+There is no bare `<<type>>` in FML, and the HL7 reference parser agrees — `StructureMapUtilities.java:1216-1219` calls `lexer.token("type")` then `lexer.token("+")` unconditionally, throwing when the `+` is absent. Do **not** make `Plus` optional "to be lenient": that silently accepts input the reference implementation rejects, and is the same mistake this plan originally made in Task 3 by widening `Identifier` to accept double-quoted strings. Add a negative test asserting `<<type>>` throws `ParseException`.
+
+**Also required: a test covering `extends` and the annotation on the same group.** With no `extends` in the test fixture, "emit the annotation before `extends`" and "emit it after `extends`" are indistinguishable positions, so a serializer ordering regression is invisible. Cross-version maps — the entire reason this task exists — use both together. Round-trip a group with `extends Base` plus the annotation and assert on `Extends` **and** `TypeMode` after the reparse.
 
 - [ ] **Step 6: Round-trip in `FmlSerializer`**
 

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -1,0 +1,2169 @@
+# FML Parser Conformance and Oracle Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the six defects that make Ignixa's FML parser reject 100% of real-world `.fml`/`.map` files, then wire the official HL7 `fhir-test-cases` structure-mapping corpus in as a permanent oracle-test suite.
+
+**Architecture:** Two halves executed in order. Part A is pure lexer/grammar work in `src/Core/Ignixa.FhirMappingLanguage/` — each defect gets a hand-written unit test first, then the minimal fix. Part B vendors the HL7 `fhir-test-cases` zip into `test/Ignixa.FhirMappingLanguage.Tests/` via the same MSBuild download target already proven in `Ignixa.FhirPath.Tests`, then adds a manifest-driven `[Theory]` runner that executes each `<fml-tests>` case end-to-end and compares against the reference-produced expected resource with canonical JSON equality. Out-of-scope cases (CDA logical-model output) go on a frozen exclusion list with written rationale, per `docs/adr/adr-2607-validation-oracle-conformance.md`.
+
+**Tech Stack:** .NET 9/10, C#, Superpower (lexer/parser combinators), xUnit + Shouldly, `System.Text.Json` / `JsonNode`, MSBuild `DownloadFile`/`Unzip` tasks, `Ignixa.Specification` schema providers, `Ignixa.FhirPath`.
+
+**Input spec:** `docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md`
+
+---
+
+## Background: what is actually broken
+
+A throwaway probe fed every file from two corpora through `MappingParser.Parse()`:
+
+| Corpus | Files | Parsed |
+|---|---|---|
+| `brianpos/fhir-r6-maps` | 355 `.fml` | **0** |
+| `FHIR/fhir-test-cases` `r4b`+`r5` `structure-mapping` | 27 `.map` | **0** |
+
+Six root causes, in dependency order:
+
+| # | Defect | Symptom | Blast radius |
+|---|---|---|---|
+| 1 | Tokenizer has no `+ - % / \| & <= >=` tokens | `Syntax error: unexpected '+'` at the *lexer* | blocks everything downstream |
+| 2 | `FhirPathExpression` re-joins tokens with `string.Join("")` | `linkId.value in ('x')` becomes `linkId.valuein('x')` | silently corrupts embedded FHIRPath |
+| 3 | `"..."` lexes as `DelimitedIdentifier`, not a string literal | `map "url" = "name"` fails at line 1 col 5 | 21 of 27 official cases (~78%) |
+| 4 | No `<<types>>` / `<<type+>>` group annotation | `unexpected '+'` / `unexpected '<'` | all cross-version maps |
+| 5 | No `///` metadata declarations; `map` header mandatory | `unexpected uses 'uses', expected map` | all R6-form maps |
+| 6 | Wildcard `imports ".../*4to6"` not resolvable | runtime, not parse | deferred — see Follow-ups |
+
+Defects 1-5 are in scope. Defect 6 is deferred (it is an `ImportResolver` concern, not a parser concern, and no in-scope oracle case needs it).
+
+---
+
+## File Structure
+
+### Part A — parser (production code)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs` | Modify | Add `Plus`, `Minus`, `Percent`, `Slash`, `Pipe`, `Ampersand`, `LessOrEqual`, `GreaterOrEqual`, `DoubleQuotedString`, `MetadataLine` |
+| `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs` | Modify | Two near-identical builders (`CreateWithTrivia()` and `Create()`) — **every change must be applied to both** |
+| `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs` | Modify | String-literal widening, source-text reconstruction, group type-mode rule, metadata + optional `map` header |
+| `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs` | Modify | Guard against a "successfully parsed nothing" map |
+| `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs` | Create | Enum for `<<types>>` / `<<type+>>` |
+| `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs` | Modify | Carry `TypeMode` |
+| `src/Core/Ignixa.FhirMappingLanguage/Expressions/MapExpression.cs` | Modify | Carry `Metadata` dictionary |
+| `src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs` | Modify | Round-trip the new syntax |
+
+### Part A — parser (tests)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs` | Modify | Update the `"quoted"` → `DelimitedIdentifier` assertion; add operator-token cases |
+| `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs` | Create | One focused test per defect, using the smallest reproducing snippet |
+
+### Part B — oracle harness
+
+| File | Action | Responsibility |
+|---|---|---|
+| `test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj` | Modify | `DownloadFhirTestCases` MSBuild target |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs` | Create | Resolve the vendored corpus root; single source of truth for paths |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleCase.cs` | Create | Immutable record for one manifest case |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleExclusions.cs` | Create | Frozen exclusion list + rationale |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoader.cs` | Create | Parse `<fml-tests>` out of `manifest.xml` |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs` | Create | Order-insensitive JSON canonicalisation for comparison |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs` | Create | Parse-rate gate over every `.map` in the corpus |
+| `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs` | Create | The manifest-driven end-to-end transform oracle |
+
+### Docs
+
+| File | Action |
+|---|---|
+| `docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md` | Modify — record measured outcome, set Verdict |
+
+---
+
+## Conventions you must follow
+
+From `AGENTS.md` / `CLAUDE.md` in this repo:
+
+- One type per file. No `#region`.
+- Test naming: `GivenContext_WhenAction_ThenResult`. AAA layout. xUnit + Shouldly.
+- 4-space indent, file-scoped namespaces, nullable enabled, warnings-as-errors.
+- Async parameters named `cancellationToken`, never `ct`.
+- **No inline comments** unless the surrounding file already uses them for the same purpose. The tokenizer/grammar files do use structural comments — match their existing style there.
+- **Never `git commit` without explicit user approval.** Each task below ends with a commit step; run it only once the user has approved that batch.
+
+**Critical gotcha:** `test/Ignixa.FhirMappingLanguage.Tests/` has **no global usings**. Every new test file needs explicit `using Xunit;` and `using Shouldly;`.
+
+**Critical gotcha:** `MappingTokenizer.cs` contains **two near-identical tokenizer builders** — `CreateWithTrivia()` (lines 24-111) and `Create()` (lines 117-204). Every tokenizer change must be applied to **both**. Because the operator blocks are byte-identical between them, a naive `edit` anchor will fail with "not unique" — the replacements below include enough trailing context (`.Build();` vs `// Whitespace (ignore for standard parsing)`) to disambiguate.
+
+---
+
+# Part A — Parser defects
+
+## Task 1: Operator tokens (`+ - % / | & <= >=`)
+
+The tokenizer has no rule for these characters, so Superpower fails at the *lexing* stage before the grammar is ever consulted. Errors look like `Syntax error (line 12, column 91): unexpected '+'`.
+
+Real occurrences:
+- `qr2patfordates.map:9` — `tgt.birthDate = (%value + 5 days)`
+- `syntax.map:17` — `('urn:uuid:' + r.lower())`
+- tutorial `whereclause` — `a2.length <= 20`
+- cross-version maps — `<<type+>>`
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs:83` (after `RightBracket`)
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs:86-110` and `:176-201`
+- Test: `test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs`, inside the existing class, before the closing brace:
+
+```csharp
+    [Theory]
+    [InlineData("+", MappingTokenKind.Plus)]
+    [InlineData("-", MappingTokenKind.Minus)]
+    [InlineData("%", MappingTokenKind.Percent)]
+    [InlineData("/", MappingTokenKind.Slash)]
+    [InlineData("|", MappingTokenKind.Pipe)]
+    [InlineData("&", MappingTokenKind.Ampersand)]
+    [InlineData("<=", MappingTokenKind.LessOrEqual)]
+    [InlineData(">=", MappingTokenKind.GreaterOrEqual)]
+    public void GivenAnArithmeticOperator_WhenTokenizing_ThenTheOperatorTokenIsProduced(string input, MappingTokenKind expected)
+    {
+        var tokenizer = MappingTokenizer.Create();
+
+        var tokens = tokenizer.Tokenize(input).ToList();
+
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenAPercentConstantWithDateArithmetic_WhenTokenizing_ThenAllTokensAreProduced()
+    {
+        var tokenizer = MappingTokenizer.Create();
+
+        var kinds = tokenizer.Tokenize("%value + 5 days").Select(t => t.Kind).ToList();
+
+        kinds.ShouldBe(new[]
+        {
+            MappingTokenKind.Percent,
+            MappingTokenKind.Identifier,
+            MappingTokenKind.Plus,
+            MappingTokenKind.IntegerLiteral,
+            MappingTokenKind.Identifier
+        });
+    }
+
+    [Fact]
+    public void GivenAnArrow_WhenTokenizing_ThenItIsStillASingleArrowNotMinus()
+    {
+        var tokenizer = MappingTokenizer.Create();
+
+        var kinds = tokenizer.Tokenize("src -> tgt").Select(t => t.Kind).ToList();
+
+        kinds.ShouldBe(new[]
+        {
+            MappingTokenKind.Identifier,
+            MappingTokenKind.Arrow,
+            MappingTokenKind.Identifier
+        });
+    }
+
+    [Fact]
+    public void GivenALineComment_WhenTokenizingWithTrivia_ThenItIsStillACommentNotTwoSlashes()
+    {
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+
+        var kinds = tokenizer.Tokenize("// hello").Select(t => t.Kind).ToList();
+
+        kinds.ShouldBe(new[] { MappingTokenKind.LineComment });
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~MappingTokenizerTests"
+```
+
+Expected: build error `CS0117: 'MappingTokenKind' does not contain a definition for 'Plus'`.
+
+- [ ] **Step 3: Add the token kinds**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs`, replace:
+
+```csharp
+    LeftBracket,         // [
+    RightBracket,        // ]
+```
+
+with:
+
+```csharp
+    LeftBracket,         // [
+    RightBracket,        // ]
+
+    // Arithmetic and FHIRPath operators (appear inside embedded FHIRPath and in <<type+>>)
+    Plus,                // +
+    Minus,               // -
+    Percent,             // % (FHIRPath environment variable prefix)
+    Slash,               // /
+    Pipe,                // |
+    Ampersand,           // &
+    LessOrEqual,         // <=
+    GreaterOrEqual,      // >=
+```
+
+- [ ] **Step 4: Patch `CreateWithTrivia()`**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs`, replace this block (it is the one that ends in `.Build();` — that trailing context makes the anchor unique):
+
+```csharp
+            .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+
+            // Single-character operators and delimiters
+            .Match(Character.EqualTo('='), MappingTokenKind.Equals)
+            .Match(Character.EqualTo(':'), MappingTokenKind.Colon)
+            .Match(Character.EqualTo('.'), MappingTokenKind.Dot)
+            .Match(Character.EqualTo('*'), MappingTokenKind.Asterisk)
+            .Match(Character.EqualTo(','), MappingTokenKind.Comma)
+            .Match(Character.EqualTo(';'), MappingTokenKind.Semicolon)
+            .Match(Character.EqualTo('('), MappingTokenKind.LeftParen)
+            .Match(Character.EqualTo(')'), MappingTokenKind.RightParen)
+            .Match(Character.EqualTo('{'), MappingTokenKind.LeftBrace)
+            .Match(Character.EqualTo('}'), MappingTokenKind.RightBrace)
+            .Match(Character.EqualTo('<'), MappingTokenKind.LeftAngle)
+            .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
+            .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
+            .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            .Build();
+```
+
+with:
+
+```csharp
+            .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+            .Match(Span.EqualTo("<="), MappingTokenKind.LessOrEqual)
+            .Match(Span.EqualTo(">="), MappingTokenKind.GreaterOrEqual)
+
+            // Single-character operators and delimiters
+            .Match(Character.EqualTo('='), MappingTokenKind.Equals)
+            .Match(Character.EqualTo(':'), MappingTokenKind.Colon)
+            .Match(Character.EqualTo('.'), MappingTokenKind.Dot)
+            .Match(Character.EqualTo('*'), MappingTokenKind.Asterisk)
+            .Match(Character.EqualTo(','), MappingTokenKind.Comma)
+            .Match(Character.EqualTo(';'), MappingTokenKind.Semicolon)
+            .Match(Character.EqualTo('('), MappingTokenKind.LeftParen)
+            .Match(Character.EqualTo(')'), MappingTokenKind.RightParen)
+            .Match(Character.EqualTo('{'), MappingTokenKind.LeftBrace)
+            .Match(Character.EqualTo('}'), MappingTokenKind.RightBrace)
+            .Match(Character.EqualTo('<'), MappingTokenKind.LeftAngle)
+            .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
+            .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
+            .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            // Arithmetic / FHIRPath operators (after multi-character forms so -> and <= win)
+            .Match(Character.EqualTo('+'), MappingTokenKind.Plus)
+            .Match(Character.EqualTo('-'), MappingTokenKind.Minus)
+            .Match(Character.EqualTo('%'), MappingTokenKind.Percent)
+            .Match(Character.EqualTo('/'), MappingTokenKind.Slash)
+            .Match(Character.EqualTo('|'), MappingTokenKind.Pipe)
+            .Match(Character.EqualTo('&'), MappingTokenKind.Ampersand)
+
+            .Build();
+```
+
+- [ ] **Step 5: Patch `Create()`**
+
+Replace the equivalent block — the one whose trailing context is the whitespace-ignore comment:
+
+```csharp
+            .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+
+            // Single-character operators and delimiters
+            .Match(Character.EqualTo('='), MappingTokenKind.Equals)
+            .Match(Character.EqualTo(':'), MappingTokenKind.Colon)
+            .Match(Character.EqualTo('.'), MappingTokenKind.Dot)
+            .Match(Character.EqualTo('*'), MappingTokenKind.Asterisk)
+            .Match(Character.EqualTo(','), MappingTokenKind.Comma)
+            .Match(Character.EqualTo(';'), MappingTokenKind.Semicolon)
+            .Match(Character.EqualTo('('), MappingTokenKind.LeftParen)
+            .Match(Character.EqualTo(')'), MappingTokenKind.RightParen)
+            .Match(Character.EqualTo('{'), MappingTokenKind.LeftBrace)
+            .Match(Character.EqualTo('}'), MappingTokenKind.RightBrace)
+            .Match(Character.EqualTo('<'), MappingTokenKind.LeftAngle)
+            .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
+            .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
+            .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            // Whitespace (ignore for standard parsing)
+```
+
+with:
+
+```csharp
+            .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+            .Match(Span.EqualTo("<="), MappingTokenKind.LessOrEqual)
+            .Match(Span.EqualTo(">="), MappingTokenKind.GreaterOrEqual)
+
+            // Single-character operators and delimiters
+            .Match(Character.EqualTo('='), MappingTokenKind.Equals)
+            .Match(Character.EqualTo(':'), MappingTokenKind.Colon)
+            .Match(Character.EqualTo('.'), MappingTokenKind.Dot)
+            .Match(Character.EqualTo('*'), MappingTokenKind.Asterisk)
+            .Match(Character.EqualTo(','), MappingTokenKind.Comma)
+            .Match(Character.EqualTo(';'), MappingTokenKind.Semicolon)
+            .Match(Character.EqualTo('('), MappingTokenKind.LeftParen)
+            .Match(Character.EqualTo(')'), MappingTokenKind.RightParen)
+            .Match(Character.EqualTo('{'), MappingTokenKind.LeftBrace)
+            .Match(Character.EqualTo('}'), MappingTokenKind.RightBrace)
+            .Match(Character.EqualTo('<'), MappingTokenKind.LeftAngle)
+            .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
+            .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
+            .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            // Arithmetic / FHIRPath operators (after multi-character forms so -> and <= win)
+            .Match(Character.EqualTo('+'), MappingTokenKind.Plus)
+            .Match(Character.EqualTo('-'), MappingTokenKind.Minus)
+            .Match(Character.EqualTo('%'), MappingTokenKind.Percent)
+            .Match(Character.EqualTo('/'), MappingTokenKind.Slash)
+            .Match(Character.EqualTo('|'), MappingTokenKind.Pipe)
+            .Match(Character.EqualTo('&'), MappingTokenKind.Ampersand)
+
+            // Whitespace (ignore for standard parsing)
+```
+
+**Why `/` is safe:** both builders match `Comment.CStyle` and `Comment.CPlusPlusStyle` as their *first two* rules, so `//` and `/* */` are consumed before the single-`/` rule is ever reached.
+
+**Why URLs are safe:** the `Url` rule (line 81 / 171) is registered before the operator block and its character class permits `+ - % / &`, so `http://x/y?a=1&b=2` still lexes as one `Url` token.
+
+**Do not** add a `<<` token — `<<` must remain two `LeftAngle` tokens for Task 4.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~MappingTokenizerTests"
+```
+
+Expected: PASS, 0 failures.
+
+- [ ] **Step 7: Run the whole FML suite for regressions**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0
+```
+
+Expected: PASS, 0 failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
+git commit -m "Add arithmetic and comparison operator tokens to FML lexer"
+```
+
+---
+
+## Task 2: Reconstruct embedded FHIRPath from source text
+
+`MappingGrammar.cs:139` and `:224` both rebuild the collected FHIRPath sub-expression with `string.Join("", ...)` — **no separator**. Consequences:
+
+| Source | Currently produced | Correct |
+|---|---|---|
+| `linkId.value in ('patient.sex')` | `linkId.valuein('patient.sex')` | `linkId.value in ('patient.sex')` |
+| `%value + 5 days` | `%value+5days` | `%value + 5 days` |
+
+This silently corrupts the FHIRPath handed to the evaluator. `qr2pat-gender.map` — an in-scope oracle case — hits it directly.
+
+The fix reconstructs the original substring from Superpower's span positions rather than re-serialising tokens.
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs:139` and `:224`, plus a new private helper near `CreatePosition`
+- Test: `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.Linq;
+using Ignixa.FhirMappingLanguage.Expressions;
+using Ignixa.FhirMappingLanguage.Parser;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Parser;
+
+/// <summary>
+/// Regression coverage for FML syntax found in the official HL7 structure-mapping corpus.
+/// Each test targets one previously unsupported construct.
+/// </summary>
+public class FmlSyntaxCoverageTests
+{
+    [Fact]
+    public void GivenAWhereClauseWithSpacedOperators_WhenParsing_ThenTheOriginalSpacingIsPreserved()
+    {
+        const string Fml = """
+            map 'http://example.org/Test' = 'Test'
+
+            group Main(source src, target tgt) {
+              src.item as item where linkId.value in ('patient.sex') -> tgt.gender = 'x';
+            }
+            """;
+
+        var map = MappingParser.Parse(Fml);
+
+        var rule = map.Groups[0].Rules[0];
+        var condition = rule.Sources[0].Condition;
+        condition.ShouldNotBeNull();
+        condition!.Expression.ShouldBe("linkId.value in ('patient.sex')");
+    }
+}
+```
+
+> If `RuleSourceExpression`'s condition property is not named `Condition`/`Expression`, open `src/Core/Ignixa.FhirMappingLanguage/Expressions/RuleSourceExpression.cs` and use the actual names. Do not guess.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlSyntaxCoverageTests"
+```
+
+Expected: FAIL — actual `linkId.valuein('patient.sex')`.
+
+- [ ] **Step 3: Add the source-text helper**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs`, insert immediately after the `UnescapeIdentifier` method (which ends at line 62):
+
+```csharp
+    // Helper: reconstruct the original source text spanned by a token run.
+    // Re-serializing tokens loses whitespace, which corrupts embedded FHIRPath
+    // (e.g. "linkId.value in (...)" would collapse to "linkId.valuein(...)").
+    private static string SourceTextOf(IReadOnlyList<Token<MappingTokenKind>> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var source = tokens[0].Span.Source;
+        if (source is null)
+        {
+            return string.Join(" ", tokens.Select(t => t.ToStringValue()));
+        }
+
+        var start = (int)tokens[0].Position.Absolute;
+        var last = tokens[^1];
+        var end = (int)last.Position.Absolute + last.Span.Length;
+        return source.Substring(start, end - start);
+    }
+```
+
+Ensure the file has `using System.Collections.Generic;` and `using System.Linq;` (it already uses `List<>` and `.Select`, so both are present or covered by implicit usings — verify before adding duplicates).
+
+- [ ] **Step 4: Use it at the parenthesized site**
+
+Replace `MappingGrammar.cs:138-140`:
+
+```csharp
+                            var expr = new FhirPathExpression(
+                                string.Join("", tokens.Select(t => t.ToStringValue())),
+                                CreatePosition(lparen.Value, lastToken));
+```
+
+with:
+
+```csharp
+                            var expr = new FhirPathExpression(
+                                SourceTextOf(tokens),
+                                CreatePosition(lparen.Value, lastToken));
+```
+
+**Important:** `tokens` here deliberately excludes both outer parens, while `lastToken` has been reassigned to the closing `)`. Pass `tokens` to `SourceTextOf` (so the parens are not included in the expression text) but keep `lastToken` in `CreatePosition` (so the reported span covers the full `( ... )`). The `tokens.Count == 0` guard in the helper covers the empty `()` case.
+
+- [ ] **Step 5: Use it at the non-parenthesized site**
+
+Replace `MappingGrammar.cs:223-225`:
+
+```csharp
+                var expr = new FhirPathExpression(
+                    string.Join("", tokens.Select(t => t.ToStringValue())),
+                    CreatePosition(tokens[0], lastToken!.Value));
+```
+
+with:
+
+```csharp
+                var expr = new FhirPathExpression(
+                    SourceTextOf(tokens),
+                    CreatePosition(tokens[0], lastToken!.Value));
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlSyntaxCoverageTests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the whole FML suite**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0
+```
+
+Expected: PASS. Some existing tests may have asserted the *glued* form — if any fail, they encoded the bug; update them to the spaced form and note it in the commit message.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+git commit -m "Preserve original source text when capturing embedded FHIRPath expressions"
+```
+
+---
+
+## Task 3: Double-quoted string literals
+
+FML permits both `'...'` and `"..."` for string literals. The tokenizer currently maps `"..."` to `DelimitedIdentifier`, and `MappingGrammar.Map` (line 512) demands a `StringLiteral`, so every official case that opens with `map "http://..." = "cast"` dies at line 1 column 5. This accounts for 21 of the 27 official-case failures.
+
+The fix introduces a distinct `DoubleQuotedString` kind rather than reusing `StringLiteral`, so the parser can keep accepting `"..."` in identifier positions (where the old behaviour allowed it) without losing the ability to treat it as a string in literal positions.
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs:73` and `:163`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs:43-51`, `:65-67`, `:91-97`, `:476`
+- Modify: `test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs:241-255`
+- Test: `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `FmlSyntaxCoverageTests`:
+
+```csharp
+    [Fact]
+    public void GivenADoubleQuotedMapHeader_WhenParsing_ThenTheUrlAndNameAreRead()
+    {
+        const string Fml = """
+            map "http://hl7.org/fhir/StructureMap/tutorial" = "tutorial"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        var map = MappingParser.Parse(Fml);
+
+        map.Url.ShouldBe("http://hl7.org/fhir/StructureMap/tutorial");
+        map.Identifier.ShouldBe("tutorial");
+    }
+
+    [Fact]
+    public void GivenADoubleQuotedStringWithAnEscapedQuote_WhenParsing_ThenTheEscapeIsResolved()
+    {
+        const string Fml = """
+            map "http://example.org/T" = "a \" b"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        var map = MappingParser.Parse(Fml);
+
+        map.Identifier.ShouldBe("a \" b");
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlSyntaxCoverageTests"
+```
+
+Expected: FAIL with a parse exception at line 1, column 5.
+
+- [ ] **Step 3: Add the token kind**
+
+In `MappingTokenKind.cs`, replace:
+
+```csharp
+    Identifier,
+    DelimitedIdentifier,
+    StringLiteral,
+```
+
+with:
+
+```csharp
+    Identifier,
+    DelimitedIdentifier,
+    StringLiteral,
+    DoubleQuotedString,
+```
+
+- [ ] **Step 4: Retarget the double-quote rule in both tokenizer builders**
+
+There are two occurrences of the following two-line block (line 72-73 and line 162-163). **Both** must change, and they are byte-identical — replace them one at a time, verifying the file after each with `grep -n "DoubleQuotedString" src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs` (expect 2 hits at the end).
+
+Old:
+
+```csharp
+            .Match(Span.Regex("`[^`]*`"), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
+            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
+```
+
+New:
+
+```csharp
+            .Match(Span.Regex("`[^`]*`"), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
+            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DoubleQuotedString, requireDelimiters: false)
+```
+
+Also update the surrounding comment on the preceding line from `// Delimited identifiers (backtick or double-quote style)` to `// Delimited identifiers (backtick) and double-quoted strings`.
+
+- [ ] **Step 5: Extend `UnescapeString`**
+
+In `MappingGrammar.cs`, replace lines 42-51:
+
+```csharp
+    // Helper: Unescape string
+    private static string UnescapeString(string str)
+    {
+        if (str.StartsWith('\'') && str.EndsWith('\''))
+        {
+            str = str.Substring(1, str.Length - 2);
+            str = str.Replace("''", "'", StringComparison.Ordinal);
+        }
+        return str;
+    }
+```
+
+with:
+
+```csharp
+    // Helper: Unescape string
+    private static string UnescapeString(string str)
+    {
+        if (str.StartsWith('\'') && str.EndsWith('\'') && str.Length >= 2)
+        {
+            str = str.Substring(1, str.Length - 2);
+            str = str.Replace("''", "'", StringComparison.Ordinal);
+            return str;
+        }
+
+        if (str.StartsWith('"') && str.EndsWith('"') && str.Length >= 2)
+        {
+            str = str.Substring(1, str.Length - 2);
+            str = str.Replace("\\\"", "\"", StringComparison.Ordinal)
+                     .Replace("\\\\", "\\", StringComparison.Ordinal);
+            return str;
+        }
+
+        return str;
+    }
+```
+
+- [ ] **Step 6: Widen the `StringLiteral` grammar rule**
+
+Replace `MappingGrammar.cs:65-67`:
+
+```csharp
+    private static readonly TokenListParser<MappingTokenKind, LiteralExpression> StringLiteral =
+        Token.EqualTo(MappingTokenKind.StringLiteral)
+            .Select(t => new LiteralExpression(UnescapeString(t.ToStringValue()), CreatePosition(t)));
+```
+
+with:
+
+```csharp
+    private static readonly TokenListParser<MappingTokenKind, LiteralExpression> StringLiteral =
+        Token.EqualTo(MappingTokenKind.StringLiteral)
+            .Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))
+            .Select(t => new LiteralExpression(UnescapeString(t.ToStringValue()), CreatePosition(t)));
+```
+
+- [ ] **Step 7: Keep `"..."` usable in identifier positions**
+
+Replace `MappingGrammar.cs:91-97`:
+
+```csharp
+    private static readonly TokenListParser<MappingTokenKind, IdentifierExpression> Identifier =
+        Token.EqualTo(MappingTokenKind.Identifier)
+            .Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier))
+            .Or(Token.EqualTo(MappingTokenKind.Type))  // 'type' can be used as property name
+            .Or(Token.EqualTo(MappingTokenKind.Default))  // 'default' can be used as property name
+            .Or(Token.EqualTo(MappingTokenKind.Prefix))  // 'prefix' can be used as property name
+            .Select(t => new IdentifierExpression(UnescapeIdentifier(t.ToStringValue()), CreatePosition(t)));
+```
+
+with:
+
+```csharp
+    private static readonly TokenListParser<MappingTokenKind, IdentifierExpression> Identifier =
+        Token.EqualTo(MappingTokenKind.Identifier)
+            .Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier))
+            .Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))  // "..." is legal where an identifier is expected
+            .Or(Token.EqualTo(MappingTokenKind.Type))  // 'type' can be used as property name
+            .Or(Token.EqualTo(MappingTokenKind.Default))  // 'default' can be used as property name
+            .Or(Token.EqualTo(MappingTokenKind.Prefix))  // 'prefix' can be used as property name
+            .Select(t => new IdentifierExpression(UnescapeIdentifier(t.ToStringValue()), CreatePosition(t)));
+```
+
+`UnescapeIdentifier` (lines 54-62) already strips both backticks and double quotes, so it needs no change.
+
+- [ ] **Step 8: Fix the ConceptMap declaration id**
+
+Open `MappingGrammar.cs` around line 476 (`ConceptMapDeclaration`). If it references `Token.EqualTo(MappingTokenKind.DelimitedIdentifier)` directly rather than going through the `Identifier` parser, add `.Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))` alongside it. If it already uses `Identifier`, no change is needed — record which case applied.
+
+- [ ] **Step 9: Update the tokenizer test that encoded the old behaviour**
+
+`test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs:241-255` asserts that `"quoted identifier"` produces `DelimitedIdentifier`. That assertion encodes the defect — in FML, delimited identifiers are backtick-delimited. Change the expected kind to `MappingTokenKind.DoubleQuotedString`, and add a sibling test proving backticks still work:
+
+```csharp
+    [Fact]
+    public void GivenABacktickDelimitedIdentifier_WhenTokenizing_ThenItIsADelimitedIdentifier()
+    {
+        var tokenizer = MappingTokenizer.Create();
+
+        var tokens = tokenizer.Tokenize("`quoted identifier`").ToList();
+
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(MappingTokenKind.DelimitedIdentifier);
+    }
+```
+
+- [ ] **Step 10: Run the whole FML suite**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0
+```
+
+Expected: PASS. Because `StringLiteral` is tried first inside the `Literal` parser (line 84-88), widening `Identifier` cannot shadow literal parsing.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirMappingLanguage/Lexer src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs test/Ignixa.FhirMappingLanguage.Tests
+git commit -m "Treat double-quoted text as a string literal in FML"
+```
+
+---
+
+## Task 4: Group type-mode annotation `<<types>>` / `<<type+>>`
+
+`MappingGrammar.Group` (lines 488-507) goes straight from the optional `extends` clause to `{`. The `LeftAngle`/`RightAngle` token kinds exist but no rule consumes them, so `group X(...) <<type+>> { ... }` fails.
+
+Occurrences: `ActivityDefinition.map:8`, `syntaxshort.map:10`, `Patient_4to6.fml:12`, and effectively every cross-version map.
+
+**Files:**
+- Create: `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs:488-507`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs:191-213`
+- Test: `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `FmlSyntaxCoverageTests`:
+
+```csharp
+    [Theory]
+    [InlineData("<<types>>", GroupTypeMode.Types)]
+    [InlineData("<<type+>>", GroupTypeMode.TypeAndTypes)]
+    public void GivenAGroupTypeModeAnnotation_WhenParsing_ThenTheModeIsCaptured(string annotation, GroupTypeMode expected)
+    {
+        var fml = $$"""
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {{annotation}} {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        var map = MappingParser.Parse(fml);
+
+        map.Groups[0].TypeMode.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenNoTypeModeAnnotation_WhenParsing_ThenTheModeIsNone()
+    {
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        var map = MappingParser.Parse(Fml);
+
+        map.Groups[0].TypeMode.ShouldBe(GroupTypeMode.None);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlSyntaxCoverageTests"
+```
+
+Expected: build error `CS0246: The type or namespace name 'GroupTypeMode' could not be found`.
+
+- [ ] **Step 3: Create the enum**
+
+Create `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Group type mode annotation for FHIR Mapping Language groups.
+ */
+
+namespace Ignixa.FhirMappingLanguage.Expressions;
+
+/// <summary>
+/// Indicates how a group participates in type-directed rule selection,
+/// declared in FML as a &lt;&lt;types&gt;&gt; or &lt;&lt;type+&gt;&gt; annotation.
+/// </summary>
+public enum GroupTypeMode
+{
+    /// <summary>No annotation present. The group is only invoked by explicit reference.</summary>
+    None = 0,
+
+    /// <summary>Declared &lt;&lt;types&gt;&gt;: the group is a candidate for type-based dispatch.</summary>
+    Types,
+
+    /// <summary>Declared &lt;&lt;type+&gt;&gt;: the group is the default for type-based dispatch.</summary>
+    TypeAndTypes
+}
+```
+
+`None = 0` is deliberate — it makes `.OptionalOrDefault()` yield the right value for groups with no annotation.
+
+- [ ] **Step 4: Add the property to `GroupExpression`**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs`, add a **trailing optional** constructor parameter (trailing so every existing positional call site keeps compiling) and the matching property:
+
+- Append `, GroupTypeMode typeMode = GroupTypeMode.None` to the constructor signature, after the current last parameter.
+- Assign `TypeMode = typeMode;` in the constructor body.
+- Add the property alongside the existing ones:
+
+```csharp
+    /// <summary>
+    /// Gets the type-mode annotation declared for this group.
+    /// </summary>
+    public GroupTypeMode TypeMode { get; }
+```
+
+Leave `ToString()` (lines 33-49) alone — round-tripping is `FmlSerializer`'s job.
+
+- [ ] **Step 5: Add the grammar rule**
+
+In `MappingGrammar.cs`, define this parser immediately **above** the `Group` parser:
+
+```csharp
+    // Group type mode annotation: <<types>> or <<type+>>
+    // Note: '<<' is two LeftAngle tokens - the lexer deliberately has no '<<' token.
+    private static readonly TokenListParser<MappingTokenKind, GroupTypeMode> GroupTypeModeAnnotation =
+        from open1 in Token.EqualTo(MappingTokenKind.LeftAngle)
+        from open2 in Token.EqualTo(MappingTokenKind.LeftAngle)
+        from mode in Token.EqualTo(MappingTokenKind.Types).Value(GroupTypeMode.Types)
+            .Or(from typeToken in Token.EqualTo(MappingTokenKind.Type)
+                from plus in Token.EqualTo(MappingTokenKind.Plus).Optional()
+                select plus.HasValue ? GroupTypeMode.TypeAndTypes : GroupTypeMode.Types)
+        from close1 in Token.EqualTo(MappingTokenKind.RightAngle)
+        from close2 in Token.EqualTo(MappingTokenKind.RightAngle)
+        select mode;
+```
+
+Then, in the `Group` parser (lines 488-507), insert between the optional `extends` clause and the opening `{`:
+
+```csharp
+        from typeMode in GroupTypeModeAnnotation.OptionalOrDefault(GroupTypeMode.None)
+```
+
+and pass `typeMode` as the new trailing argument to the `GroupExpression` constructor in that parser's `select`.
+
+**Lexer note:** `Span.Regex(@"\btype\b")` still matches inside `type+` because `+` is a non-word character, and `\btypes\b` is registered before `\btype\b`, so `types` is never split. Task 1 supplied the `Plus` token this rule needs.
+
+- [ ] **Step 6: Round-trip in `FmlSerializer`**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs`, in `SerializeGroup` (starting line 191), emit the annotation **after** the `extends` clause (lines 208-212) and before the opening brace:
+
+```csharp
+        if (group.TypeMode != GroupTypeMode.None)
+        {
+            builder.Append(group.TypeMode == GroupTypeMode.TypeAndTypes ? " <<type+>>" : " <<types>>");
+        }
+```
+
+Match the surrounding code's `StringBuilder` variable name and spacing conventions rather than copying `builder` verbatim.
+
+- [ ] **Step 7: Add a round-trip test**
+
+Append to `FmlSyntaxCoverageTests`:
+
+```csharp
+    [Theory]
+    [InlineData("<<types>>")]
+    [InlineData("<<type+>>")]
+    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(string annotation)
+    {
+        var fml = $$"""
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {{annotation}} {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        var reparsed = MappingParser.Parse(new FmlSerializer().Serialize(MappingParser.Parse(fml)));
+
+        reparsed.Groups[0].TypeMode.ShouldBe(MappingParser.Parse(fml).Groups[0].TypeMode);
+    }
+```
+
+Add `using Ignixa.FhirMappingLanguage.Serialization;` to the file. If `FmlSerializer` exposes a static `Serialize` rather than an instance method, adjust the call — check the file before writing.
+
+- [ ] **Step 8: Run the whole FML suite**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirMappingLanguage test/Ignixa.FhirMappingLanguage.Tests
+git commit -m "Support group type mode annotations in FML"
+```
+
+---
+
+## Task 5: `///` metadata declarations and optional `map` header
+
+R6-era FML replaces the `map "url" = "name"` header with a run of metadata lines:
+
+```
+/// url = 'http://hl7.org/fhir/uv/xver/StructureMap/Element4to6'
+/// name = 'Element4to6'
+/// title = 'Element Transforms: R4 to R6'
+```
+
+The tokenizer currently swallows these as `LineComment` (because `Comment.CPlusPlusStyle` matches `//`), and `MappingGrammar.Map` (line 511) requires a leading `Map` token, so parsing fails with `unexpected uses 'uses', expected map`. This blocks every `brianpos/fhir-r6-maps` file and `syntax.map:1`.
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs` (before the comment rules in **both** builders)
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs:509-528`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Expressions/MapExpression.cs`
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs` (empty-map guard)
+- Test: `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `FmlSyntaxCoverageTests`:
+
+```csharp
+    [Fact]
+    public void GivenMetadataDeclarationsInsteadOfAMapHeader_WhenParsing_ThenUrlAndNameAreDerivedFromMetadata()
+    {
+        const string Fml = """
+            /// url = 'http://hl7.org/fhir/uv/xver/StructureMap/Element4to6'
+            /// name = 'Element4to6'
+            /// title = 'Element Transforms: R4 to R6'
+
+            group Element(source src, target tgt) {
+              src.id as v -> tgt.id = v;
+            }
+            """;
+
+        var map = MappingParser.Parse(Fml);
+
+        map.Url.ShouldBe("http://hl7.org/fhir/uv/xver/StructureMap/Element4to6");
+        map.Identifier.ShouldBe("Element4to6");
+        map.Metadata["title"].ShouldBe("Element Transforms: R4 to R6");
+    }
+
+    [Fact]
+    public void GivenOnlyCommentsAndWhitespace_WhenParsing_ThenAParseExceptionIsThrown()
+    {
+        const string Fml = """
+            // nothing to see here
+            """;
+
+        Should.Throw<ParseException>(() => MappingParser.Parse(Fml));
+    }
+```
+
+Add `using Ignixa.FhirMappingLanguage.Parser;` if not already present, and reference `ParseException` by its real namespace — confirm it in `MappingParser.cs` before writing.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlSyntaxCoverageTests"
+```
+
+Expected: FAIL — `unexpected group 'group', expected map` (or a `CS1061` on `Metadata`).
+
+- [ ] **Step 3: Add the token kind**
+
+In `MappingTokenKind.cs`, replace:
+
+```csharp
+    // Comments (for trivia mode)
+    LineComment,         // //
+    BlockComment,        // /* */
+```
+
+with:
+
+```csharp
+    // Metadata declarations (R6 FML header form)
+    MetadataLine,        // /// key = 'value'
+
+    // Comments (for trivia mode)
+    LineComment,         // //
+    BlockComment,        // /* */
+```
+
+- [ ] **Step 4: Match `///` before the comment rules in `CreateWithTrivia()`**
+
+Replace:
+
+```csharp
+        return new TokenizerBuilder<MappingTokenKind>()
+            // Comments (must come before other operators to avoid capturing // as division)
+            .Match(Comment.CStyle, MappingTokenKind.BlockComment, requireDelimiters: true)
+            .Match(Comment.CPlusPlusStyle, MappingTokenKind.LineComment)
+
+            // Whitespace
+            .Match(Span.WhiteSpace, MappingTokenKind.Whitespace)
+```
+
+with:
+
+```csharp
+        return new TokenizerBuilder<MappingTokenKind>()
+            // Metadata declarations (must precede the comment rules - '///' is a prefix of '//')
+            .Match(Span.Regex(@"///[^\r\n]*"), MappingTokenKind.MetadataLine, requireDelimiters: false)
+
+            // Comments (must come before other operators to avoid capturing // as division)
+            .Match(Comment.CStyle, MappingTokenKind.BlockComment, requireDelimiters: true)
+            .Match(Comment.CPlusPlusStyle, MappingTokenKind.LineComment)
+
+            // Whitespace
+            .Match(Span.WhiteSpace, MappingTokenKind.Whitespace)
+```
+
+- [ ] **Step 5: Match `///` before the comment rules in `Create()`**
+
+Replace:
+
+```csharp
+        return new TokenizerBuilder<MappingTokenKind>()
+            // Comments (ignore for standard parsing)
+            .Ignore(Comment.CStyle)
+            .Ignore(Comment.CPlusPlusStyle)
+```
+
+with:
+
+```csharp
+        return new TokenizerBuilder<MappingTokenKind>()
+            // Metadata declarations (must precede the comment rules - '///' is a prefix of '//')
+            .Match(Span.Regex(@"///[^\r\n]*"), MappingTokenKind.MetadataLine, requireDelimiters: false)
+
+            // Comments (ignore for standard parsing)
+            .Ignore(Comment.CStyle)
+            .Ignore(Comment.CPlusPlusStyle)
+```
+
+`///` does not collide with `/* */`, and it must win over `//`.
+
+- [ ] **Step 6: Add the `Metadata` property to `MapExpression`**
+
+In `src/Core/Ignixa.FhirMappingLanguage/Expressions/MapExpression.cs`:
+
+- Append a trailing optional constructor parameter `, IReadOnlyDictionary<string, string>? metadata = null`.
+- Assign `Metadata = metadata ?? new Dictionary<string, string>(StringComparer.Ordinal);` in the body.
+- Add:
+
+```csharp
+    /// <summary>
+    /// Gets the metadata declarations (<c>/// key = 'value'</c>) that preceded the map body.
+    /// Empty when the map used the classic <c>map "url" = "name"</c> header form.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+```
+
+The constructor currently throws `ArgumentNullException` on null `url`/`identifier` (lines 25-26) — pass `string.Empty`, never null, from the grammar.
+
+- [ ] **Step 7: Parse metadata lines and make the header optional**
+
+In `MappingGrammar.cs`, add above the `Map` parser:
+
+```csharp
+    private static readonly Regex MetadataLinePattern = new(
+        @"^///\s*(?<key>[A-Za-z_][A-Za-z0-9_.\-]*)\s*=\s*(?<value>.*?)\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly TokenListParser<MappingTokenKind, KeyValuePair<string, string>?> MetadataDeclaration =
+        Token.EqualTo(MappingTokenKind.MetadataLine)
+            .Select(t =>
+            {
+                var match = MetadataLinePattern.Match(t.ToStringValue());
+                if (!match.Success)
+                {
+                    return (KeyValuePair<string, string>?)null;
+                }
+
+                return new KeyValuePair<string, string>(
+                    match.Groups["key"].Value,
+                    UnescapeString(match.Groups["value"].Value));
+            });
+
+    private sealed record MapHeaderInfo(string Url, string Identifier, SourcePosition Position);
+```
+
+Use the repo's actual position type in `MapHeaderInfo` — `CreatePosition` (lines 30-40) shows what it returns; copy that type name exactly rather than assuming `SourcePosition`.
+
+Then restructure the `Map` parser (lines 509-528) so that:
+
+1. It starts with `from metadataLines in MetadataDeclaration.Many()`.
+2. The existing `map "url" = "name"` header becomes a `MapHeaderInfo`-producing parser applied with `.OptionalOrDefault()` (it is a reference type, so the default is `null`).
+3. `url` resolves as `header?.Url ?? metadata.GetValueOrDefault("url", string.Empty)`, and `identifier` as `header?.Identifier ?? metadata.GetValueOrDefault("name", string.Empty)` — the explicit header wins for backwards compatibility. The two forms are mutually exclusive across every corpus file, so this branch is never contentious.
+4. The metadata dictionary is built from the non-null `metadataLines` entries with `StringComparer.Ordinal` and passed as the new trailing `MapExpression` argument.
+
+Add `using System.Text.RegularExpressions;` to the file.
+
+- [ ] **Step 8: Guard against a map that parsed to nothing**
+
+Making both the header and the metadata optional means a comments-only file would now "successfully" parse into an empty map. In `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs`, immediately after the successful-parse result is unwrapped (after line 69), add:
+
+```csharp
+        if (result.Value.Groups.Count == 0 &&
+            string.IsNullOrEmpty(result.Value.Url) &&
+            string.IsNullOrEmpty(result.Value.Identifier))
+        {
+            throw new ParseException("The input contains no map header, metadata declarations, or groups.");
+        }
+```
+
+Use the exact local variable name that exists at that point in `Parse`, and the exception type/constructor the file already throws elsewhere. `Parse` already rejects null/whitespace input at line 45 and enforces `.AtEnd()` at line 60, so this is the only remaining hole.
+
+- [ ] **Step 9: Run the whole FML suite**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Core/Ignixa.FhirMappingLanguage test/Ignixa.FhirMappingLanguage.Tests
+git commit -m "Support R6 metadata declarations and make the FML map header optional"
+```
+
+---
+
+# Part B — Oracle harness
+
+## Task 6: Vendor the official `fhir-test-cases` corpus
+
+`test/Ignixa.FhirPath.Tests/Ignixa.FhirPath.Tests.csproj:29-60` already contains a proven, race-safe MSBuild target that downloads and unpacks the HL7 `fhir-test-cases` release zip. Copy it verbatim into the FML test project — same pinned version, so both projects agree on corpus contents.
+
+**Files:**
+- Modify: `test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj`
+- Modify: `.gitignore` (if `TestData/` is not already ignored)
+
+- [ ] **Step 1: Add the download target**
+
+In `test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj`, replace:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\Ignixa.FhirMappingLanguage\Ignixa.FhirMappingLanguage.csproj" />
+    <ProjectReference Include="..\..\src\Core\Ignixa.Specification\Ignixa.Specification.csproj" />
+    <ProjectReference Include="..\Ignixa.Serialization.TestSupport\Ignixa.Serialization.TestSupport.csproj" />
+  </ItemGroup>
+
+</Project>
+```
+
+with:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\Ignixa.FhirMappingLanguage\Ignixa.FhirMappingLanguage.csproj" />
+    <ProjectReference Include="..\..\src\Core\Ignixa.Specification\Ignixa.Specification.csproj" />
+    <ProjectReference Include="..\Ignixa.Serialization.TestSupport\Ignixa.Serialization.TestSupport.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <FhirTestCasesVersion>1.7.46</FhirTestCasesVersion>
+    <FhirTestCasesUrl>https://github.com/FHIR/fhir-test-cases/releases/download/$(FhirTestCasesVersion)/testcases.zip</FhirTestCasesUrl>
+    <FhirTestCasesZip>$(MSBuildProjectDirectory)\TestData\testcases.zip</FhirTestCasesZip>
+    <FhirTestCasesDir>$(MSBuildProjectDirectory)\TestData\fhir-test-cases</FhirTestCasesDir>
+    <FhirTestCasesTempDir>$(MSBuildProjectDirectory)\TestData\temp-extract</FhirTestCasesTempDir>
+    <FhirTestCasesMarker>$(FhirTestCasesDir)\.downloaded</FhirTestCasesMarker>
+  </PropertyGroup>
+
+  <!-- Runs once in the outer (multi-targeting) build via DispatchToInnerBuilds so the parallel
+       per-TFM inner builds don't race on the shared testcases.zip; BeforeBuild covers single-TFM builds. -->
+  <Target Name="DownloadFhirTestCases" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="!Exists('$(FhirTestCasesMarker)')">
+    <Message Text="Downloading FHIR test cases from $(FhirTestCasesUrl)..." Importance="high" />
+    <MakeDir Directories="$(MSBuildProjectDirectory)\TestData" />
+    <DownloadFile SourceUrl="$(FhirTestCasesUrl)" DestinationFolder="$(MSBuildProjectDirectory)\TestData" DestinationFileName="testcases.zip" SkipUnchangedFiles="true" />
+
+    <Message Text="Extracting FHIR test cases to temporary location..." Importance="high" />
+    <RemoveDir Directories="$(FhirTestCasesTempDir)" Condition="Exists('$(FhirTestCasesTempDir)')" />
+    <Unzip SourceFiles="$(FhirTestCasesZip)" DestinationFolder="$(FhirTestCasesTempDir)" OverwriteReadOnlyFiles="true" />
+
+    <ItemGroup>
+      <ExtractedFiles Include="$(FhirTestCasesTempDir)\fhir-test-cases\**\*.*" />
+    </ItemGroup>
+
+    <Message Text="Moving extracted files from nested directory to $(FhirTestCasesDir)..." Importance="high" />
+    <RemoveDir Directories="$(FhirTestCasesDir)" Condition="Exists('$(FhirTestCasesDir)')" />
+    <Move SourceFiles="@(ExtractedFiles)" DestinationFolder="$(FhirTestCasesDir)\%(RecursiveDir)" />
+
+    <RemoveDir Directories="$(FhirTestCasesTempDir)" />
+    <Touch Files="$(FhirTestCasesMarker)" AlwaysCreate="true" />
+    <Message Text="FHIR test cases downloaded and extracted successfully." Importance="high" />
+  </Target>
+
+</Project>
+```
+
+- [ ] **Step 2: Build to trigger the download**
+
+```bash
+dotnet build test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj
+```
+
+Expected: `Downloading FHIR test cases from https://github.com/FHIR/fhir-test-cases/releases/download/1.7.46/testcases.zip...` then a successful build. This is a ~100 MB download on first run.
+
+- [ ] **Step 3: Verify the corpus landed**
+
+```bash
+Get-ChildItem test/Ignixa.FhirMappingLanguage.Tests/TestData/fhir-test-cases/r5/structure-mapping -Filter *.map | Measure-Object
+Get-ChildItem test/Ignixa.FhirMappingLanguage.Tests/TestData/fhir-test-cases/r4b/structure-mapping -Filter *.map | Measure-Object
+```
+
+Expected: 16 and 12 respectively. If the counts differ, the pinned version changed upstream — record the actual counts and use them in Task 8.
+
+- [ ] **Step 4: Confirm `TestData/` is not committed**
+
+```bash
+git status --short test/Ignixa.FhirMappingLanguage.Tests/TestData
+```
+
+Expected: no output. If the directory shows as untracked, add `test/Ignixa.FhirMappingLanguage.Tests/TestData/` to `.gitignore` (check how `Ignixa.FhirPath.Tests/TestData` is ignored and mirror it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj .gitignore
+git commit -m "Vendor the HL7 fhir-test-cases corpus into the FML test project"
+```
+
+---
+
+## Task 7: Corpus locator
+
+One place that knows where the vendored corpus lives, so no test hard-codes relative paths.
+
+**Files:**
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class FmlTestCasesLocatorTests
+{
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenAVendoredCorpus_WhenLocatingStructureMappingDirectory_ThenTheDirectoryExists(string version)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+
+        Directory.Exists(directory).ShouldBeTrue($"Expected the vendored corpus at {directory}. Run 'dotnet build' to download it.");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlTestCasesLocatorTests"
+```
+
+Expected: `CS0103: The name 'FmlTestCasesLocator' does not exist`.
+
+- [ ] **Step 3: Implement the locator**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Resolves paths into the vendored HL7 fhir-test-cases corpus.
+ */
+
+using System;
+using System.IO;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Resolves paths into the vendored HL7 <c>fhir-test-cases</c> corpus.
+/// The corpus is downloaded by the <c>DownloadFhirTestCases</c> MSBuild target
+/// into <c>TestData/fhir-test-cases</c> beside the project file.
+/// </summary>
+public static class FmlTestCasesLocator
+{
+    private static readonly Lazy<string> RootDirectory = new(FindRoot);
+
+    /// <summary>
+    /// Gets the root of the vendored corpus.
+    /// </summary>
+    public static string Root => RootDirectory.Value;
+
+    /// <summary>
+    /// Gets the <c>structure-mapping</c> directory for a FHIR version folder such as
+    /// <c>r5</c> or <c>r4b</c>.
+    /// </summary>
+    public static string StructureMappingDirectory(string version) =>
+        Path.Combine(Root, version, "structure-mapping");
+
+    private static string FindRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "TestData", "fhir-test-cases");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the vendored fhir-test-cases corpus. Run 'dotnet build' on " +
+            "test/Ignixa.FhirMappingLanguage.Tests to download it.");
+    }
+}
+```
+
+Walking up from `AppContext.BaseDirectory` (which is `bin/Debug/net9.0/`) reaches the project directory in four hops and works identically for both target frameworks.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlTestCasesLocatorTests"
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Conformance
+git commit -m "Add a locator for the vendored FML conformance corpus"
+```
+
+---
+
+## Task 8: Corpus parse-rate gate
+
+This is the regression net for Part A. It parses every `.map` in the official corpus and asserts an exact pass count — so a future grammar change that silently drops support for a construct fails the build rather than quietly regressing.
+
+**Files:**
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs`
+
+- [ ] **Step 1: Write the test with a deliberately impossible expectation**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ignixa.FhirMappingLanguage.Parser;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Parses every map in the official HL7 structure-mapping corpus and asserts an exact
+/// pass count. The count is a ratchet: raising it is a feature, lowering it is a regression.
+/// </summary>
+public class FmlCorpusParseTests(ITestOutputHelper output)
+{
+    [Theory]
+    [InlineData("r5", 16)]
+    [InlineData("r4b", 12)]
+    public void GivenTheOfficialCorpus_WhenParsingEveryMap_ThenTheExpectedNumberParse(string version, int expectedParsed)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+        var files = Directory.GetFiles(directory, "*.map").OrderBy(f => f, StringComparer.Ordinal).ToList();
+
+        var failures = new List<string>();
+        var parsed = 0;
+
+        foreach (var file in files)
+        {
+            try
+            {
+                MappingParser.Parse(File.ReadAllText(file, Encoding.UTF8));
+                parsed++;
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{Path.GetFileName(file)}: {ex.Message}");
+            }
+        }
+
+        var report = new StringBuilder();
+        report.AppendLine($"{version}: parsed {parsed}/{files.Count}");
+        foreach (var failure in failures)
+        {
+            report.AppendLine("  FAIL " + failure);
+        }
+
+        output.WriteLine(report.ToString());
+
+        parsed.ShouldBe(expectedParsed, report.ToString());
+    }
+}
+```
+
+- [ ] **Step 2: Run it and read the report**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlCorpusParseTests" --logger "console;verbosity=detailed"
+```
+
+The failure message lists every file that still fails and why. Two outcomes:
+
+- **All parse** → the test passes as written. Move on.
+- **Some fail** → read each message. If the cause is a construct in scope for Tasks 1-5, fix it there. If it is `imports "…/*4to6"` wildcard resolution or another deferred item, lower the `expectedParsed` numbers to the actual counts and add a comment above the `[InlineData]` attributes naming the excluded files and the reason.
+
+Do **not** silently lower the number without recording why.
+
+- [ ] **Step 3: Record the measured numbers**
+
+Update the `[InlineData]` values to the counts you actually achieved and re-run to confirm green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
+git commit -m "Gate FML parser on the official structure-mapping corpus parse rate"
+```
+
+---
+
+## Task 9: Manifest model, loader, and exclusions
+
+The corpus declares its transform oracle cases in `manifest.xml`:
+
+```xml
+<fml-tests>
+  <test name="…/qr2patgender" source="qr.json" map="qr2pat-gender.map" output="qr2pat-gender-res.json" />
+</fml-tests>
+```
+
+`r5/manifest.xml` holds 10 cases; `r4b/manifest.xml` holds a copy of the same 10. Four of them produce CDA logical-model XML, which Ignixa's transform pipeline does not target — those go on a frozen exclusion list with written rationale, per `docs/adr/adr-2607-validation-oracle-conformance.md`.
+
+**Files:**
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleCase.cs`
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleExclusions.cs`
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoader.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoaderTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class FmlManifestLoaderTests
+{
+    [Fact]
+    public void GivenTheR5Manifest_WhenLoadingFmlTests_ThenTheDeclaredCasesAreReturned()
+    {
+        var cases = FmlManifestLoader.Load("r5").ToList();
+
+        cases.ShouldNotBeEmpty();
+        cases.ShouldContain(c => c.MapFile == "qr2pat-gender.map"
+                                 && c.SourceFile == "qr.json"
+                                 && c.OutputFile == "qr2pat-gender-res.json");
+    }
+
+    [Fact]
+    public void GivenTheR5Manifest_WhenFilteringToSupportedCases_ThenCdaCasesAreExcluded()
+    {
+        var supported = FmlManifestLoader.Load("r5")
+            .Where(c => !FmlOracleExclusions.IsExcluded(c.Name))
+            .ToList();
+
+        supported.ShouldNotBeEmpty();
+        supported.ShouldNotContain(c => c.Name.Contains("cda", System.StringComparison.OrdinalIgnoreCase));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlManifestLoaderTests"
+```
+
+Expected: `CS0103: The name 'FmlManifestLoader' does not exist`.
+
+- [ ] **Step 3: Create the case record**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleCase.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * One <test> entry from an <fml-tests> manifest section.
+ */
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// A single transform oracle case declared in the corpus <c>manifest.xml</c>.
+/// </summary>
+/// <param name="Version">Corpus version folder, e.g. <c>r5</c>.</param>
+/// <param name="Name">Case name as declared in the manifest.</param>
+/// <param name="SourceFile">Input resource file name, relative to the structure-mapping directory.</param>
+/// <param name="MapFile">FML map file name, relative to the structure-mapping directory.</param>
+/// <param name="OutputFile">Expected output file name, relative to the structure-mapping directory.</param>
+public sealed record FmlOracleCase(
+    string Version,
+    string Name,
+    string SourceFile,
+    string MapFile,
+    string OutputFile)
+{
+    /// <inheritdoc />
+    public override string ToString() => $"{Version}/{Name}";
+}
+```
+
+The `ToString()` override drives readable xUnit theory display names.
+
+This record is passed through `IEnumerable<object[]>` `MemberData`, matching the precedent set by `FhirPathTestCase` in `test/Ignixa.FhirPath.Tests/OfficialTestSuiteRunner.cs:169-212`. It does not need to implement `IXunitSerializable` — that runner proves the pattern works in this repo's xUnit v2 setup.
+
+- [ ] **Step 4: Create the exclusion list**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleExclusions.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Frozen list of official FML oracle cases outside Ignixa's supported scope.
+ */
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Cases from the official corpus that Ignixa deliberately does not attempt.
+/// Per ADR-2607, the exclusion list is frozen and each entry carries a written
+/// rationale: conformance is reported as a percentage of supported scope, never
+/// inflated by quietly skipping hard cases.
+/// </summary>
+public static class FmlOracleExclusions
+{
+    private static readonly FrozenDictionary<string, string> Excluded =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["qr2cda"] = "Targets the CDA logical model and produces XML output; Ignixa's transform pipeline emits FHIR JSON only.",
+            ["qr2cdaxsi"] = "CDA logical model with xsi:type discrimination; XML output is out of scope.",
+            ["qr2cd-eval-json"] = "CDA logical model target; XML output is out of scope.",
+            ["qr2cd-eval-fml"] = "CDA logical model target; XML output is out of scope."
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether a manifest case name is excluded from the supported scope.
+    /// Manifest names are URLs, so the final path segment is used for matching.
+    /// </summary>
+    public static bool IsExcluded(string caseName) => Excluded.ContainsKey(LastSegment(caseName));
+
+    /// <summary>
+    /// Gets the written rationale for an excluded case, or <c>null</c> if it is not excluded.
+    /// </summary>
+    public static string? RationaleFor(string caseName) =>
+        Excluded.TryGetValue(LastSegment(caseName), out var rationale) ? rationale : null;
+
+    /// <summary>
+    /// Gets every excluded case name paired with its rationale.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> All => Excluded;
+
+    private static string LastSegment(string caseName) =>
+        caseName.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? caseName;
+}
+```
+
+> The four names above are the CDA cases observed in the pinned corpus. When you run Task 11 for the first time, confirm the manifest's actual `name` attributes and correct these keys if the last path segment differs. Do not add new entries just to make a test green — an entry is only legitimate if the case is genuinely outside Ignixa's target scope, and the rationale must say why.
+
+- [ ] **Step 5: Create the manifest loader**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoader.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Reads <fml-tests> entries out of the corpus manifest.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Reads the <c>&lt;fml-tests&gt;</c> section of a corpus <c>manifest.xml</c>.
+/// </summary>
+public static class FmlManifestLoader
+{
+    /// <summary>
+    /// Loads every declared transform oracle case for a corpus version folder
+    /// such as <c>r5</c> or <c>r4b</c>.
+    /// </summary>
+    public static IReadOnlyList<FmlOracleCase> Load(string version)
+    {
+        var manifestPath = Path.Combine(FmlTestCasesLocator.StructureMappingDirectory(version), "manifest.xml");
+
+        if (!File.Exists(manifestPath))
+        {
+            throw new FileNotFoundException($"Corpus manifest not found at {manifestPath}.", manifestPath);
+        }
+
+        var document = XDocument.Load(manifestPath);
+
+        return document.Descendants("fml-tests")
+            .Elements("test")
+            .Select(element => new FmlOracleCase(
+                version,
+                (string?)element.Attribute("name") ?? string.Empty,
+                (string?)element.Attribute("source") ?? string.Empty,
+                (string?)element.Attribute("map") ?? string.Empty,
+                (string?)element.Attribute("output") ?? string.Empty))
+            .Where(c => c.MapFile.Length > 0 && c.SourceFile.Length > 0 && c.OutputFile.Length > 0)
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlManifestLoaderTests"
+```
+
+Expected: PASS, 2 tests.
+
+If `manifest.xml` for `r4b` is a copy of `r5`'s and its `source`/`map`/`output` files do not exist under `r4b/structure-mapping`, note it — Task 11 filters on file existence, so this is handled, but the expected case count changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Conformance
+git commit -m "Load FML transform oracle cases from the corpus manifest"
+```
+
+---
+
+## Task 10: Canonical JSON comparison
+
+Expected outputs are pretty-printed by the reference implementation (`{"resourceType" : "Patient", "gender" : "female"}` — note the spaces around the colons), so text comparison is useless. Property order in FHIR JSON is also not semantically significant. Comparison must be structural.
+
+**Files:**
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class CanonicalJsonTests
+{
+    [Fact]
+    public void GivenTwoObjectsDifferingOnlyByWhitespace_WhenCanonicalizing_ThenTheResultsMatch()
+    {
+        var a = CanonicalJson.Canonicalize("""{"resourceType" : "Patient", "gender" : "female"}""");
+        var b = CanonicalJson.Canonicalize("""{"resourceType":"Patient","gender":"female"}""");
+
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void GivenTwoObjectsDifferingOnlyByPropertyOrder_WhenCanonicalizing_ThenTheResultsMatch()
+    {
+        var a = CanonicalJson.Canonicalize("""{"gender":"female","resourceType":"Patient"}""");
+        var b = CanonicalJson.Canonicalize("""{"resourceType":"Patient","gender":"female"}""");
+
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void GivenArraysInDifferentOrder_WhenCanonicalizing_ThenTheResultsDiffer()
+    {
+        var a = CanonicalJson.Canonicalize("""{"given":["a","b"]}""");
+        var b = CanonicalJson.Canonicalize("""{"given":["b","a"]}""");
+
+        a.ShouldNotBe(b);
+    }
+
+    [Fact]
+    public void GivenNonAsciiText_WhenCanonicalizing_ThenTheCharactersAreNotEscaped()
+    {
+        var canonical = CanonicalJson.Canonicalize("""{"family":"Brönnimann-Bertholet"}""");
+
+        canonical.ShouldContain("Brönnimann-Bertholet");
+    }
+}
+```
+
+Array order is significant in FHIR, so the third test asserts they must **not** compare equal.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~CanonicalJsonTests"
+```
+
+Expected: `CS0103: The name 'CanonicalJson' does not exist`.
+
+- [ ] **Step 3: Implement**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Structural JSON canonicalization for oracle comparison.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Renders JSON in a canonical form so that formatting and object property order
+/// do not affect comparison. Array order is preserved because it is semantically
+/// significant in FHIR.
+/// </summary>
+public static class CanonicalJson
+{
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>
+    /// Parses <paramref name="json"/> and re-renders it with object properties sorted
+    /// by ordinal name.
+    /// </summary>
+    public static string Canonicalize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var node = JsonNode.Parse(json, documentOptions: new JsonDocumentOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        });
+
+        return Sort(node)?.ToJsonString(WriteOptions) ?? "null";
+    }
+
+    private static JsonNode? Sort(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+            {
+                var sorted = new JsonObject();
+                foreach (var property in obj.OrderBy(p => p.Key, StringComparer.Ordinal))
+                {
+                    sorted[property.Key] = Sort(property.Value?.DeepClone());
+                }
+
+                return sorted;
+            }
+
+            case JsonArray array:
+            {
+                var result = new JsonArray();
+                foreach (var item in array)
+                {
+                    result.Add(Sort(item?.DeepClone()));
+                }
+
+                return result;
+            }
+
+            default:
+                return node?.DeepClone();
+        }
+    }
+}
+```
+
+`UnsafeRelaxedJsonEscaping` keeps non-ASCII characters readable, which matters because `qr.json` contains `Brönnimann-Bertholet`; and `DeepClone()` is required because a `JsonNode` cannot have two parents.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~CanonicalJsonTests"
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs
+git commit -m "Add canonical JSON comparison for FML oracle tests"
+```
+
+---
+
+## Task 11: The transform oracle runner
+
+Executes each supported manifest case end-to-end and compares the produced resource against the reference-produced expected output.
+
+The execution wiring mirrors `src/Application/Ignixa.Application.Operations/Features/Transform/TransformResourceHandler.cs:88-163` — read that file before writing this, and copy the real type and member names from it rather than trusting the sketch below.
+
+**Files:**
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs`
+
+- [ ] **Step 1: Write the runner**
+
+Create `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs`:
+
+```csharp
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ignixa.Abstractions;
+using Ignixa.FhirMappingLanguage.Evaluation;
+using Ignixa.FhirMappingLanguage.Mutator;
+using Ignixa.FhirMappingLanguage.Parser;
+using Ignixa.FhirPath;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.Extensions;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Executes every in-scope case from the official <c>&lt;fml-tests&gt;</c> manifest and
+/// compares the produced resource against the reference implementation's expected output.
+/// </summary>
+public class FmlTransformOracleTests(ITestOutputHelper output)
+{
+    public static IEnumerable<object[]> SupportedCases()
+    {
+        foreach (var version in new[] { "r5", "r4b" })
+        {
+            var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+
+            foreach (var oracleCase in FmlManifestLoader.Load(version))
+            {
+                if (FmlOracleExclusions.IsExcluded(oracleCase.Name))
+                {
+                    continue;
+                }
+
+                if (!oracleCase.OutputFile.EndsWith(".json", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!File.Exists(Path.Combine(directory, oracleCase.MapFile)) ||
+                    !File.Exists(Path.Combine(directory, oracleCase.SourceFile)) ||
+                    !File.Exists(Path.Combine(directory, oracleCase.OutputFile)))
+                {
+                    continue;
+                }
+
+                yield return [oracleCase];
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedCases))]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenAnOfficialFmlTestCase_WhenExecutingTheMap_ThenTheResultMatchesTheReferenceOutput(FmlOracleCase oracleCase)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(oracleCase.Version);
+        var fhirVersion = oracleCase.Version == "r4b" ? FhirVersion.R4B : FhirVersion.R5;
+        var schema = fhirVersion.GetSchemaProvider();
+
+        var map = MappingParser.Parse(File.ReadAllText(Path.Combine(directory, oracleCase.MapFile), Encoding.UTF8));
+
+        var source = ResourceJsonNode.Parse(File.ReadAllText(Path.Combine(directory, oracleCase.SourceFile), Encoding.UTF8));
+        var targetType = DetermineTargetType(map);
+        var target = JsonSourceNodeFactory.Parse<ResourceJsonNode>($"{{\"resourceType\":\"{targetType}\"}}");
+
+        var fhirPathEvaluator = new FhirPathEvaluator();
+        var context = new MappingContext
+        {
+            ErrorMode = ErrorMode.Strict,
+            ResourceCreator = type => JsonSourceNodeFactory.Parse<ResourceJsonNode>($"{{\"resourceType\":\"{type}\"}}").ToElement(schema),
+            Logger = message => output.WriteLine(message),
+            FhirPathEvaluator = (expression, element) => fhirPathEvaluator.Evaluate(expression, element)
+        };
+
+        context.SetSource("src", source.ToElement(schema));
+        context.SetTarget("tgt", target.ToElement(schema));
+        context.SetTargetResource("tgt", target);
+
+        var mutator = new JsonNodeMutator(fhirPathEvaluator, new FhirPathParser(), () => schema);
+        new MappingEvaluator(MappingEvaluatorOptions.Default, mutator).Execute(map, context);
+
+        var expected = CanonicalJson.Canonicalize(File.ReadAllText(Path.Combine(directory, oracleCase.OutputFile), Encoding.UTF8));
+        var actual = CanonicalJson.Canonicalize(target.ToJson());
+
+        output.WriteLine("EXPECTED:");
+        output.WriteLine(expected);
+        output.WriteLine("ACTUAL:");
+        output.WriteLine(actual);
+
+        actual.ShouldBe(expected);
+    }
+
+    private static string DetermineTargetType(MapExpression map)
+    {
+        var targetUses = map.Uses.LastOrDefault(u => u.Mode == UsesMode.Target)
+            ?? throw new InvalidDataException($"Map '{map.Url}' declares no target 'uses' statement.");
+
+        return targetUses.Url.Split('/').Last();
+    }
+}
+```
+
+**Names you must verify before running** (all exist, but the sketch above may have the wrong spelling — take the real ones from `TransformResourceHandler.cs`, `MappingContext.cs`, `UsesExpression.cs`, and `ResourceJsonNode`):
+- `ErrorMode.Strict` and the `MappingContext` initialiser property names
+- `ResourceCreator`'s delegate signature — `TransformResourceHandler` assigns `CreateResourceElement`; match its parameter and return types
+- `UsesExpression`'s mode property and enum (`Mode` / `UsesMode.Target` above are placeholders until confirmed)
+- The method that renders a `ResourceJsonNode` back to JSON text (`ToJson()` above)
+- `FhirPathEvaluator.Evaluate(expression, element)`'s exact signature and return type
+
+- [ ] **Step 2: Run it**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlTransformOracleTests" --logger "console;verbosity=detailed"
+```
+
+Expected on first run: compile clean, then a mix of passes and failures. The `EXPECTED:` / `ACTUAL:` output for each failure is the diagnostic.
+
+- [ ] **Step 3: Triage each failure honestly**
+
+For every failing case, classify it:
+
+1. **Ignixa bug** — fix it. This is the point of the exercise.
+2. **Genuinely outside supported scope** — add it to `FmlOracleExclusions` with a rationale naming the specific unsupported capability. Never add an entry whose rationale is "it fails".
+3. **Harness bug** — fix the runner.
+
+Record the classification for each case; it feeds Task 13.
+
+- [ ] **Step 4: Re-run until green**
+
+```bash
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --filter "FullyQualifiedName~FmlTransformOracleTests"
+```
+
+Expected: PASS, with the supported-scope case count printed in the run summary.
+
+- [ ] **Step 5: Run the whole solution to check for collateral damage**
+
+```bash
+dotnet test All.sln
+```
+
+Expected: PASS. The Part A parser changes touch shared code, so this is not optional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/Ignixa.FhirMappingLanguage.Tests/Conformance
+git commit -m "Add FML transform oracle tests driven by the official test manifest"
+```
+
+---
+
+## Task 12: Wire the FML validation cases into the existing validator oracle
+
+`validator/manifest.json` in the same corpus already drives `ValidatorConformanceRunner`, and it includes `map-general-test.fml` and `map-general-test2.fml` with recorded Java outcomes at `validator/outcomes/java/R5.map-general-test-base.json` and `validator/outcomes/java/R5.map-general-test2-base.json`. These grade FML *diagnostics* — the errors and warnings a conforming implementation should raise — which the transform oracle cannot.
+
+**Files:**
+- Modify: the case-selection logic in `ValidatorConformanceRunner` (locate it with `grep -rn "ValidatorConformanceRunner" test/`)
+
+- [ ] **Step 1: Locate the runner and its case filter**
+
+```bash
+grep -rn "class ValidatorConformanceRunner" test/
+grep -rn "manifest.json" test/
+```
+
+Read the file. Determine how it decides which of the 972 `test-cases` entries to execute — most likely an allow-list or an extension filter.
+
+- [ ] **Step 2: Check whether the two FML cases already run**
+
+```bash
+dotnet test <the validator test project> -f net9.0 --filter "FullyQualifiedName~ValidatorConformance" --logger "console;verbosity=detailed" 2>&1 | Select-String "map-general"
+```
+
+If both appear and pass, this task is already satisfied — record that and skip to Step 5.
+
+- [ ] **Step 3: Add them to the executed set**
+
+Extend the runner's filter to include `map-general-test.fml` and `map-general-test2.fml`, following whatever mechanism the file already uses. Do not restructure the runner.
+
+- [ ] **Step 4: Run and triage**
+
+Compare Ignixa's diagnostics against the recorded Java outcomes. Per ADR-2607, the bar is: no over-strict diagnostics (never report an error the reference does not), and a recorded pass rate for the rest. Add exclusions only with written rationale.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/
+git commit -m "Include FML validation cases in the validator conformance oracle"
+```
+
+---
+
+## Task 13: Record the outcome in the investigation
+
+**Files:**
+- Modify: `docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md`
+- Modify: `docs/features/structuremap/readme.md`
+
+- [ ] **Step 1: Replace the measured-baseline table with before/after numbers**
+
+In the Evidence section, keep the original `0/355` and `0/27` figures as the "before" column and add an "after" column with the counts measured in Tasks 8 and 11. Do not round or estimate — use the exact numbers the test output printed.
+
+- [ ] **Step 2: Fill in the Verdict**
+
+Set status to **Viable** (or **Partially viable** if material cases remain excluded) and state:
+- corpus parse rate, per version
+- transform oracle pass rate as a fraction of supported scope
+- every exclusion, with its rationale
+- which of the five defects are fully closed
+
+- [ ] **Step 3: Update the index**
+
+In `docs/features/structuremap/readme.md`, change the investigation row's status from `In Progress` to the final status.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/features/structuremap
+git commit -m "Record measured FML conformance results in the investigation"
+```
+
+---
+
+# Explicitly out of scope
+
+These were surveyed and deliberately deferred. Each is a candidate for its own investigation and plan.
+
+| Item | Why deferred |
+|---|---|
+| `HL7/fhir-cross-version` (1,201 `.fml`) | Grammar corpus only — no source/expected instance pairs, so it can grade parsing but not transformation. Valuable as a Phase 2 parse ratchet once the official corpus is green. |
+| `brianpos/fhir-r6-maps` (355 `.fml`) | Staging area for the above; not HL7-governed. Same limitation. |
+| `ahdis/fhir-mapping-tutorial` (36 tutorial results + 75 careconnect pairs) | Genuine oracle data and 3-4× the case count, but it is a community-maintained fixture repo, needs its own vendoring mechanism, and depends on 28 logical StructureDefinitions Ignixa would have to load. Do this after the official corpus passes. |
+| Serialization oracles (`.map` / `.json` / `.xml` triples in the tutorial repo) | Would grade `StructureMapParser`, `StructureMapBuilder`, and `FmlSerializer` against reference output. Separate concern from the parser and evaluator. |
+| Wildcard `imports "…/*4to6"` | An `ImportResolver` glob-semantics feature, not a parser defect. No in-scope oracle case needs it. |
+| Date arithmetic evaluation (`%value + 5 days`) | Task 1 and Task 2 make it *tokenize and parse* correctly. Making the evaluator compute it is a distinct feature. |
+| CDA logical-model / XML output | Four excluded oracle cases. Requires XML serialization of logical models, which Ignixa's transform pipeline does not target. |

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -31,8 +31,11 @@ Six root causes, in dependency order:
 | 4 | No `<<types>>` / `<<type+>>` group annotation | `unexpected '+'` / `unexpected '<'` | all cross-version maps |
 | 5 | No `///` metadata declarations; `map` header mandatory | `unexpected uses 'uses', expected map` | all R6-form maps |
 | 6 | Wildcard `imports ".../*4to6"` not resolvable | runtime, not parse | deferred — see Follow-ups |
+| 7 | No `'(' fpExpression ')'` transform in target position | `unexpected leftparen '('` | **found by Task 8** — blocks 3 of 6 in-scope oracle cases |
 
 Defects 1-5 are in scope. Defect 6 is deferred (it is an `ImportResolver` concern, not a parser concern, and no in-scope oracle case needs it).
+
+**Defect 7 was not visible to the original probe.** The probe reported only the *first* parse error per file, and every file failed on defects 1-5 first. Once those were fixed, Task 8's corpus gate measured r5 at 9/15 and r4b at 7/12 and exposed this as the next layer. It is in scope and is handled by Task 5b, because three of the six in-scope oracle cases (`qr2pat-gender.map`, `qr2pat-humannametwice.map`, `qr2pat-humannameshared.map`) cannot parse without it — Task 11 would otherwise silently exercise half its intended coverage.
 
 ---
 
@@ -1563,6 +1566,47 @@ Update the `[InlineData]` values to the counts you actually achieved and re-run 
 git add test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
 git commit -m "Gate FML parser on the official structure-mapping corpus parse rate"
 ```
+
+---
+
+## Task 5b: Parenthesized FHIRPath transforms (defect 7)
+
+Discovered by Task 8's corpus gate, which measured r5 at 9/15 and r4b at 7/12. Every remaining failure is `unexpected leftparen '('`. Runs **after** Task 8 exists (it is what measures the fix) but is a Part A parser change.
+
+**Why this is in scope and not deferred:** three of the six in-scope oracle cases — `qr2pat-gender.map`, `qr2pat-humannametwice.map`, `qr2pat-humannameshared.map` — fail on it. Task 11's transform oracle would run at half coverage while appearing green.
+
+**The construct**, from the official `mapping.g4`:
+
+```
+transform
+  : ...
+  | '(' fpExpression ')'      // fhirpath based expressions
+```
+
+Real corpus instances:
+
+```
+src.item as item where linkId.value in ('patient.sex') -> tgt.gender = (item.answer.valueString);
+src -> tgt.identifer as ext, ext.system = ('urn:uuid:' + r.lower()) "rootuuid";
+ext.value as value -> tgt.birthDate = (%value + 5 days) "plus";
+```
+
+**Files:**
+- Modify: `src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs`
+- Modify: `test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs`
+- Modify: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs` (ratchet the counts up)
+
+**Critical constraint — do not reuse `FhirPathExpression` directly.**
+
+`FhirPathExpression` (`MappingGrammar.cs` ~line 135) has two branches. The `(`-branch does correct balanced-paren collection and is exactly what we want. The `else` branch greedily consumes tokens until a terminator, and its terminator set is `Arrow, Semicolon, RightBrace, Default, Where, Check, Log, Comma` — which does **not** include `As`, any list mode, or `StringLiteral`. Adding `FhirPathExpression` to `Target`'s expression alternation would therefore let `tgt.x = foo as v "name";` be swallowed whole as a single FHIRPath.
+
+Add a **parenthesized-only** parser instead. This is also the conformant reading: the official grammar permits `'(' fpExpression ')'` as a transform, never a bare unparenthesized `fpExpression`.
+
+**Scope limits:**
+- `tgt.field = (expr)` is the required form. The bare `ruleTarget : '(' fpExpression ')' alias?` form (a target with no context and no `=`) appears in no corpus file — do not implement it speculatively.
+- Nested function calls in transform arguments — `evaluate(src, iif(src.is(X),"a","b"))` in `qr2cda-eval.map` — are **out of scope**. `TransformArgumentExpression` accepts only literals and qualified identifiers, and widening it hits the same greedy-fallback hazard *plus* an unbalanced-`)` problem, since `RightParen` is not a terminator. `qr2cda-eval.map` backs only `qr2cd-eval-fml`, a CDA case already excluded from the oracle for XML output, so this costs the oracle nothing. Record it as a known gap.
+
+**Expected outcome:** r5 **14/15**, r4b **11/12**, with only `qr2cda-eval.map` failing in each. Ratchet `FmlCorpusParseTests` to those numbers and name `qr2cda-eval.map` as the expected failure with its reason.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -939,9 +939,10 @@ Append to `FmlSyntaxCoverageTests`:
 
 ```csharp
     [Theory]
-    [InlineData("<<types>>")]
-    [InlineData("<<type+>>")]
-    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(string annotation)
+    [InlineData("<<types>>", GroupTypeMode.Types)]
+    [InlineData("<<type+>>", GroupTypeMode.TypeAndTypes)]
+    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(
+        string annotation, GroupTypeMode expected)
     {
         var fml = $$"""
             map 'http://example.org/T' = 'T'
@@ -953,11 +954,37 @@ Append to `FmlSyntaxCoverageTests`:
 
         var reparsed = new MappingParser().Parse(new FmlSerializer().Serialize(new MappingParser().Parse(fml)));
 
-        reparsed.Groups[0].TypeMode.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode);
+        reparsed.Groups[0].TypeMode.ShouldBe(expected);
     }
 ```
 
-Add `using Ignixa.FhirMappingLanguage.Serialization;` to the file. If `FmlSerializer` exposes a static `Serialize` rather than an instance method, adjust the call — check the file before writing.
+**Assert against the `[InlineData]` literal, never against a second parse of the same input.** An earlier draft of this step wrote `.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode)`. Both sides then derive from the parser, so any parser mutation moves them together and the test passes vacuously — verified empirically: it stayed green under two parser mutations that a literal-asserting sibling caught. The same trap applies to every round-trip test later in this plan.
+
+**Also required: a serializer test for the un-annotated case.** The `if (TypeMode != None)` guard has no coverage from round-trip tests, because a spuriously-emitted `<<types>>` reparses to `Types` and an annotated fixture cannot see it. Assert on the serialized *text*:
+
+```csharp
+    [Fact]
+    public void GivenNoTypeModeAnnotation_WhenSerializing_ThenNoAnnotationIsEmitted()
+    {
+        // ... parse an un-annotated group, serialize it ...
+        fml.ShouldNotContain("<<");
+    }
+```
+
+Without it, mutating the guard to always-true leaves the whole suite green.
+
+- [ ] **Step 7b: Propagate the mode through `StructureMapBuilder`**
+
+`StructureMapBuilder.BuildGroup` hardcodes `groupNode.MutableNode["typeMode"] = "none"`. That was true by construction before this task, because no FML input could express anything else; once the annotation parses it is actively false for exactly the groups this task exists to support.
+
+The version guard must stay — R4/R4B's `map-group-type-mode` value set includes `none`, while **R5 dropped `none` entirely** (only `types` | `type-and-types`) and made the element optional. So:
+
+- R4/R4B: always write, mapping `None`→`"none"`, `Types`→`"types"`, `TypeAndTypes`→`"type-and-types"`.
+- R5: omit the element when `None`; otherwise write the same kebab-case literals.
+
+Wire literals are FHIR kebab-case (`type-and-types`), not the C# enum names. Cover both versions × both `None` and annotated in `test/Ignixa.FhirMappingLanguage.Tests/Serialization/StructureMapBuilderVersionTests.cs`.
+
+The reverse direction (`StructureMapParser`) is **out of scope** — see the deferred-work note in Task 13.
 
 - [ ] **Step 8: Run the whole FML suite**
 

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -2195,43 +2195,62 @@ git commit -m "Add FML transform oracle tests driven by the official test manife
 
 ---
 
-## Task 12: Wire the FML validation cases into the existing validator oracle
+## Task 12: Parse-ratchet the official validator FML files
 
-`validator/manifest.json` in the same corpus already drives `ValidatorConformanceRunner`, and it includes `map-general-test.fml` and `map-general-test2.fml` with recorded Java outcomes at `validator/outcomes/java/R5.map-general-test-base.json` and `validator/outcomes/java/R5.map-general-test2-base.json`. These grade FML *diagnostics* — the errors and warnings a conforming implementation should raise — which the transform oracle cannot.
+> **Amended after measurement.** The original task assumed the two official FML cases could be added to `ValidatorConformanceRunner`'s case filter. That premise was verified false. Recorded here rather than deleted, because the finding matters for Task 13.
+>
+> **What was measured:**
+> - `ConformanceCaseAnalysis.IsR4CleanBase` requires `version == "4.0"` and a `.json` input file. Both FML manifest entries omit `version` (meaning R5 — consistent with their `R5.*` outcome filenames) and carry `.fml` files. They are excluded twice over, deliberately.
+> - `ValidatorConformanceRunner.TryValidate` does `JsonNode.Parse(File.ReadAllText(inputPath))`. FML text throws `JsonException`, which the runner scores as "invalid" — so such a case would appear to pass *because JSON parsing failed*. A pass for the wrong reason, not coverage.
+> - The runner grades binary valid/invalid on error count; these outcomes are line/column-anchored diagnostics (test1: 2 errors + 2 warnings; test2: 3 errors + 2 information).
+> - The diagnostics require StructureMap **semantic** validation Ignixa does not have: cross-map group resolution through `imports` (incl. the wildcard `*4to3` form already deferred), cross-version R3 StructureDefinition resolution, element-path validation, default-rule inference, and source/target mode cross-checking.
+>
+> Diagnostic grading is therefore tracked as its own issue, gated behind the evaluator fixes. What *is* in scope and valuable now: both files parse cleanly today, and they are the richest parser coverage available — `extends Element <<type+>>` (Task 4), wildcard `imports`, the `map` header (Task 5), the `+` operator (Task 1), and the parenthesized FHIRPath transform `('urn:uuid:' + r.lower())` (Task 5b) — several of which appear nowhere in the `structure-mapping` corpus. Lock that in against regression.
+
+Both files are present in this project's **own** corpus copy (`TestData/fhir-test-cases/validator/`), so no cross-project dependency is needed.
 
 **Files:**
-- Modify: the case-selection logic in `ValidatorConformanceRunner` (locate it with `grep -rn "ValidatorConformanceRunner" test/`)
+- Modify: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs`
+- Create: `test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlValidatorCorpusParseTests.cs`
 
-- [ ] **Step 1: Locate the runner and its case filter**
+- [ ] **Step 1: Add a `validator` directory accessor to the locator**
+
+Mirror the existing `StructureMappingDirectory(string version)` with a parameterless `ValidatorDirectory()` returning `Path.Combine(Root, "validator")`. Do not restructure the locator.
+
+- [ ] **Step 2: Add the parse ratchet**
+
+A new test class covering exactly `map-general-test.fml` and `map-general-test2.fml`.
+
+Requirements, in priority order:
+
+1. **Assert the files exist**, with the resolved path in the failure message, *before* attempting to parse. A partial corpus download must produce "file X not found", never a vacuous green.
+2. **Assert parsing succeeds** — let the exception escape rather than catching and asserting on a bool, so the failure message carries the parser's own diagnostic.
+3. **Assert structural facts, not merely "did not throw."** Measured values:
+
+   | file | `Url` | `Groups` | `Uses` | `Imports` |
+   |---|---|---|---|---|
+   | `map-general-test.fml` | `http://hl7.org/fhir/StructureMap/Address4to3` | 1 | 2 | 1 |
+   | `map-general-test2.fml` | `http://github.com/FHIR/fhir-test-cases/r5/fml/syntax` | 2 | 2 | 0 |
+
+4. **Assert the constructs that make these files worth having.** This is the actual point of the task — without it the test is just "two more files parse."
+   - `map-general-test.fml`: the group's `extends` target (`Element`) and its type-mode annotation (`type+`) survived parsing.
+   - `map-general-test2.fml`: the parenthesized FHIRPath transform in the `"rootuuid"` rule survived parsing.
+
+   **Verify the property names against `src/Core/Ignixa.FhirMappingLanguage/Expressions/` before writing these assertions — do not assume them.** If a construct genuinely is not surfaced on the expression model, say so in your handoff instead of asserting something weaker and calling it done.
+
+- [ ] **Step 3: Verify**
 
 ```bash
-grep -rn "class ValidatorConformanceRunner" test/
-grep -rn "manifest.json" test/
+dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj -f net9.0 --nologo
 ```
 
-Read the file. Determine how it decides which of the 972 `test-cases` entries to execute — most likely an allow-list or an extension filter.
+Then mutation-check at least the existence guard and one structural assertion: replace content (never delete lines — every mutation must compile under warnings-as-errors) and confirm the test fails. Restore and re-verify green.
 
-- [ ] **Step 2: Check whether the two FML cases already run**
-
-```bash
-dotnet test <the validator test project> -f net9.0 --filter "FullyQualifiedName~ValidatorConformance" --logger "console;verbosity=detailed" 2>&1 | Select-String "map-general"
-```
-
-If both appear and pass, this task is already satisfied — record that and skip to Step 5.
-
-- [ ] **Step 3: Add them to the executed set**
-
-Extend the runner's filter to include `map-general-test.fml` and `map-general-test2.fml`, following whatever mechanism the file already uses. Do not restructure the runner.
-
-- [ ] **Step 4: Run and triage**
-
-Compare Ignixa's diagnostics against the recorded Java outcomes. Per ADR-2607, the bar is: no over-strict diagnostics (never report an error the reference does not), and a recorded pass rate for the rest. Add exclusions only with written rationale.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add test/
-git commit -m "Include FML validation cases in the validator conformance oracle"
+git add test/Ignixa.FhirMappingLanguage.Tests
+git commit -F <message-file>
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -92,6 +92,15 @@ From `AGENTS.md` / `CLAUDE.md` in this repo:
 
 **Critical gotcha:** `test/Ignixa.FhirMappingLanguage.Tests/` has **no global usings**. Every new test file needs explicit `using Xunit;` and `using Shouldly;`.
 
+**Verified API facts** (corrected during Task 2 — earlier drafts of this plan got these wrong):
+
+- `MappingParser.Parse` is an **instance** method, not static. Call it as `new MappingParser().Parse(fml)`.
+- A source condition is `SourceExpression.Condition`, typed `Expression?`. To read the FHIRPath text, cast and use `PathExpression`: `((FhirPathExpression)source.Condition!).PathExpression`. There is no `.Expression` property.
+- `MapExpression.Groups`, `GroupExpression.Rules`, and `RuleExpression.Sources` are all `IReadOnlyList<T>` and named as this plan assumes.
+- `ImplicitUsings` is enabled in the test project, which covers `System.*` — but **not** `Xunit` or `Shouldly`, which still need explicit usings (see gotcha above).
+
+Any other member name quoted in this plan is an assumption, not a verified fact. Open the source and confirm before relying on it; report the correction rather than working around it silently.
+
 **Critical gotcha:** `MappingTokenizer.cs` contains **two near-identical tokenizer builders** — `CreateWithTrivia()` (lines 24-111) and `Create()` (lines 117-204). Every tokenizer change must be applied to **both**. Because the operator blocks are byte-identical between them, a naive `edit` anchor will fail with "not unique" — the replacements below include enough trailing context (`.Build();` vs `// Whitespace (ignore for standard parsing)`) to disambiguate.
 
 ---
@@ -558,7 +567,7 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var map = MappingParser.Parse(Fml);
+        var map = new MappingParser().Parse(Fml);
 
         map.Url.ShouldBe("http://hl7.org/fhir/StructureMap/tutorial");
         map.Identifier.ShouldBe("tutorial");
@@ -575,7 +584,7 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var map = MappingParser.Parse(Fml);
+        var map = new MappingParser().Parse(Fml);
 
         map.Identifier.ShouldBe("a \" b");
     }
@@ -787,7 +796,7 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var map = MappingParser.Parse(fml);
+        var map = new MappingParser().Parse(fml);
 
         map.Groups[0].TypeMode.ShouldBe(expected);
     }
@@ -803,7 +812,7 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var map = MappingParser.Parse(Fml);
+        var map = new MappingParser().Parse(Fml);
 
         map.Groups[0].TypeMode.ShouldBe(GroupTypeMode.None);
     }
@@ -926,9 +935,9 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var reparsed = MappingParser.Parse(new FmlSerializer().Serialize(MappingParser.Parse(fml)));
+        var reparsed = new MappingParser().Parse(new FmlSerializer().Serialize(new MappingParser().Parse(fml)));
 
-        reparsed.Groups[0].TypeMode.ShouldBe(MappingParser.Parse(fml).Groups[0].TypeMode);
+        reparsed.Groups[0].TypeMode.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode);
     }
 ```
 
@@ -989,7 +998,7 @@ Append to `FmlSyntaxCoverageTests`:
             }
             """;
 
-        var map = MappingParser.Parse(Fml);
+        var map = new MappingParser().Parse(Fml);
 
         map.Url.ShouldBe("http://hl7.org/fhir/uv/xver/StructureMap/Element4to6");
         map.Identifier.ShouldBe("Element4to6");
@@ -1003,7 +1012,7 @@ Append to `FmlSyntaxCoverageTests`:
             // nothing to see here
             """;
 
-        Should.Throw<ParseException>(() => MappingParser.Parse(Fml));
+        Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
     }
 ```
 
@@ -1454,7 +1463,7 @@ public class FmlCorpusParseTests(ITestOutputHelper output)
         {
             try
             {
-                MappingParser.Parse(File.ReadAllText(file, Encoding.UTF8));
+                new MappingParser().Parse(File.ReadAllText(file, Encoding.UTF8));
                 parsed++;
             }
             catch (Exception ex)
@@ -1989,7 +1998,7 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
         var fhirVersion = oracleCase.Version == "r4b" ? FhirVersion.R4B : FhirVersion.R5;
         var schema = fhirVersion.GetSchemaProvider();
 
-        var map = MappingParser.Parse(File.ReadAllText(Path.Combine(directory, oracleCase.MapFile), Encoding.UTF8));
+        var map = new MappingParser().Parse(File.ReadAllText(Path.Combine(directory, oracleCase.MapFile), Encoding.UTF8));
 
         var source = ResourceJsonNode.Parse(File.ReadAllText(Path.Combine(directory, oracleCase.SourceFile), Encoding.UTF8));
         var targetType = DetermineTargetType(map);

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -1327,7 +1327,7 @@ Get-ChildItem test/Ignixa.FhirMappingLanguage.Tests/TestData/fhir-test-cases/r5/
 Get-ChildItem test/Ignixa.FhirMappingLanguage.Tests/TestData/fhir-test-cases/r4b/structure-mapping -Filter *.map | Measure-Object
 ```
 
-Expected: 16 and 12 respectively. If the counts differ, the pinned version changed upstream — record the actual counts and use them in Task 8.
+Expected: **15** and **12** respectively (measured against pinned release `1.7.46`; the corpus checkout carries git tag `1.7.46`, so this is verifiable). If the counts differ, the pinned version changed upstream — record the actual counts and use them in Task 8.
 
 - [ ] **Step 4: Confirm `TestData/` is not committed**
 
@@ -1788,7 +1788,13 @@ dotnet test test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tes
 
 Expected: PASS, 2 tests.
 
-If `manifest.xml` for `r4b` is a copy of `r5`'s and its `source`/`map`/`output` files do not exist under `r4b/structure-mapping`, note it — Task 11 filters on file existence, so this is handled, but the expected case count changes.
+**Measured facts about the manifests (release `1.7.46`) — verified after Task 6, use these rather than re-deriving:**
+
+- Manifests live at `{version}/structure-mapping/manifest.xml`. There is **no** `{version}/fml/` directory in this release.
+- `r4b/structure-mapping/manifest.xml` is **byte-identical** to `r5`'s, including test `name` attributes that all read `.../org.hl7.fhir.r5.tests/...` even in the r4b copy.
+- Every referenced `source`/`map`/`output` file **does exist** in both `r5` and `r4b`. So the existence filter removes nothing and the expected case count does **not** shrink for r4b: **10 cases per version**, of which **4** have `.xml` outputs (`qr2cda`, `qr2cdaxsi`, `qr2cd-eval-json`, `qr2cd-eval-fml`) and are excluded, leaving **6 in-scope JSON cases per version = 12 total**.
+- **Hazard:** because the `name` attributes are identical across versions, `name` alone is **not** a unique test identifier. Any xUnit `MemberData` display name or dictionary key must incorporate the version, or the r4b and r5 cases will collide and be indistinguishable in test output.
+- **Hazard:** `qr2cd-eval-json` has `map="qr2cda-eval.json"` — a JSON StructureMap, not FML. It is excluded by the XML-output rule anyway, but the loader must not assume every `map` attribute ends in `.map`.
 
 - [ ] **Step 7: Commit**
 

--- a/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
+++ b/docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md
@@ -542,7 +542,7 @@ git commit -m "Preserve original source text when capturing embedded FHIRPath ex
 
 FML permits both `'...'` and `"..."` for string literals. The tokenizer currently maps `"..."` to `DelimitedIdentifier`, and `MappingGrammar.Map` (line 512) demands a `StringLiteral`, so every official case that opens with `map "http://..." = "cast"` dies at line 1 column 5. This accounts for 21 of the 27 official-case failures.
 
-The fix introduces a distinct `DoubleQuotedString` kind rather than reusing `StringLiteral`, so the parser can keep accepting `"..."` in identifier positions (where the old behaviour allowed it) without losing the ability to treat it as a string in literal positions.
+The fix introduces a distinct `DoubleQuotedString` kind rather than reusing `StringLiteral`. This matches the official ANTLR grammar (`HL7/fhir` `images/mapping.g4`), which declares `DOUBLE_QUOTED_STRING` as a token distinct from `STRING`, and uses it in `url`, `ruleName` and `literal` — but **not** in `identifier`, where the delimited form is backtick-only.
 
 **Files:**
 - Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs`
@@ -698,34 +698,33 @@ with:
             .Select(t => new LiteralExpression(UnescapeString(t.ToStringValue()), CreatePosition(t)));
 ```
 
-- [ ] **Step 7: Keep `"..."` usable in identifier positions**
+- [ ] **Step 7: Do NOT accept `"..."` in identifier positions**
 
-Replace `MappingGrammar.cs:91-97`:
+> **Corrected 2026-07-28 after the Task 3 code-quality review.** An earlier draft of this step widened the `Identifier` rule with `.Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))`, on the theory that it preserved backward compatibility. That was wrong on three counts:
+>
+> 1. **It is non-conformant.** The official ANTLR grammar (`HL7/fhir` `images/mapping.g4`) lists `DOUBLE_QUOTED_STRING` in `url`, `ruleName` and `literal`, and **not** in `identifier`. The delimited-identifier form is backtick-only (`DELIMITEDIDENTIFIER : '`' (ESC | .)*? '`' ;`).
+> 2. **The compatibility was with our own bug, not with FML.** Before Task 3 the tokenizer mis-classified `"..."` as `DelimitedIdentifier`; the widening carried that misfeature forward. Mutation testing showed **zero** of 562 tests depended on it.
+> 3. **It creates a two-valued unescaping.** `UnescapeString` resolves `\"`, `UnescapeIdentifier` does not — so the same token would mean `a " b` in literal position and `a \" b` in identifier position.
+>
+> It also increases ambiguity in the top-level alternation that Task 5 has to extend.
 
-```csharp
-    private static readonly TokenListParser<MappingTokenKind, IdentifierExpression> Identifier =
-        Token.EqualTo(MappingTokenKind.Identifier)
-            .Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier))
-            .Or(Token.EqualTo(MappingTokenKind.Type))  // 'type' can be used as property name
-            .Or(Token.EqualTo(MappingTokenKind.Default))  // 'default' can be used as property name
-            .Or(Token.EqualTo(MappingTokenKind.Prefix))  // 'prefix' can be used as property name
-            .Select(t => new IdentifierExpression(UnescapeIdentifier(t.ToStringValue()), CreatePosition(t)));
-```
+Leave the `Identifier` rule (current lines ~114-120) **unchanged**. `"..."` reaches the parser only through `StringLiteral` (Step 6).
 
-with:
+Then remove the now-dead double-quote branch from `UnescapeIdentifier` (current lines 63-72), which has exactly one caller — the `Identifier` rule:
 
 ```csharp
-    private static readonly TokenListParser<MappingTokenKind, IdentifierExpression> Identifier =
-        Token.EqualTo(MappingTokenKind.Identifier)
-            .Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier))
-            .Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))  // "..." is legal where an identifier is expected
-            .Or(Token.EqualTo(MappingTokenKind.Type))  // 'type' can be used as property name
-            .Or(Token.EqualTo(MappingTokenKind.Default))  // 'default' can be used as property name
-            .Or(Token.EqualTo(MappingTokenKind.Prefix))  // 'prefix' can be used as property name
-            .Select(t => new IdentifierExpression(UnescapeIdentifier(t.ToStringValue()), CreatePosition(t)));
+    // Helper: Unescape identifier
+    private static string UnescapeIdentifier(string id)
+    {
+        if (id.StartsWith('`') && id.EndsWith('`'))
+        {
+            return id.Substring(1, id.Length - 2);
+        }
+        return id;
+    }
 ```
 
-`UnescapeIdentifier` (lines 54-62) already strips both backticks and double quotes, so it needs no change.
+No `Length >= 2` guard is needed: the backtick regex requires at least two characters and the method is private with token-sourced input only.
 
 - [ ] **Step 8: Fix the ConceptMap declaration id**
 
@@ -971,6 +970,17 @@ R6-era FML replaces the `map "url" = "name"` header with a run of metadata lines
 ```
 
 The tokenizer currently swallows these as `LineComment` (because `Comment.CPlusPlusStyle` matches `//`), and `MappingGrammar.Map` (line 511) requires a leading `Map` token, so parsing fails with `unexpected uses 'uses', expected map`. This blocks every `brianpos/fhir-r6-maps` file and `syntax.map:1`.
+
+> **Known hazard, surfaced by the Task 3 code-quality review.** The spec grammar pairs `metadataDeclaration` with a `markdownLiteral`:
+>
+> ```antlr
+> metadataDeclaration : METADATA_PREFIX qualifiedIdentifier '=' (literal | markdownLiteral)? ;
+> TRIPLE_QUOTED_STRING_LITERAL : '"""' [\r\n] (.)*? [\r\n] '"""' ;
+> ```
+>
+> Our double-quote rule is `"([^"\\]|\\.)*"`, which lexes `"""` as an **empty `DoubleQuotedString` followed by a dangling `"`** — and since Task 3, that first token looks like a legitimate empty string literal rather than a lexer gap, so the failure will be confusing.
+>
+> This task only needs to parse metadata *values* that are ordinary literals; the corpora in scope do not use `"""` blocks. **Do not** add triple-quoted support here. But if you hit a corpus file that uses one, stop and report it rather than widening the regex — a `"""` rule must be registered *before* the `"..."` rule in both builders, and getting that ordering wrong silently breaks every ordinary double-quoted string.
 
 **Files:**
 - Modify: `src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs`

--- a/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs
@@ -17,18 +17,25 @@ public class GroupExpression : Expression
         IEnumerable<ParameterExpression> parameters,
         string? extends,
         IEnumerable<RuleExpression> rules,
-        ISourcePositionInfo? location = null) : base(location)
+        ISourcePositionInfo? location = null,
+        GroupTypeMode typeMode = GroupTypeMode.None) : base(location)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Parameters = parameters?.ToList() ?? [];
         Extends = extends;
         Rules = rules?.ToList() ?? [];
+        TypeMode = typeMode;
     }
 
     public string Name { get; }
     public IReadOnlyList<ParameterExpression> Parameters { get; }
     public string? Extends { get; }
     public IReadOnlyList<RuleExpression> Rules { get; }
+
+    /// <summary>
+    /// Gets the type-mode annotation declared for this group.
+    /// </summary>
+    public GroupTypeMode TypeMode { get; }
 
     public override string ToString()
     {

--- a/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupExpression.cs
@@ -17,8 +17,8 @@ public class GroupExpression : Expression
         IEnumerable<ParameterExpression> parameters,
         string? extends,
         IEnumerable<RuleExpression> rules,
-        ISourcePositionInfo? location = null,
-        GroupTypeMode typeMode = GroupTypeMode.None) : base(location)
+        GroupTypeMode typeMode = GroupTypeMode.None,
+        ISourcePositionInfo? location = null) : base(location)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Parameters = parameters?.ToList() ?? [];
@@ -45,6 +45,11 @@ public class GroupExpression : Expression
         if (Extends is not null)
         {
             result += $" extends {Extends}";
+        }
+
+        if (TypeMode != GroupTypeMode.None)
+        {
+            result += TypeMode == GroupTypeMode.TypeAndTypes ? " <<type+>>" : " <<types>>";
         }
 
         if (Rules.Count > 0)

--- a/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs
@@ -15,9 +15,14 @@ public enum GroupTypeMode
     /// <summary>No annotation present. The group is only invoked by explicit reference.</summary>
     None = 0,
 
-    /// <summary>Declared &lt;&lt;types&gt;&gt;: the group is a candidate for type-based dispatch.</summary>
+    /// <summary>
+    /// Declared &lt;&lt;types&gt;&gt;: the group is the default mapping group for the specified
+    /// types <em>and</em> for the primary source type.
+    /// </summary>
     Types,
 
-    /// <summary>Declared &lt;&lt;type+&gt;&gt;: the group is the default for type-based dispatch.</summary>
+    /// <summary>
+    /// Declared &lt;&lt;type+&gt;&gt;: the group is the default mapping group for the specified types.
+    /// </summary>
     TypeAndTypes
 }

--- a/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Expressions/GroupTypeMode.cs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Group type mode annotation for FHIR Mapping Language groups.
+ */
+
+namespace Ignixa.FhirMappingLanguage.Expressions;
+
+/// <summary>
+/// Indicates how a group participates in type-directed rule selection,
+/// declared in FML as a &lt;&lt;types&gt;&gt; or &lt;&lt;type+&gt;&gt; annotation.
+/// </summary>
+public enum GroupTypeMode
+{
+    /// <summary>No annotation present. The group is only invoked by explicit reference.</summary>
+    None = 0,
+
+    /// <summary>Declared &lt;&lt;types&gt;&gt;: the group is a candidate for type-based dispatch.</summary>
+    Types,
+
+    /// <summary>Declared &lt;&lt;type+&gt;&gt;: the group is the default for type-based dispatch.</summary>
+    TypeAndTypes
+}

--- a/src/Core/Ignixa.FhirMappingLanguage/Expressions/MapExpression.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Expressions/MapExpression.cs
@@ -20,6 +20,7 @@ public class MapExpression : Expression
         IEnumerable<GroupExpression> groups,
         IEnumerable<ConceptMapDeclarationExpression>? conceptMaps = null,
         IEnumerable<ConstantDeclarationExpression>? constants = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
         ISourcePositionInfo? location = null) : base(location)
     {
         Url = url ?? throw new ArgumentNullException(nameof(url));
@@ -29,6 +30,7 @@ public class MapExpression : Expression
         Groups = groups?.ToList() ?? [];
         ConceptMaps = conceptMaps?.ToList() ?? [];
         Constants = constants?.ToList() ?? [];
+        Metadata = metadata ?? new Dictionary<string, string>(StringComparer.Ordinal);
     }
 
     public string Url { get; }
@@ -36,6 +38,12 @@ public class MapExpression : Expression
     public IReadOnlyList<UsesExpression> Uses { get; }
     public IReadOnlyList<ImportsExpression> Imports { get; }
     public IReadOnlyList<GroupExpression> Groups { get; }
+
+    /// <summary>
+    /// Gets the metadata declarations (<c>/// key = 'value'</c>) that preceded the map body.
+    /// Empty when the map used the classic <c>map "url" = "name"</c> header form.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
 
     /// <summary>
     /// Inline ConceptMap declarations.

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
@@ -82,6 +82,16 @@ public enum MappingTokenKind
     LeftBracket,         // [
     RightBracket,        // ]
 
+    // Arithmetic and FHIRPath operators (appear inside embedded FHIRPath and in <<type+>>)
+    Plus,                // +
+    Minus,               // -
+    Percent,             // % (FHIRPath environment variable prefix)
+    Slash,               // /
+    Pipe,                // |
+    Ampersand,           // &
+    LessOrEqual,         // <=
+    GreaterOrEqual,      // >=
+
     // Comments (for trivia mode)
     LineComment,         // //
     BlockComment,        // /* */

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
@@ -52,6 +52,7 @@ public enum MappingTokenKind
     Identifier,
     DelimitedIdentifier,
     StringLiteral,
+    DoubleQuotedString,
     IntegerLiteral,
     DecimalLiteral,
     Url,

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenKind.cs
@@ -93,6 +93,9 @@ public enum MappingTokenKind
     LessOrEqual,         // <=
     GreaterOrEqual,      // >=
 
+    // Metadata declarations (R6 FML header form)
+    MetadataLine,        // /// key = 'value'
+
     // Comments (for trivia mode)
     LineComment,         // //
     BlockComment,        // /* */

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
@@ -90,6 +90,8 @@ public static class MappingTokenizer
             .Match(Span.EqualTo("~="), MappingTokenKind.RelatedTo)
             .Match(Span.EqualTo("!="), MappingTokenKind.NotEquals)
             .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+            .Match(Span.EqualTo("<="), MappingTokenKind.LessOrEqual)
+            .Match(Span.EqualTo(">="), MappingTokenKind.GreaterOrEqual)
 
             // Single-character operators and delimiters
             .Match(Character.EqualTo('='), MappingTokenKind.Equals)
@@ -106,6 +108,14 @@ public static class MappingTokenizer
             .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
             .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
             .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            // Arithmetic / FHIRPath operators (after multi-character forms so -> and <= win)
+            .Match(Character.EqualTo('+'), MappingTokenKind.Plus)
+            .Match(Character.EqualTo('-'), MappingTokenKind.Minus)
+            .Match(Character.EqualTo('%'), MappingTokenKind.Percent)
+            .Match(Character.EqualTo('/'), MappingTokenKind.Slash)
+            .Match(Character.EqualTo('|'), MappingTokenKind.Pipe)
+            .Match(Character.EqualTo('&'), MappingTokenKind.Ampersand)
 
             .Build();
     }
@@ -180,6 +190,8 @@ public static class MappingTokenizer
             .Match(Span.EqualTo("~="), MappingTokenKind.RelatedTo)
             .Match(Span.EqualTo("!="), MappingTokenKind.NotEquals)
             .Match(Span.EqualTo("<-"), MappingTokenKind.LeftArrow)
+            .Match(Span.EqualTo("<="), MappingTokenKind.LessOrEqual)
+            .Match(Span.EqualTo(">="), MappingTokenKind.GreaterOrEqual)
 
             // Single-character operators and delimiters
             .Match(Character.EqualTo('='), MappingTokenKind.Equals)
@@ -196,6 +208,14 @@ public static class MappingTokenizer
             .Match(Character.EqualTo('>'), MappingTokenKind.RightAngle)
             .Match(Character.EqualTo('['), MappingTokenKind.LeftBracket)
             .Match(Character.EqualTo(']'), MappingTokenKind.RightBracket)
+
+            // Arithmetic / FHIRPath operators (after multi-character forms so -> and <= win)
+            .Match(Character.EqualTo('+'), MappingTokenKind.Plus)
+            .Match(Character.EqualTo('-'), MappingTokenKind.Minus)
+            .Match(Character.EqualTo('%'), MappingTokenKind.Percent)
+            .Match(Character.EqualTo('/'), MappingTokenKind.Slash)
+            .Match(Character.EqualTo('|'), MappingTokenKind.Pipe)
+            .Match(Character.EqualTo('&'), MappingTokenKind.Ampersand)
 
             // Whitespace (ignore for standard parsing)
             .Ignore(Span.WhiteSpace)

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
@@ -24,6 +24,9 @@ public static class MappingTokenizer
     public static Tokenizer<MappingTokenKind> CreateWithTrivia()
     {
         return new TokenizerBuilder<MappingTokenKind>()
+            // Metadata declarations (must precede the comment rules - '///' is a prefix of '//')
+            .Match(Span.Regex(@"///[^\r\n]*"), MappingTokenKind.MetadataLine, requireDelimiters: false)
+
             // Comments (must come before other operators to avoid capturing // as division)
             .Match(Comment.CStyle, MappingTokenKind.BlockComment, requireDelimiters: true)
             .Match(Comment.CPlusPlusStyle, MappingTokenKind.LineComment)
@@ -127,6 +130,9 @@ public static class MappingTokenizer
     public static Tokenizer<MappingTokenKind> Create()
     {
         return new TokenizerBuilder<MappingTokenKind>()
+            // Metadata declarations (must precede the comment rules - '///' is a prefix of '//')
+            .Match(Span.Regex(@"///[^\r\n]*"), MappingTokenKind.MetadataLine, requireDelimiters: false)
+
             // Comments (ignore for standard parsing)
             .Ignore(Comment.CStyle)
             .Ignore(Comment.CPlusPlusStyle)

--- a/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Lexer/MappingTokenizer.cs
@@ -68,9 +68,9 @@ public static class MappingTokenizer
             // String literals (single-quoted, SQL-style escaping)
             .Match(QuotedString.SqlStyle, MappingTokenKind.StringLiteral)
 
-            // Delimited identifiers (backtick or double-quote style)
+            // Delimited identifiers (backtick) and double-quoted strings
             .Match(Span.Regex("`[^`]*`"), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
-            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
+            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DoubleQuotedString, requireDelimiters: false)
 
             // Numeric literals
             .Match(Span.Regex(@"[0-9]+\.[0-9]+"), MappingTokenKind.DecimalLiteral, requireDelimiters: true)
@@ -168,9 +168,9 @@ public static class MappingTokenizer
             // String literals (single-quoted, SQL-style escaping)
             .Match(QuotedString.SqlStyle, MappingTokenKind.StringLiteral)
 
-            // Delimited identifiers (backtick or double-quote style)
+            // Delimited identifiers (backtick) and double-quoted strings
             .Match(Span.Regex("`[^`]*`"), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
-            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DelimitedIdentifier, requireDelimiters: false)
+            .Match(Span.Regex("\"([^\"\\\\]|\\\\.)*\""), MappingTokenKind.DoubleQuotedString, requireDelimiters: false)
 
             // Numeric literals
             .Match(Span.Regex(@"[0-9]+\.[0-9]+"), MappingTokenKind.DecimalLiteral, requireDelimiters: true)

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -552,8 +552,8 @@ internal static class MappingGrammar
             parameters,
             extends,
             rules,
-            CreatePosition(groupToken),
-            typeMode);
+            typeMode,
+            CreatePosition(groupToken));
 
     // Map: map "url" = "Identifier" [conceptMaps]* [uses]* [imports]* [constants]* [groups]*
     public static readonly TokenListParser<MappingTokenKind, MapExpression> Map =

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -61,6 +61,29 @@ internal static class MappingGrammar
         return id;
     }
 
+    // Helper: reconstruct the original source text spanned by a token run.
+    // Re-serializing tokens loses whitespace, which corrupts embedded FHIRPath
+    // (e.g. "linkId.value in (...)" would collapse to "linkId.valuein(...)").
+    private static string SourceTextOf(IReadOnlyList<Token<MappingTokenKind>> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var source = tokens[0].Span.Source;
+        if (source is null)
+        {
+            throw new InvalidOperationException(
+                "SourceTextOf requires tokens produced from the parsed input; token span has no source.");
+        }
+
+        var start = (int)tokens[0].Position.Absolute;
+        var last = tokens[^1];
+        var end = (int)last.Position.Absolute + last.Span.Length;
+        return source.Substring(start, end - start);
+    }
+
     // Literal parsers
     private static readonly TokenListParser<MappingTokenKind, LiteralExpression> StringLiteral =
         Token.EqualTo(MappingTokenKind.StringLiteral)
@@ -136,7 +159,7 @@ internal static class MappingGrammar
                             lastToken = rightParenResult.Value;
                             current = rightParenResult.Remainder;
                             var expr = new FhirPathExpression(
-                                string.Join("", tokens.Select(t => t.ToStringValue())),
+                                SourceTextOf(tokens),
                                 CreatePosition(lparen.Value, lastToken));
                             return TokenListParserResult.Value(expr, input, current);
                         }
@@ -221,7 +244,7 @@ internal static class MappingGrammar
                     return TokenListParserResult.Empty<MappingTokenKind, FhirPathExpression>(input);
 
                 var expr = new FhirPathExpression(
-                    string.Join("", tokens.Select(t => t.ToStringValue())),
+                    SourceTextOf(tokens),
                     CreatePosition(tokens[0], lastToken!.Value));
                 return TokenListParserResult.Value(expr, input, current);
             }

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -519,13 +519,14 @@ internal static class MappingGrammar
 
     // Group type mode annotation: <<types>> or <<type+>>
     // Note: '<<' is two LeftAngle tokens - the lexer deliberately has no '<<' token.
+    // The grammar is closed: only <<types>> and <<type+>> are valid; <<type>> is rejected.
     private static readonly TokenListParser<MappingTokenKind, GroupTypeMode> GroupTypeModeAnnotation =
         from open1 in Token.EqualTo(MappingTokenKind.LeftAngle)
         from open2 in Token.EqualTo(MappingTokenKind.LeftAngle)
         from mode in Token.EqualTo(MappingTokenKind.Types).Value(GroupTypeMode.Types)
             .Or(from typeToken in Token.EqualTo(MappingTokenKind.Type)
-                from plus in Token.EqualTo(MappingTokenKind.Plus).Optional()
-                select plus.HasValue ? GroupTypeMode.TypeAndTypes : GroupTypeMode.Types)
+                from plus in Token.EqualTo(MappingTokenKind.Plus)
+                select GroupTypeMode.TypeAndTypes)
         from close1 in Token.EqualTo(MappingTokenKind.RightAngle)
         from close2 in Token.EqualTo(MappingTokenKind.RightAngle)
         select mode;

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -42,19 +42,28 @@ internal static class MappingGrammar
     // Helper: Unescape string
     private static string UnescapeString(string str)
     {
-        if (str.StartsWith('\'') && str.EndsWith('\''))
+        if (str.StartsWith('\'') && str.EndsWith('\'') && str.Length >= 2)
         {
             str = str.Substring(1, str.Length - 2);
             str = str.Replace("''", "'", StringComparison.Ordinal);
+            return str;
         }
+
+        if (str.StartsWith('"') && str.EndsWith('"') && str.Length >= 2)
+        {
+            str = str.Substring(1, str.Length - 2);
+            str = str.Replace("\\\"", "\"", StringComparison.Ordinal)
+                     .Replace("\\\\", "\\", StringComparison.Ordinal);
+            return str;
+        }
+
         return str;
     }
 
     // Helper: Unescape identifier
     private static string UnescapeIdentifier(string id)
     {
-        if ((id.StartsWith('`') && id.EndsWith('`')) ||
-            (id.StartsWith('"') && id.EndsWith('"')))
+        if (id.StartsWith('`') && id.EndsWith('`'))
         {
             return id.Substring(1, id.Length - 2);
         }
@@ -87,6 +96,7 @@ internal static class MappingGrammar
     // Literal parsers
     private static readonly TokenListParser<MappingTokenKind, LiteralExpression> StringLiteral =
         Token.EqualTo(MappingTokenKind.StringLiteral)
+            .Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))
             .Select(t => new LiteralExpression(UnescapeString(t.ToStringValue()), CreatePosition(t)));
 
     private static readonly TokenListParser<MappingTokenKind, LiteralExpression> IntegerLiteral =
@@ -496,7 +506,7 @@ internal static class MappingGrammar
     // ConceptMap declaration: conceptmap "#id" { prefixes codeMaps }
     private static readonly TokenListParser<MappingTokenKind, ConceptMapDeclarationExpression> ConceptMapDeclaration =
         from cmToken in Token.EqualTo(MappingTokenKind.ConceptMap)
-        from id in Token.EqualTo(MappingTokenKind.StringLiteral).Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier))
+        from id in Token.EqualTo(MappingTokenKind.StringLiteral).Or(Token.EqualTo(MappingTokenKind.DelimitedIdentifier)).Or(Token.EqualTo(MappingTokenKind.DoubleQuotedString))
         from lbrace in Token.EqualTo(MappingTokenKind.LeftBrace)
         from prefixes in ConceptMapPrefix.Many()
         from codeMaps in ConceptMapCodeMap.Many()

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -94,11 +94,10 @@ internal static class MappingGrammar
         return source.Substring(start, end - start);
     }
 
-    // Paren-branch logic shared by FhirPathExpression and ParenthesizedFhirPathExpression.
-    // Matches '(' tokens... ')' with balanced depth tracking; returns a FhirPathExpression
-    // built from the inner source text. Returns Empty when input does not start with '('.
     private static readonly string[] UnmatchedParenErrorMessages = ["unmatched parentheses in FHIRPath expression"];
 
+    // Shared by FhirPathExpression and ParenthesizedFhirPathExpression. Returns Empty rather than
+    // failing hard when input does not start with '(', so callers can fall through to other alternatives.
     private static TokenListParserResult<MappingTokenKind, FhirPathExpression> ParseParenthesizedFhirPath(
         TokenList<MappingTokenKind> input)
     {
@@ -404,9 +403,9 @@ internal static class MappingGrammar
             defaultValue,
             cardinality);
 
-    // Parenthesized FHIRPath expression: '(' fpExpression ')'
-    // Implements the grammar rule: transform = '(' fpExpression ')'.
-    // Uses the shared paren-branch logic; does not fall back to an unparenthesized form.
+    // Grammar rule: transform = '(' fpExpression ')'. Deliberately parenthesized-only — falling back
+    // to an unparenthesized form would let FhirPathExpression's greedy branch swallow a trailing
+    // 'as <var>' and rule name, since neither is in its terminator set.
     private static readonly TokenListParser<MappingTokenKind, FhirPathExpression> ParenthesizedFhirPathExpression =
         ParseParenthesizedFhirPath;
 

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -94,6 +94,75 @@ internal static class MappingGrammar
         return source.Substring(start, end - start);
     }
 
+    // Paren-branch logic shared by FhirPathExpression and ParenthesizedFhirPathExpression.
+    // Matches '(' tokens... ')' with balanced depth tracking; returns a FhirPathExpression
+    // built from the inner source text. Returns Empty when input does not start with '('.
+    private static readonly string[] UnmatchedParenErrorMessages = ["unmatched parentheses in FHIRPath expression"];
+
+    private static TokenListParserResult<MappingTokenKind, FhirPathExpression> ParseParenthesizedFhirPath(
+        TokenList<MappingTokenKind> input)
+    {
+        var lparen = Token.EqualTo(MappingTokenKind.LeftParen)(input);
+        if (!lparen.HasValue)
+            return TokenListParserResult.Empty<MappingTokenKind, FhirPathExpression>(input);
+
+        List<Token<MappingTokenKind>> tokens = [];
+        var current = lparen.Remainder;
+        var depth = 0;
+        Token<MappingTokenKind> lastToken = lparen.Value;
+
+        while (!current.IsAtEnd)
+        {
+            var leftParenResult = Token.EqualTo(MappingTokenKind.LeftParen)(current);
+            if (leftParenResult.HasValue)
+            {
+                depth++;
+                tokens.Add(leftParenResult.Value);
+                lastToken = leftParenResult.Value;
+                current = leftParenResult.Remainder;
+                continue;
+            }
+
+            var rightParenResult = Token.EqualTo(MappingTokenKind.RightParen)(current);
+            if (rightParenResult.HasValue)
+            {
+                if (depth == 0)
+                {
+                    lastToken = rightParenResult.Value;
+                    current = rightParenResult.Remainder;
+                    var expr = new FhirPathExpression(
+                        SourceTextOf(tokens),
+                        CreatePosition(lparen.Value, lastToken));
+                    return TokenListParserResult.Value(expr, input, current);
+                }
+                else
+                {
+                    depth--;
+                    tokens.Add(rightParenResult.Value);
+                    lastToken = rightParenResult.Value;
+                    current = rightParenResult.Remainder;
+                    continue;
+                }
+            }
+
+            var anyToken = Token.Matching<MappingTokenKind>(_ => true, "any token")(current);
+            if (anyToken.HasValue)
+            {
+                tokens.Add(anyToken.Value);
+                lastToken = anyToken.Value;
+                current = anyToken.Remainder;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return TokenListParserResult.Empty<MappingTokenKind, FhirPathExpression>(
+            input,
+            UnmatchedParenErrorMessages);
+    }
+
     // Literal parsers
     private static readonly TokenListParser<MappingTokenKind, LiteralExpression> StringLiteral =
         Token.EqualTo(MappingTokenKind.StringLiteral)
@@ -140,67 +209,7 @@ internal static class MappingGrammar
 
             if (lparen.HasValue)
             {
-                // Parenthesized expression - collect until matching close paren
-                List<Token<MappingTokenKind>> tokens = [];
-                var current = lparen.Remainder;
-                var depth = 0;
-                Token<MappingTokenKind> lastToken = lparen.Value;
-
-                // Capture tokens until we find the matching closing paren
-                while (!current.IsAtEnd)
-                {
-                    // Try to match a left paren
-                    var leftParenResult = Token.EqualTo(MappingTokenKind.LeftParen)(current);
-                    if (leftParenResult.HasValue)
-                    {
-                        depth++;
-                        tokens.Add(leftParenResult.Value);
-                        lastToken = leftParenResult.Value;
-                        current = leftParenResult.Remainder;
-                        continue;
-                    }
-
-                    // Try to match a right paren
-                    var rightParenResult = Token.EqualTo(MappingTokenKind.RightParen)(current);
-                    if (rightParenResult.HasValue)
-                    {
-                        if (depth == 0)
-                        {
-                            // Found matching closing paren - consume it and return
-                            lastToken = rightParenResult.Value;
-                            current = rightParenResult.Remainder;
-                            var expr = new FhirPathExpression(
-                                SourceTextOf(tokens),
-                                CreatePosition(lparen.Value, lastToken));
-                            return TokenListParserResult.Value(expr, input, current);
-                        }
-                        else
-                        {
-                            depth--;
-                            tokens.Add(rightParenResult.Value);
-                            lastToken = rightParenResult.Value;
-                            current = rightParenResult.Remainder;
-                            continue;
-                        }
-                    }
-
-                    // Match any other token
-                    var anyToken = Token.Matching<MappingTokenKind>(_ => true, "any token")(current);
-                    if (anyToken.HasValue)
-                    {
-                        tokens.Add(anyToken.Value);
-                        lastToken = anyToken.Value;
-                        current = anyToken.Remainder;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-
-                return TokenListParserResult.Empty<MappingTokenKind, FhirPathExpression>(
-                    input,
-                    new[] { "unmatched parentheses in FHIRPath expression" });
+                return ParseParenthesizedFhirPath(input);
             }
             else
             {
@@ -395,6 +404,12 @@ internal static class MappingGrammar
             defaultValue,
             cardinality);
 
+    // Parenthesized FHIRPath expression: '(' fpExpression ')'
+    // Implements the grammar rule: transform = '(' fpExpression ')'.
+    // Uses the shared paren-branch logic; does not fall back to an unparenthesized form.
+    private static readonly TokenListParser<MappingTokenKind, FhirPathExpression> ParenthesizedFhirPathExpression =
+        ParseParenthesizedFhirPath;
+
     // Target: [context] [= expression] [as variable] [list mode]
     // Note: The order is context -> expression -> as variable -> list mode
     // This matches FHIR spec: "tgt.name = create('Type') as variable listmode"
@@ -409,6 +424,7 @@ internal static class MappingGrammar
                 .Or(DecimalLiteral.Select(l => (Expression)l))
                 .Or(BooleanLiteral.Select(l => (Expression)l))
                 .Or(Transform.Select(t => (Expression)t).Try())
+                .Or(ParenthesizedFhirPathExpression.Select(e => (Expression)e))
                 .Or(QualifiedIdentifier)
             select expr
         ).OptionalOrDefault()

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -596,12 +596,11 @@ internal static class MappingGrammar
         ConstantDeclarationExpression[] constants,
         GroupExpression[] groups)
     {
-        var metaDict = metadataLines
-            .Where(kvp => kvp.HasValue)
-            .ToDictionary(
-                kvp => kvp!.Value.Key,
-                kvp => kvp!.Value.Value,
-                StringComparer.Ordinal);
+        var metaDict = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var kvp in metadataLines.Where(kvp => kvp.HasValue).Select(kvp => kvp!.Value))
+        {
+            metaDict[kvp.Key] = kvp.Value;
+        }
 
         var url = header?.Url ?? (metaDict.GetValueOrDefault("url") ?? string.Empty);
         var identifier = header?.Identifier ?? (metaDict.GetValueOrDefault("name") ?? string.Empty);

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -517,7 +517,20 @@ internal static class MappingGrammar
             codeMaps.Any() ? [new ConceptMapGroupExpression(null, null, codeMaps)] : [],
             CreatePosition(cmToken));
 
-    // Group: group Name(params) [extends OtherGroup] { rules }
+    // Group type mode annotation: <<types>> or <<type+>>
+    // Note: '<<' is two LeftAngle tokens - the lexer deliberately has no '<<' token.
+    private static readonly TokenListParser<MappingTokenKind, GroupTypeMode> GroupTypeModeAnnotation =
+        from open1 in Token.EqualTo(MappingTokenKind.LeftAngle)
+        from open2 in Token.EqualTo(MappingTokenKind.LeftAngle)
+        from mode in Token.EqualTo(MappingTokenKind.Types).Value(GroupTypeMode.Types)
+            .Or(from typeToken in Token.EqualTo(MappingTokenKind.Type)
+                from plus in Token.EqualTo(MappingTokenKind.Plus).Optional()
+                select plus.HasValue ? GroupTypeMode.TypeAndTypes : GroupTypeMode.Types)
+        from close1 in Token.EqualTo(MappingTokenKind.RightAngle)
+        from close2 in Token.EqualTo(MappingTokenKind.RightAngle)
+        select mode;
+
+    // Group: group Name(params) [extends OtherGroup] [<<typeMode>>] { rules }
     private static readonly TokenListParser<MappingTokenKind, GroupExpression> Group =
         from groupToken in Token.EqualTo(MappingTokenKind.Group)
         from name in Identifier
@@ -529,6 +542,7 @@ internal static class MappingGrammar
             from extendName in Identifier
             select extendName.Name
         ).OptionalOrDefault()
+        from typeMode in GroupTypeModeAnnotation.OptionalOrDefault(GroupTypeMode.None)
         from lbrace in Token.EqualTo(MappingTokenKind.LeftBrace)
         from rules in Rule.Many()
         from rbrace in Token.EqualTo(MappingTokenKind.RightBrace)
@@ -537,7 +551,8 @@ internal static class MappingGrammar
             parameters,
             extends,
             rules,
-            CreatePosition(groupToken));
+            CreatePosition(groupToken),
+            typeMode);
 
     // Map: map "url" = "Identifier" [conceptMaps]* [uses]* [imports]* [constants]* [groups]*
     public static readonly TokenListParser<MappingTokenKind, MapExpression> Map =

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -10,6 +10,7 @@ using Ignixa.FhirMappingLanguage.Lexer;
 using Superpower;
 using Superpower.Model;
 using Superpower.Parsers;
+using System.Text.RegularExpressions;
 
 namespace Ignixa.FhirMappingLanguage.Parser;
 
@@ -556,23 +557,74 @@ internal static class MappingGrammar
             CreatePosition(groupToken));
 
     // Map: map "url" = "Identifier" [conceptMaps]* [uses]* [imports]* [constants]* [groups]*
-    public static readonly TokenListParser<MappingTokenKind, MapExpression> Map =
-        from mapToken in Token.EqualTo(MappingTokenKind.Map)
+    //   OR metadata-based R6 form: /// key = 'value' … [groups]*
+    private static readonly Regex MetadataLinePattern = new(
+        @"^///\s*(?<key>[A-Za-z_][A-Za-z0-9_.\-]*)\s*=\s*(?<value>.*?)\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly TokenListParser<MappingTokenKind, KeyValuePair<string, string>?> MetadataDeclaration =
+        Token.EqualTo(MappingTokenKind.MetadataLine)
+            .Select(t =>
+            {
+                var match = MetadataLinePattern.Match(t.ToStringValue());
+                if (!match.Success)
+                {
+                    return (KeyValuePair<string, string>?)null;
+                }
+
+                return new KeyValuePair<string, string>(
+                    match.Groups["key"].Value,
+                    UnescapeString(match.Groups["value"].Value));
+            });
+
+    private sealed record MapHeaderInfo(string Url, string Identifier, ISourcePositionInfo Position);
+
+    private static readonly TokenListParser<MappingTokenKind, MapHeaderInfo?> MapHeader =
+        (from mapToken in Token.EqualTo(MappingTokenKind.Map)
         from url in StringLiteral
         from equalsToken in Token.EqualTo(MappingTokenKind.Equals)
         from identifier in StringLiteral
-        from conceptMaps in ConceptMapDeclaration.Many()
-        from uses in Uses.Many()
-        from imports in Imports.Many()
-        from constants in Constant.Many()
-        from groups in Group.Many()
-        select new MapExpression(
-            url.Value.ToString()!,
-            identifier.Value.ToString()!,
+        select new MapHeaderInfo(url.Value.ToString()!, identifier.Value.ToString()!, CreatePosition(mapToken)))
+        .Select(h => (MapHeaderInfo?)h);
+
+    private static MapExpression BuildMap(
+        KeyValuePair<string, string>?[] metadataLines,
+        MapHeaderInfo? header,
+        ConceptMapDeclarationExpression[] conceptMaps,
+        UsesExpression[] uses,
+        ImportsExpression[] imports,
+        ConstantDeclarationExpression[] constants,
+        GroupExpression[] groups)
+    {
+        var metaDict = metadataLines
+            .Where(kvp => kvp.HasValue)
+            .ToDictionary(
+                kvp => kvp!.Value.Key,
+                kvp => kvp!.Value.Value,
+                StringComparer.Ordinal);
+
+        var url = header?.Url ?? (metaDict.GetValueOrDefault("url") ?? string.Empty);
+        var identifier = header?.Identifier ?? (metaDict.GetValueOrDefault("name") ?? string.Empty);
+
+        return new MapExpression(
+            url,
+            identifier,
             uses,
             imports,
             groups,
             conceptMaps,
             constants,
-            CreatePosition(mapToken));
+            metaDict,
+            header?.Position);
+    }
+
+    public static readonly TokenListParser<MappingTokenKind, MapExpression> Map =
+        from metadataLines in MetadataDeclaration.Many()
+        from header in MapHeader.OptionalOrDefault()
+        from conceptMaps in ConceptMapDeclaration.Many()
+        from uses in Uses.Many()
+        from imports in Imports.Many()
+        from constants in Constant.Many()
+        from groups in Group.Many()
+        select BuildMap(metadataLines, header, conceptMaps, uses, imports, constants, groups);
 }

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingGrammar.cs
@@ -559,17 +559,19 @@ internal static class MappingGrammar
     // Map: map "url" = "Identifier" [conceptMaps]* [uses]* [imports]* [constants]* [groups]*
     //   OR metadata-based R6 form: /// key = 'value' … [groups]*
     private static readonly Regex MetadataLinePattern = new(
-        @"^///\s*(?<key>[A-Za-z_][A-Za-z0-9_.\-]*)\s*=\s*(?<value>.*?)\s*$",
+        @"^///\s+(?<key>[A-Za-z_][A-Za-z0-9_.\-]*)\s*=\s*(?<value>.*?)\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly TokenListParser<MappingTokenKind, KeyValuePair<string, string>?> MetadataDeclaration =
+    private static readonly TokenListParser<MappingTokenKind, KeyValuePair<string, string>> MetadataDeclaration =
         Token.EqualTo(MappingTokenKind.MetadataLine)
             .Select(t =>
             {
                 var match = MetadataLinePattern.Match(t.ToStringValue());
                 if (!match.Success)
                 {
-                    return (KeyValuePair<string, string>?)null;
+                    throw new ParseException(
+                        $"Malformed metadata declaration at line {t.Position.Line}, column {t.Position.Column}: expected '/// key = value' format.",
+                        t.Position);
                 }
 
                 return new KeyValuePair<string, string>(
@@ -588,7 +590,7 @@ internal static class MappingGrammar
         .Select(h => (MapHeaderInfo?)h);
 
     private static MapExpression BuildMap(
-        KeyValuePair<string, string>?[] metadataLines,
+        KeyValuePair<string, string>[] metadataLines,
         MapHeaderInfo? header,
         ConceptMapDeclarationExpression[] conceptMaps,
         UsesExpression[] uses,
@@ -597,7 +599,7 @@ internal static class MappingGrammar
         GroupExpression[] groups)
     {
         var metaDict = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var kvp in metadataLines.Where(kvp => kvp.HasValue).Select(kvp => kvp!.Value))
+        foreach (var kvp in metadataLines)
         {
             metaDict[kvp.Key] = kvp.Value;
         }

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
@@ -66,6 +66,15 @@ public class MappingParser
                     result.ErrorPosition);
             }
 
+            if (result.Value.Groups.Count == 0 &&
+                string.IsNullOrEmpty(result.Value.Url) &&
+                string.IsNullOrEmpty(result.Value.Identifier))
+            {
+                throw new ParseException(
+                    "The input contains no map header, metadata declarations, or groups.",
+                    Position.Zero);
+            }
+
             return result.Value;
         }
         catch (ParseException)

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
@@ -66,12 +66,10 @@ public class MappingParser
                     result.ErrorPosition);
             }
 
-            if (result.Value.Groups.Count == 0 &&
-                string.IsNullOrEmpty(result.Value.Url) &&
-                string.IsNullOrEmpty(result.Value.Identifier))
+            if (result.Value.Groups.Count == 0)
             {
                 throw new ParseException(
-                    "The input has no groups and no url or name from a map header or metadata declarations.",
+                    "The input has no group declarations; at least one group is required.",
                     Position.Zero);
             }
 

--- a/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Parser/MappingParser.cs
@@ -71,7 +71,7 @@ public class MappingParser
                 string.IsNullOrEmpty(result.Value.Identifier))
             {
                 throw new ParseException(
-                    "The input contains no map header, metadata declarations, or groups.",
+                    "The input has no groups and no url or name from a map header or metadata declarations.",
                     Position.Zero);
             }
 

--- a/src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs
@@ -211,6 +211,12 @@ public class FmlSerializer
             context.Append($" extends {group.Extends}");
         }
 
+        // Type-mode annotation
+        if (group.TypeMode != GroupTypeMode.None)
+        {
+            context.Append(group.TypeMode == GroupTypeMode.TypeAndTypes ? " <<type+>>" : " <<types>>");
+        }
+
         // Rules
         if (group.Rules.Count == 0)
         {

--- a/src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Serialization/FmlSerializer.cs
@@ -186,7 +186,7 @@ public class FmlSerializer
 
     /// <summary>
     /// Serializes a group definition.
-    /// Format: group Name(parameters) extends Base { rules }
+    /// Format: group Name(parameters) [extends Base] [&lt;&lt;types&gt;&gt;|&lt;&lt;type+&gt;&gt;] { rules }
     /// </summary>
     private void SerializeGroup(GroupExpression group, SerializationContext context)
     {

--- a/src/Core/Ignixa.FhirMappingLanguage/Serialization/StructureMapBuilder.cs
+++ b/src/Core/Ignixa.FhirMappingLanguage/Serialization/StructureMapBuilder.cs
@@ -116,7 +116,18 @@ public class StructureMapBuilder
         // element optional, so omit it there rather than writing a value R5 doesn't accept.
         if (_targetVersion < FhirVersion.R5)
         {
-            groupNode.MutableNode["typeMode"] = "none";
+            groupNode.MutableNode["typeMode"] = group.TypeMode switch
+            {
+                GroupTypeMode.Types => "types",
+                GroupTypeMode.TypeAndTypes => "type-and-types",
+                _ => "none"
+            };
+        }
+        else if (group.TypeMode != GroupTypeMode.None)
+        {
+            groupNode.MutableNode["typeMode"] = group.TypeMode == GroupTypeMode.TypeAndTypes
+                ? "type-and-types"
+                : "types";
         }
 
         // Add input parameters

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJson.cs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Structural JSON canonicalization for oracle comparison.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Renders JSON in a canonical form so that formatting and object property order
+/// do not affect comparison. Array order is preserved because it is semantically
+/// significant in FHIR.
+/// </summary>
+public static class CanonicalJson
+{
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>
+    /// Parses <paramref name="json"/> and re-renders it with object properties sorted
+    /// by ordinal name.
+    /// </summary>
+    public static string Canonicalize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var node = JsonNode.Parse(json, documentOptions: new JsonDocumentOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        });
+
+        return Sort(node)?.ToJsonString(WriteOptions) ?? "null";
+    }
+
+    private static JsonNode? Sort(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+            {
+                var sorted = new JsonObject();
+                foreach (var property in obj.OrderBy(p => p.Key, StringComparer.Ordinal))
+                {
+                    sorted[property.Key] = Sort(property.Value?.DeepClone());
+                }
+
+                return sorted;
+            }
+
+            case JsonArray array:
+            {
+                var result = new JsonArray();
+                foreach (var item in array)
+                {
+                    result.Add(Sort(item?.DeepClone()));
+                }
+
+                return result;
+            }
+
+            default:
+                return node?.DeepClone();
+        }
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Tests for CanonicalJson structural JSON canonicalization.
+ */
+
+using System;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class CanonicalJsonTests
+{
+    [Fact]
+    public void GivenTwoObjectsDifferingOnlyByWhitespace_WhenCanonicalizing_ThenTheResultsMatch()
+    {
+        // Arrange
+        var withSpaces = """{"resourceType" : "Patient", "gender" : "female"}""";
+        var withoutSpaces = """{"resourceType":"Patient","gender":"female"}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(withSpaces).ShouldBe(CanonicalJson.Canonicalize(withoutSpaces));
+    }
+
+    [Fact]
+    public void GivenTwoObjectsDifferingOnlyByPropertyOrder_WhenCanonicalizing_ThenTheResultsMatch()
+    {
+        // Arrange
+        var genderFirst = """{"gender":"female","resourceType":"Patient"}""";
+        var resourceTypeFirst = """{"resourceType":"Patient","gender":"female"}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(genderFirst).ShouldBe(CanonicalJson.Canonicalize(resourceTypeFirst));
+    }
+
+    [Fact]
+    public void GivenArraysInDifferentOrder_WhenCanonicalizing_ThenTheResultsDiffer()
+    {
+        // Arrange
+        var abOrder = """{"given":["a","b"]}""";
+        var baOrder = """{"given":["b","a"]}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(abOrder).ShouldNotBe(CanonicalJson.Canonicalize(baOrder));
+    }
+
+    [Fact]
+    public void GivenNonAsciiText_WhenCanonicalizing_ThenTheCharactersAreNotEscaped()
+    {
+        // Arrange
+        var json = """{"family":"Brönnimann-Bertholet"}""";
+
+        // Act
+        var result = CanonicalJson.Canonicalize(json);
+
+        // Assert
+        result.ShouldContain("Brönnimann-Bertholet");
+    }
+
+    // Proves Sort() recurses into nested object values, not just top-level properties.
+    [Fact]
+    public void GivenNestedObjectWithDifferentPropertyOrder_WhenCanonicalizing_ThenResultsMatch()
+    {
+        // Arrange
+        var familyFirst = """{"name":{"family":"X","given":"Y"}}""";
+        var givenFirst = """{"name":{"given":"Y","family":"X"}}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(familyFirst).ShouldBe(CanonicalJson.Canonicalize(givenFirst));
+    }
+
+    // Proves Sort() recurses through array elements into the objects they contain.
+    [Fact]
+    public void GivenObjectInsideArrayWithDifferentPropertyOrder_WhenCanonicalizing_ThenResultsMatch()
+    {
+        // Arrange
+        var familyFirst = """{"name":[{"family":"X","given":"Y"}]}""";
+        var givenFirst = """{"name":[{"given":"Y","family":"X"}]}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(familyFirst).ShouldBe(CanonicalJson.Canonicalize(givenFirst));
+    }
+
+    // Proves an implementation that discards values cannot pass by returning a constant.
+    [Fact]
+    public void GivenObjectsWithDifferentValues_WhenCanonicalizing_ThenResultsDiffer()
+    {
+        // Arrange
+        var female = """{"gender":"female"}""";
+        var male = """{"gender":"male"}""";
+
+        // Act / Assert
+        CanonicalJson.Canonicalize(female).ShouldNotBe(CanonicalJson.Canonicalize(male));
+    }
+
+    // Pins the exact canonical form: keys sorted by ordinal, WriteIndented=true (2-space indent).
+    // Environment.NewLine is correct because System.Text.Json uses it for indented output.
+    [Fact]
+    public void GivenTwoPropertyObject_WhenCanonicalizing_ThenOutputMatchesExpectedForm()
+    {
+        // Arrange
+        var json = """{"gender":"female","resourceType":"Patient"}""";
+        // "gender" < "resourceType" under StringComparer.Ordinal ('g' < 'r')
+        var nl = Environment.NewLine;
+        var expected = $"{{{nl}  \"gender\": \"female\",{nl}  \"resourceType\": \"Patient\"{nl}}}";
+
+        // Act
+        var result = CanonicalJson.Canonicalize(json);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    // Guards: ArgumentException.ThrowIfNullOrWhiteSpace sets ParamName to the argument expression.
+    // Asserting ParamName prevents a false pass from an unrelated call throwing the same exception type.
+    [Fact]
+    public void GivenNullInput_WhenCanonicalizing_ThenThrowsArgumentExceptionWithCorrectParamName()
+    {
+        var exception = Should.Throw<ArgumentException>(() => CanonicalJson.Canonicalize(null!));
+        exception.ParamName.ShouldBe("json");
+    }
+
+    [Fact]
+    public void GivenEmptyInput_WhenCanonicalizing_ThenThrowsArgumentExceptionWithCorrectParamName()
+    {
+        var exception = Should.Throw<ArgumentException>(() => CanonicalJson.Canonicalize(""));
+        exception.ParamName.ShouldBe("json");
+    }
+
+    [Fact]
+    public void GivenWhitespaceOnlyInput_WhenCanonicalizing_ThenThrowsArgumentExceptionWithCorrectParamName()
+    {
+        var exception = Should.Throw<ArgumentException>(() => CanonicalJson.Canonicalize("   "));
+        exception.ParamName.ShouldBe("json");
+    }
+
+    // Canonicalized output is itself valid input: a second pass produces an identical string.
+    [Fact]
+    public void GivenCanonicalized_WhenCanonicalizingAgain_ThenResultIsUnchanged()
+    {
+        // Arrange
+        var json = """{"resourceType":"Patient","name":[{"given":["John"],"family":"Doe"}],"gender":"male"}""";
+
+        // Act
+        var once = CanonicalJson.Canonicalize(json);
+        var twice = CanonicalJson.Canonicalize(once);
+
+        // Assert
+        twice.ShouldBe(once);
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/CanonicalJsonTests.cs
@@ -112,15 +112,9 @@ public class CanonicalJsonTests
         result.ShouldBe(expected);
     }
 
-    // Guards: ArgumentException.ThrowIfNullOrWhiteSpace sets ParamName to the argument expression.
-    // Asserting ParamName prevents a false pass from an unrelated call throwing the same exception type.
-    [Fact]
-    public void GivenNullInput_WhenCanonicalizing_ThenThrowsArgumentExceptionWithCorrectParamName()
-    {
-        var exception = Should.Throw<ArgumentException>(() => CanonicalJson.Canonicalize(null!));
-        exception.ParamName.ShouldBe("json");
-    }
-
+    // ParamName is asserted so these fail if some unrelated call throws ArgumentException instead.
+    // Null is deliberately not covered: JsonNode.Parse throws ArgumentNullException with the same
+    // ParamName, so such a test would pass whether or not the guard exists.
     [Fact]
     public void GivenEmptyInput_WhenCanonicalizing_ThenThrowsArgumentExceptionWithCorrectParamName()
     {

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
@@ -34,51 +34,35 @@ public class FmlCorpusParseTests(ITestOutputHelper output)
     ///   (b) explicitly deferred — known out-of-scope construct
     ///   (c) other — new/unknown failure mode
     ///
-    /// All current failures are classification (a): the parser does not handle parenthesized
-    /// expressions `(expr)` when they appear as target-value assignments (e.g. `tgt.x = (expr)`)
-    /// or as arguments to transform function calls (e.g. `evaluate(src, iif(...))`).
-    /// This is a single grammar gap not addressed by any of the five Part A fixes.
-    /// Root cause: "unexpected leftparen `(`, expected …" in target-value or transform position.
+    /// qr2cda-eval.map is classification (b): it uses nested function calls of the form
+    /// evaluate(src, iif(src.is(X),"a","b")) as a transform. The inner iif() is a
+    /// TransformArgumentExpression which the greedy FhirPathExpression fallback cannot safely
+    /// expand without a parenthesised-only guard — and the RightParen that closes iif() is
+    /// not in the fallback terminator set. This construct is explicitly deferred: the file
+    /// produces XML-format CDA output and is excluded from the end-to-end oracle.
     /// </summary>
     public static TheoryData<string, int, string[]> CorpusTheoryData() => new()
     {
         // r5: 15 .map files measured in vendored release 1.7.46.
-        // parsed: 9/15
-        // Failures — all (a) parenthesized-expression gap:
-        //   qr2cda-eval.map        line 7  col 50  title.data= evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad")) "eval"
-        //   qr2pat-gender.map      line 11 col 74  tgt.gender = (item.answer.valueString)
-        //   qr2pat-humannameshared.map line 14 col 71  tgt.gender = (item.answer.valueString)
-        //   qr2pat-humannametwice.map  line 14 col 71  tgt.gender = (item.answer.valueString)
-        //   qr2patfordates.map     line 9  col 42  tgt.birthDate = (%value + 5 days) "plus"
-        //   syntax.map             line 17 col 45  ext.system = ('urn:uuid:' + r.lower()) "rootuuid"
+        // parsed: 14/15
+        // Remaining failure — classification (b) explicitly deferred:
+        //   qr2cda-eval.map: evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad"))
+        //   nested iif() inside evaluate() — greedy-swallow hazard; CDA output excluded from oracle.
         {
             "r5", 15,
             [
                 "qr2cda-eval.map",
-                "qr2pat-gender.map",
-                "qr2pat-humannameshared.map",
-                "qr2pat-humannametwice.map",
-                "qr2patfordates.map",
-                "syntax.map",
             ]
         },
 
         // r4b: 12 .map files measured in vendored release 1.7.46.
-        // parsed: 7/12
-        // Failures — all (a) parenthesized-expression gap:
-        //   qr2cda-eval.map        line 7  col 50  title.data= evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad")) "eval"
-        //   qr2pat-gender.map      line 11 col 74  tgt.gender = (item.answer.valueString)
-        //   qr2pat-humannameshared.map line 14 col 71  tgt.gender = (item.answer.valueString)
-        //   qr2pat-humannametwice.map  line 14 col 71  tgt.gender = (item.answer.valueString)
-        //   syntax.map             line 18 col 45  ext.system = ('urn:uuid:' + r.lower()) "rootuuid"
+        // parsed: 11/12
+        // Remaining failure — classification (b) explicitly deferred:
+        //   qr2cda-eval.map: same nested evaluate/iif as r5 variant.
         {
             "r4b", 12,
             [
                 "qr2cda-eval.map",
-                "qr2pat-gender.map",
-                "qr2pat-humannameshared.map",
-                "qr2pat-humannametwice.map",
-                "syntax.map",
             ]
         },
     };

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlCorpusParseTests.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ignixa.FhirMappingLanguage.Parser;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Parses every .map in the official HL7 structure-mapping corpus and asserts both the
+/// total file count (guarding against a silent missing corpus) and the exact set of
+/// failing file names (guarding against silent regressions and silent fixes cancelling out).
+///
+/// The expected-failure set is a ratchet: removing an entry is a feature, adding one is a
+/// regression. The count assertion catches the "vacuous pass" failure mode where the glob
+/// finds zero files and zero failures look like success.
+/// </summary>
+public class FmlCorpusParseTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Theory data: version, expected total .map files, expected failing file names (sorted).
+    /// Keep entries sorted by file name (StringComparer.Ordinal) and document each with a reason.
+    ///
+    /// Failure classifications:
+    ///   (a) real Part A gap — a construct Tasks 1–5 were supposed to handle but did not
+    ///   (b) explicitly deferred — known out-of-scope construct
+    ///   (c) other — new/unknown failure mode
+    ///
+    /// All current failures are classification (a): the parser does not handle parenthesized
+    /// expressions `(expr)` when they appear as target-value assignments (e.g. `tgt.x = (expr)`)
+    /// or as arguments to transform function calls (e.g. `evaluate(src, iif(...))`).
+    /// This is a single grammar gap not addressed by any of the five Part A fixes.
+    /// Root cause: "unexpected leftparen `(`, expected …" in target-value or transform position.
+    /// </summary>
+    public static TheoryData<string, int, string[]> CorpusTheoryData() => new()
+    {
+        // r5: 15 .map files measured in vendored release 1.7.46.
+        // parsed: 9/15
+        // Failures — all (a) parenthesized-expression gap:
+        //   qr2cda-eval.map        line 7  col 50  title.data= evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad")) "eval"
+        //   qr2pat-gender.map      line 11 col 74  tgt.gender = (item.answer.valueString)
+        //   qr2pat-humannameshared.map line 14 col 71  tgt.gender = (item.answer.valueString)
+        //   qr2pat-humannametwice.map  line 14 col 71  tgt.gender = (item.answer.valueString)
+        //   qr2patfordates.map     line 9  col 42  tgt.birthDate = (%value + 5 days) "plus"
+        //   syntax.map             line 17 col 45  ext.system = ('urn:uuid:' + r.lower()) "rootuuid"
+        {
+            "r5", 15,
+            [
+                "qr2cda-eval.map",
+                "qr2pat-gender.map",
+                "qr2pat-humannameshared.map",
+                "qr2pat-humannametwice.map",
+                "qr2patfordates.map",
+                "syntax.map",
+            ]
+        },
+
+        // r4b: 12 .map files measured in vendored release 1.7.46.
+        // parsed: 7/12
+        // Failures — all (a) parenthesized-expression gap:
+        //   qr2cda-eval.map        line 7  col 50  title.data= evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad")) "eval"
+        //   qr2pat-gender.map      line 11 col 74  tgt.gender = (item.answer.valueString)
+        //   qr2pat-humannameshared.map line 14 col 71  tgt.gender = (item.answer.valueString)
+        //   qr2pat-humannametwice.map  line 14 col 71  tgt.gender = (item.answer.valueString)
+        //   syntax.map             line 18 col 45  ext.system = ('urn:uuid:' + r.lower()) "rootuuid"
+        {
+            "r4b", 12,
+            [
+                "qr2cda-eval.map",
+                "qr2pat-gender.map",
+                "qr2pat-humannameshared.map",
+                "qr2pat-humannametwice.map",
+                "syntax.map",
+            ]
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(CorpusTheoryData))]
+    public void GivenTheOfficialCorpus_WhenParsingEveryMap_ThenOnlyExpectedFilesFail(
+        string version,
+        int expectedTotalFiles,
+        string[] expectedFailingFileNames)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+        var files = Directory.GetFiles(directory, "*.map")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        // Guard against the "vacuous pass" failure mode: a glob that matches nothing
+        // produces 0 files, 0 failures, and a spuriously green test.
+        files.Count.ShouldBe(
+            expectedTotalFiles,
+            $"{version}: expected {expectedTotalFiles} .map files in corpus but found {files.Count}");
+
+        var failureNames = new List<string>();
+        var failureDetails = new List<string>();
+        var parsed = 0;
+
+        foreach (var file in files)
+        {
+            try
+            {
+                new MappingParser().Parse(File.ReadAllText(file, Encoding.UTF8));
+                parsed++;
+            }
+            catch (Exception ex)
+            {
+                var name = Path.GetFileName(file);
+                failureNames.Add(name);
+                failureDetails.Add($"  FAIL {name}: {ex.Message}");
+            }
+        }
+
+        var report = new StringBuilder();
+        report.AppendLine($"{version}: parsed {parsed}/{files.Count}");
+        foreach (var detail in failureDetails)
+        {
+            report.AppendLine(detail);
+        }
+
+        output.WriteLine(report.ToString());
+
+        // Assert the exact set of failing file names (sorted). This detects both new
+        // failures and silent swaps where a fixed file cancels out a newly broken one.
+        var actualSorted = failureNames.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        var expectedSorted = expectedFailingFileNames.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        actualSorted.ShouldBe(expectedSorted, report.ToString());
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlKnownEvaluatorGaps.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlKnownEvaluatorGaps.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Frozen list of official FML oracle cases the evaluator currently fails.
+ */
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// In-scope oracle cases the transform harness executes and compares, but which
+/// the <c>MappingEvaluator</c> currently gets wrong. Unlike <see cref="FmlOracleExclusions"/>
+/// (cases we cannot compare at all), these are executed on every run and ratcheted:
+/// the moment one starts producing matching output, its transform test fails and demands
+/// the entry be removed. Each defect is scheduled for a dedicated evaluator branch.
+/// </summary>
+public static class FmlKnownEvaluatorGaps
+{
+    private static readonly FrozenDictionary<string, string> Gaps =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["qr2patgender"] = "Target alias binds to the source element rather than the target resource; the QuestionnaireResponse tree is emitted under a 'patient' key instead of a Patient with 'gender'.",
+            ["qr2pathumannametwice"] = "Nested/recursive 'then' groups are not evaluated, so repeated HumanName rules yield an empty Patient.",
+            ["qr2pathumannameshared"] = "'share' combined with nested 'then' groups is not evaluated, so shared-variable HumanName rules yield an empty Patient.",
+            ["reference"] = "The create()/reference() builtins throw TARGET_RESOURCE_NOT_FOUND because the 'ext' target resource is never registered.",
+            ["qr2pat-gender-conformstoqr"] = "Depends on the FHIRPath conformsTo() function, which FhirSpecificFunctions declares unsupported (requires profile validation infrastructure)."
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether a manifest case name is a known evaluator gap.
+    /// Manifest names are URLs, so the final path segment is used for matching.
+    /// </summary>
+    public static bool IsKnownGap(string caseName) => Gaps.ContainsKey(LastSegment(caseName));
+
+    /// <summary>
+    /// Gets the written rationale for a known gap, or <c>null</c> if the case is not a gap.
+    /// </summary>
+    public static string? RationaleFor(string caseName) =>
+        Gaps.TryGetValue(LastSegment(caseName), out var rationale) ? rationale : null;
+
+    /// <summary>
+    /// Gets every known gap case name paired with its rationale.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> All => Gaps;
+
+    private static string LastSegment(string caseName) =>
+        caseName.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? caseName;
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlKnownEvaluatorGaps.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlKnownEvaluatorGaps.cs
@@ -37,12 +37,6 @@ public static class FmlKnownEvaluatorGaps
     public static bool IsKnownGap(string caseName) => Gaps.ContainsKey(LastSegment(caseName));
 
     /// <summary>
-    /// Gets the written rationale for a known gap, or <c>null</c> if the case is not a gap.
-    /// </summary>
-    public static string? RationaleFor(string caseName) =>
-        Gaps.TryGetValue(LastSegment(caseName), out var rationale) ? rationale : null;
-
-    /// <summary>
     /// Gets every known gap case name paired with its rationale.
     /// </summary>
     public static IReadOnlyDictionary<string, string> All => Gaps;

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoader.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoader.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Reads <fml-tests> entries out of the corpus manifest.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Reads the <c>&lt;fml-tests&gt;</c> section of a corpus <c>manifest.xml</c>.
+/// </summary>
+public static class FmlManifestLoader
+{
+    /// <summary>
+    /// Loads every declared transform oracle case for a corpus version folder
+    /// such as <c>r5</c> or <c>r4b</c>.
+    /// </summary>
+    public static IReadOnlyList<FmlOracleCase> Load(string version)
+    {
+        var manifestPath = Path.Combine(FmlTestCasesLocator.StructureMappingDirectory(version), "manifest.xml");
+
+        if (!File.Exists(manifestPath))
+        {
+            throw new FileNotFoundException($"Corpus manifest not found at {manifestPath}.", manifestPath);
+        }
+
+        var document = XDocument.Load(manifestPath);
+
+        return document.Descendants("fml-tests")
+            .Elements("test")
+            .Select(element => new FmlOracleCase(
+                version,
+                (string?)element.Attribute("name") ?? string.Empty,
+                (string?)element.Attribute("source") ?? string.Empty,
+                (string?)element.Attribute("map") ?? string.Empty,
+                (string?)element.Attribute("output") ?? string.Empty))
+            .Where(c => c.MapFile.Length > 0 && c.SourceFile.Length > 0 && c.OutputFile.Length > 0)
+            .ToList();
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoaderTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoaderTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Shouldly;
 using Xunit;
@@ -12,6 +13,11 @@ namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
 
 public class FmlManifestLoaderTests
 {
+    // Re-derives the URL last segment in test code; intentionally does not
+    // delegate to production code to avoid circular trust in the stale-key test.
+    private static string LastSegment(string name) =>
+        name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
+
     [Theory]
     [InlineData("r5")]
     [InlineData("r4b")]
@@ -19,7 +25,7 @@ public class FmlManifestLoaderTests
     {
         var cases = FmlManifestLoader.Load(version);
 
-        cases.Count.ShouldBe(10);
+        cases.Count.ShouldBe(10, $"{version}: manifest yielded {cases.Count} cases");
         cases.ShouldContain(c =>
             c.MapFile == "qr2pat-gender.map" &&
             c.SourceFile == "qr.json" &&
@@ -47,7 +53,7 @@ public class FmlManifestLoaderTests
         };
 
         var actualSegments = supported
-            .Select(c => c.Name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last())
+            .Select(c => LastSegment(c.Name))
             .OrderBy(n => n, StringComparer.Ordinal)
             .ToList();
 
@@ -65,8 +71,12 @@ public class FmlManifestLoaderTests
     {
         var cases = FmlManifestLoader.Load(version);
         var caseSegments = cases
-            .Select(c => c.Name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last())
+            .Select(c => LastSegment(c.Name))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Guard against the vacuous pass: if the exclusion list were emptied
+        // entirely the loop below runs zero times and passes, defeating its purpose.
+        FmlOracleExclusions.All.ShouldNotBeEmpty();
 
         foreach (var key in FmlOracleExclusions.All.Keys)
         {
@@ -80,6 +90,9 @@ public class FmlManifestLoaderTests
     public void GivenManifest_WhenCheckingOutputExtensions_ThenXmlMeansExcludedAndJsonMeansInScope(string version)
     {
         var cases = FmlManifestLoader.Load(version);
+
+        cases.Count(c => FmlOracleExclusions.IsExcluded(c.Name)).ShouldBe(4);
+        cases.Count(c => !FmlOracleExclusions.IsExcluded(c.Name)).ShouldBe(6);
 
         foreach (var c in cases.Where(c => FmlOracleExclusions.IsExcluded(c.Name)))
         {
@@ -98,6 +111,9 @@ public class FmlManifestLoaderTests
     public void GivenManifest_WhenCheckingRationales_ThenExcludedCasesHaveRationaleAndInScopeDoNot(string version)
     {
         var cases = FmlManifestLoader.Load(version);
+
+        cases.Count(c => FmlOracleExclusions.IsExcluded(c.Name)).ShouldBe(4);
+        cases.Count(c => !FmlOracleExclusions.IsExcluded(c.Name)).ShouldBe(6);
 
         foreach (var c in cases.Where(c => FmlOracleExclusions.IsExcluded(c.Name)))
         {
@@ -124,5 +140,11 @@ public class FmlManifestLoaderTests
             c.Version.ShouldBe(version);
             c.ToString().ShouldStartWith($"{version}/");
         }
+    }
+
+    [Fact]
+    public void GivenMissingManifest_WhenLoading_ThenThrowsFileNotFoundException()
+    {
+        Should.Throw<FileNotFoundException>(() => FmlManifestLoader.Load("nonexistent-version"));
     }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoaderTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlManifestLoaderTests.cs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class FmlManifestLoaderTests
+{
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenManifest_WhenLoading_ThenReturnsAllTenCases(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+
+        cases.Count.ShouldBe(10);
+        cases.ShouldContain(c =>
+            c.MapFile == "qr2pat-gender.map" &&
+            c.SourceFile == "qr.json" &&
+            c.OutputFile == "qr2pat-gender-res.json");
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenManifest_WhenFilteringExcluded_ThenExactlyInScopeCasesRemain(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+        var supported = cases
+            .Where(c => !FmlOracleExclusions.IsExcluded(c.Name))
+            .ToList();
+
+        var expectedSegments = new List<string>
+        {
+            "qr2patassignment",
+            "qr2patgender",
+            "qr2pathumannametwice",
+            "qr2pathumannameshared",
+            "reference",
+            "qr2pat-gender-conformstoqr"
+        };
+
+        var actualSegments = supported
+            .Select(c => c.Name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last())
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        var expectedSorted = expectedSegments
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        actualSegments.ShouldBe(expectedSorted);
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenExclusionList_WhenCheckingAgainstManifest_ThenAllKeysMatchActualCases(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+        var caseSegments = cases
+            .Select(c => c.Name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var key in FmlOracleExclusions.All.Keys)
+        {
+            caseSegments.ShouldContain(key);
+        }
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenManifest_WhenCheckingOutputExtensions_ThenXmlMeansExcludedAndJsonMeansInScope(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+
+        foreach (var c in cases.Where(c => FmlOracleExclusions.IsExcluded(c.Name)))
+        {
+            c.OutputFile.ShouldEndWith(".xml");
+        }
+
+        foreach (var c in cases.Where(c => !FmlOracleExclusions.IsExcluded(c.Name)))
+        {
+            c.OutputFile.ShouldEndWith(".json");
+        }
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenManifest_WhenCheckingRationales_ThenExcludedCasesHaveRationaleAndInScopeDoNot(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+
+        foreach (var c in cases.Where(c => FmlOracleExclusions.IsExcluded(c.Name)))
+        {
+            var rationale = FmlOracleExclusions.RationaleFor(c.Name);
+            rationale.ShouldNotBeNull();
+            rationale.Trim().ShouldNotBeEmpty();
+        }
+
+        foreach (var c in cases.Where(c => !FmlOracleExclusions.IsExcluded(c.Name)))
+        {
+            FmlOracleExclusions.RationaleFor(c.Name).ShouldBeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenManifest_WhenLoading_ThenVersionIsCarriedOnAllCases(string version)
+    {
+        var cases = FmlManifestLoader.Load(version);
+
+        foreach (var c in cases)
+        {
+            c.Version.ShouldBe(version);
+            c.ToString().ShouldStartWith($"{version}/");
+        }
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleCase.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleCase.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * One <test> entry from an <fml-tests> manifest section.
+ */
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// A single transform oracle case declared in the corpus <c>manifest.xml</c>.
+/// </summary>
+/// <param name="Version">Corpus version folder, e.g. <c>r5</c>.</param>
+/// <param name="Name">Case name as declared in the manifest.</param>
+/// <param name="SourceFile">Input resource file name, relative to the structure-mapping directory.</param>
+/// <param name="MapFile">FML map file name, relative to the structure-mapping directory.</param>
+/// <param name="OutputFile">Expected output file name, relative to the structure-mapping directory.</param>
+public sealed record FmlOracleCase(
+    string Version,
+    string Name,
+    string SourceFile,
+    string MapFile,
+    string OutputFile)
+{
+    /// <inheritdoc />
+    public override string ToString() => $"{Version}/{Name}";
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleExclusions.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlOracleExclusions.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Frozen list of official FML oracle cases outside Ignixa's supported scope.
+ */
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Cases from the official corpus that Ignixa deliberately does not attempt.
+/// Per ADR-2607, the exclusion list is frozen and each entry carries a written
+/// rationale: conformance is reported as a percentage of supported scope, never
+/// inflated by quietly skipping hard cases.
+/// </summary>
+public static class FmlOracleExclusions
+{
+    private static readonly FrozenDictionary<string, string> Excluded =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["qr2cda"] = "Targets the CDA logical model and produces XML output; Ignixa's transform pipeline emits FHIR JSON only.",
+            ["qr2cdaxsi"] = "CDA logical model with xsi:type discrimination; XML output is out of scope.",
+            ["qr2cd-eval-json"] = "CDA logical model target; XML output is out of scope.",
+            ["qr2cd-eval-fml"] = "CDA logical model target; XML output is out of scope."
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether a manifest case name is excluded from the supported scope.
+    /// Manifest names are URLs, so the final path segment is used for matching.
+    /// </summary>
+    public static bool IsExcluded(string caseName) => Excluded.ContainsKey(LastSegment(caseName));
+
+    /// <summary>
+    /// Gets the written rationale for an excluded case, or <c>null</c> if it is not excluded.
+    /// </summary>
+    public static string? RationaleFor(string caseName) =>
+        Excluded.TryGetValue(LastSegment(caseName), out var rationale) ? rationale : null;
+
+    /// <summary>
+    /// Gets every excluded case name paired with its rationale.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> All => Excluded;
+
+    private static string LastSegment(string caseName) =>
+        caseName.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? caseName;
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Resolves paths into the vendored HL7 fhir-test-cases corpus.
+ */
+
+using System;
+using System.IO;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Resolves paths into the vendored HL7 <c>fhir-test-cases</c> corpus.
+/// The corpus is downloaded by the <c>DownloadFhirTestCases</c> MSBuild target
+/// into <c>TestData/fhir-test-cases</c> beside the project file.
+/// </summary>
+public static class FmlTestCasesLocator
+{
+    private static readonly Lazy<string> RootDirectory = new(FindRoot);
+
+    /// <summary>
+    /// Gets the root of the vendored corpus.
+    /// </summary>
+    public static string Root => RootDirectory.Value;
+
+    /// <summary>
+    /// Gets the <c>structure-mapping</c> directory for a FHIR version folder such as
+    /// <c>r5</c> or <c>r4b</c>.
+    /// </summary>
+    public static string StructureMappingDirectory(string version) =>
+        Path.Combine(Root, version, "structure-mapping");
+
+    private static string FindRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "TestData", "fhir-test-cases");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the vendored fhir-test-cases corpus. Run 'dotnet build' on " +
+            "test/Ignixa.FhirMappingLanguage.Tests to download it.");
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
@@ -27,8 +27,11 @@ public static class FmlTestCasesLocator
     /// Gets the <c>structure-mapping</c> directory for a FHIR version folder such as
     /// <c>r5</c> or <c>r4b</c>.
     /// </summary>
-    public static string StructureMappingDirectory(string version) =>
-        Path.Combine(Root, version, "structure-mapping");
+    public static string StructureMappingDirectory(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        return Path.Combine(Root, version, "structure-mapping");
+    }
 
     private static string FindRoot()
     {

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocator.cs
@@ -33,6 +33,12 @@ public static class FmlTestCasesLocator
         return Path.Combine(Root, version, "structure-mapping");
     }
 
+    /// <summary>
+    /// Gets the version-independent <c>validator</c> directory that holds the official
+    /// FML validator fixtures.
+    /// </summary>
+    public static string ValidatorDirectory() => Path.Combine(Root, "validator");
+
     private static string FindRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
@@ -26,6 +26,8 @@ public class FmlTestCasesLocatorTests
     [InlineData(null)]
     public void GivenABlankVersion_WhenLocatingStructureMappingDirectory_ThenThrowsArgumentException(string? version)
     {
-        Should.Throw<ArgumentException>(() => FmlTestCasesLocator.StructureMappingDirectory(version!));
+        var exception = Should.Throw<ArgumentException>(() => FmlTestCasesLocator.StructureMappingDirectory(version!));
+
+        exception.ParamName.ShouldBe("version");
     }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
@@ -19,4 +19,13 @@ public class FmlTestCasesLocatorTests
 
         Directory.Exists(directory).ShouldBeTrue($"Expected the vendored corpus at {directory}. Run 'dotnet build' to download it.");
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void GivenABlankVersion_WhenLocatingStructureMappingDirectory_ThenThrowsArgumentException(string? version)
+    {
+        Should.Throw<ArgumentException>(() => FmlTestCasesLocator.StructureMappingDirectory(version!));
+    }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTestCasesLocatorTests.cs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+public class FmlTestCasesLocatorTests
+{
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    public void GivenAVendoredCorpus_WhenLocatingStructureMappingDirectory_ThenTheDirectoryExists(string version)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+
+        Directory.Exists(directory).ShouldBeTrue($"Expected the vendored corpus at {directory}. Run 'dotnet build' to download it.");
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
@@ -76,6 +76,29 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
         cases.Count.ShouldBe(12);
     }
 
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenTheOfficialManifests_WhenCheckingTheCorpus_ThenEveryInScopeCaseHasItsThreeFilesOnDisk(string version)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+
+        var inScope = FmlManifestLoader.Load(version)
+            .Where(c => !FmlOracleExclusions.IsExcluded(c.Name))
+            .Where(c => c.OutputFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        inScope.Count.ShouldBe(6);
+
+        foreach (var oracleCase in inScope)
+        {
+            AssertCorpusFileExists(directory, oracleCase, oracleCase.MapFile);
+            AssertCorpusFileExists(directory, oracleCase, oracleCase.SourceFile);
+            AssertCorpusFileExists(directory, oracleCase, oracleCase.OutputFile);
+        }
+    }
+
     [Fact]
     [Trait("Category", "OfficialTestSuite")]
     public void GivenTheInScopeCases_WhenPartitioningByKnownGaps_ThenTwoPassAndTenAreRatchetedGapExecutions()
@@ -135,13 +158,7 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
             return;
         }
 
-        var (expected, actual, context) = ExecuteCase(oracleCase);
-
-        context.Errors.ShouldBeEmpty(
-            context.Errors.Count == 0
-                ? string.Empty
-                : "Execution accumulated errors:" + Environment.NewLine +
-                  string.Join(Environment.NewLine, context.Errors.Select(e => e.ToString())));
+        var (expected, actual) = ExecuteCase(oracleCase);
 
         output.WriteLine("EXPECTED:");
         output.WriteLine(expected);
@@ -158,7 +175,7 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
 
         try
         {
-            (expected, actual, _) = ExecuteCase(oracleCase);
+            (expected, actual) = ExecuteCase(oracleCase);
         }
         catch (MappingExecutionException)
         {
@@ -175,7 +192,7 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
             $"The underlying defect appears fixed — remove '{oracleCase.Name}' from {nameof(FmlKnownEvaluatorGaps)}.");
     }
 
-    private (string Expected, string Actual, MappingContext Context) ExecuteCase(FmlOracleCase oracleCase)
+    private (string Expected, string Actual) ExecuteCase(FmlOracleCase oracleCase)
     {
         var directory = FmlTestCasesLocator.StructureMappingDirectory(oracleCase.Version);
         var fhirVersion = oracleCase.Version == "r4b" ? FhirVersion.R4B : FhirVersion.R5;
@@ -210,7 +227,16 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
         var expected = CanonicalJson.Canonicalize(File.ReadAllText(Path.Combine(directory, oracleCase.OutputFile), Encoding.UTF8));
         var actual = CanonicalJson.Canonicalize(target.MutableNode().ToJsonString());
 
-        return (expected, actual, context);
+        return (expected, actual);
+    }
+
+    private static void AssertCorpusFileExists(string directory, FmlOracleCase oracleCase, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+
+        File.Exists(path).ShouldBeTrue(
+            $"Corpus file for case '{oracleCase.Name}' is missing: {path}. " +
+            "Verify the fhir-test-cases download completed.");
     }
 
     private static string DetermineTargetType(MapExpression map)

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
@@ -76,10 +76,106 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
         cases.Count.ShouldBe(12);
     }
 
+    [Fact]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenTheInScopeCases_WhenPartitioningByKnownGaps_ThenTwoPassAndTenAreRatchetedGapExecutions()
+    {
+        var cases = SupportedCases().Select(row => (FmlOracleCase)row[0]).ToList();
+
+        cases.Count.ShouldBe(12);
+        cases.Count(c => FmlKnownEvaluatorGaps.IsKnownGap(c.Name)).ShouldBe(10);
+        cases.Count(c => !FmlKnownEvaluatorGaps.IsKnownGap(c.Name)).ShouldBe(2);
+    }
+
+    [Fact]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenTheKnownEvaluatorGaps_WhenListingEntries_ThenContainsExactlyTheFiveDocumentedGaps()
+    {
+        var expected = new List<string>
+        {
+            "qr2patgender",
+            "qr2pathumannametwice",
+            "qr2pathumannameshared",
+            "reference",
+            "qr2pat-gender-conformstoqr"
+        };
+
+        FmlKnownEvaluatorGaps.All.Keys
+            .OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(expected.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("r5")]
+    [InlineData("r4b")]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenTheKnownEvaluatorGaps_WhenCheckingAgainstTheManifest_ThenEveryGapKeyMatchesAnInScopeCase(string version)
+    {
+        var inScopeSegments = FmlManifestLoader.Load(version)
+            .Where(c => !FmlOracleExclusions.IsExcluded(c.Name))
+            .Select(c => c.Name.Split('/', StringSplitOptions.RemoveEmptyEntries).Last())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        FmlKnownEvaluatorGaps.All.ShouldNotBeEmpty();
+
+        foreach (var key in FmlKnownEvaluatorGaps.All.Keys)
+        {
+            inScopeSegments.ShouldContain(key);
+        }
+    }
+
     [Theory]
     [MemberData(nameof(SupportedCases))]
     [Trait("Category", "OfficialTestSuite")]
     public void GivenAnOfficialFmlTestCase_WhenExecutingTheMap_ThenTheResultMatchesTheReferenceOutput(FmlOracleCase oracleCase)
+    {
+        if (FmlKnownEvaluatorGaps.IsKnownGap(oracleCase.Name))
+        {
+            AssertKnownGapStillBroken(oracleCase);
+            return;
+        }
+
+        var (expected, actual, context) = ExecuteCase(oracleCase);
+
+        context.Errors.ShouldBeEmpty(
+            context.Errors.Count == 0
+                ? string.Empty
+                : "Execution accumulated errors:" + Environment.NewLine +
+                  string.Join(Environment.NewLine, context.Errors.Select(e => e.ToString())));
+
+        output.WriteLine("EXPECTED:");
+        output.WriteLine(expected);
+        output.WriteLine("ACTUAL:");
+        output.WriteLine(actual);
+
+        actual.ShouldBe(expected);
+    }
+
+    private void AssertKnownGapStillBroken(FmlOracleCase oracleCase)
+    {
+        string expected;
+        string actual;
+
+        try
+        {
+            (expected, actual, _) = ExecuteCase(oracleCase);
+        }
+        catch (MappingExecutionException)
+        {
+            return;
+        }
+        catch (NotSupportedException)
+        {
+            return;
+        }
+
+        actual.ShouldNotBe(
+            expected,
+            $"Known evaluator gap '{oracleCase}' now produces output matching the reference. " +
+            $"The underlying defect appears fixed — remove '{oracleCase.Name}' from {nameof(FmlKnownEvaluatorGaps)}.");
+    }
+
+    private (string Expected, string Actual, MappingContext Context) ExecuteCase(FmlOracleCase oracleCase)
     {
         var directory = FmlTestCasesLocator.StructureMappingDirectory(oracleCase.Version);
         var fhirVersion = oracleCase.Version == "r4b" ? FhirVersion.R4B : FhirVersion.R5;
@@ -111,21 +207,10 @@ public class FmlTransformOracleTests(ITestOutputHelper output)
         var mutator = new JsonNodeMutator(fhirPathEvaluator, fhirPathParser, () => schema);
         new MappingEvaluator(MappingEvaluatorOptions.Default, mutator).Execute(map, context);
 
-        context.Errors.ShouldBeEmpty(
-            context.Errors.Count == 0
-                ? string.Empty
-                : "Execution accumulated errors:" + Environment.NewLine +
-                  string.Join(Environment.NewLine, context.Errors.Select(e => e.ToString())));
-
         var expected = CanonicalJson.Canonicalize(File.ReadAllText(Path.Combine(directory, oracleCase.OutputFile), Encoding.UTF8));
         var actual = CanonicalJson.Canonicalize(target.MutableNode().ToJsonString());
 
-        output.WriteLine("EXPECTED:");
-        output.WriteLine(expected);
-        output.WriteLine("ACTUAL:");
-        output.WriteLine(actual);
-
-        actual.ShouldBe(expected);
+        return (expected, actual, context);
     }
 
     private static string DetermineTargetType(MapExpression map)

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlTransformOracleTests.cs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ *
+ * Executes every in-scope official FML oracle case end-to-end and compares
+ * the produced resource against the reference implementation's expected output.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ignixa.Abstractions;
+using Ignixa.FhirMappingLanguage.Evaluation;
+using Ignixa.FhirMappingLanguage.Expressions;
+using Ignixa.FhirMappingLanguage.Mutator;
+using Ignixa.FhirMappingLanguage.Parser;
+using Ignixa.FhirPath.Evaluation;
+using Ignixa.FhirPath.Parser;
+using Ignixa.Serialization;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Serialization.TestSupport;
+using Ignixa.Specification.Extensions;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Executes every in-scope case from the official <c>&lt;fml-tests&gt;</c> manifest and
+/// compares the produced resource against the reference implementation's expected output.
+/// </summary>
+public class FmlTransformOracleTests(ITestOutputHelper output)
+{
+    private static readonly string[] Versions = ["r5", "r4b"];
+
+    public static IEnumerable<object[]> SupportedCases()
+    {
+        foreach (var version in Versions)
+        {
+            var directory = FmlTestCasesLocator.StructureMappingDirectory(version);
+
+            foreach (var oracleCase in FmlManifestLoader.Load(version))
+            {
+                if (FmlOracleExclusions.IsExcluded(oracleCase.Name))
+                {
+                    continue;
+                }
+
+                if (!oracleCase.OutputFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!File.Exists(Path.Combine(directory, oracleCase.MapFile)) ||
+                    !File.Exists(Path.Combine(directory, oracleCase.SourceFile)) ||
+                    !File.Exists(Path.Combine(directory, oracleCase.OutputFile)))
+                {
+                    continue;
+                }
+
+                yield return [oracleCase];
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenTheOfficialManifests_WhenDiscoveringSupportedCases_ThenSixInScopeCasesExistPerVersion()
+    {
+        var cases = SupportedCases().Select(row => (FmlOracleCase)row[0]).ToList();
+
+        cases.Count(c => c.Version == "r5").ShouldBe(6);
+        cases.Count(c => c.Version == "r4b").ShouldBe(6);
+        cases.Count.ShouldBe(12);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedCases))]
+    [Trait("Category", "OfficialTestSuite")]
+    public void GivenAnOfficialFmlTestCase_WhenExecutingTheMap_ThenTheResultMatchesTheReferenceOutput(FmlOracleCase oracleCase)
+    {
+        var directory = FmlTestCasesLocator.StructureMappingDirectory(oracleCase.Version);
+        var fhirVersion = oracleCase.Version == "r4b" ? FhirVersion.R4B : FhirVersion.R5;
+        var schema = fhirVersion.GetSchemaProvider();
+
+        var map = new MappingParser().Parse(File.ReadAllText(Path.Combine(directory, oracleCase.MapFile), Encoding.UTF8));
+
+        var source = ResourceJsonNode.Parse(File.ReadAllText(Path.Combine(directory, oracleCase.SourceFile), Encoding.UTF8));
+        var targetType = DetermineTargetType(map);
+        var target = JsonSourceNodeFactory.Parse<ResourceJsonNode>($"{{\"resourceType\":\"{targetType}\"}}");
+
+        var fhirPathParser = new FhirPathParser();
+        var fhirPathEvaluator = new FhirPathEvaluator();
+        var context = new MappingContext
+        {
+            ErrorMode = ErrorMode.Strict,
+            ResourceCreator = type => JsonSourceNodeFactory.Parse<ResourceJsonNode>($"{{\"resourceType\":\"{type}\"}}").ToElement(schema),
+            Logger = message => output.WriteLine(message),
+            FhirPathEvaluator = (expression, element) =>
+                string.IsNullOrWhiteSpace(expression)
+                    ? Enumerable.Empty<IElement>()
+                    : fhirPathEvaluator.Evaluate(element, fhirPathParser.Parse(expression))
+        };
+
+        context.SetSource("src", source.ToElement(schema));
+        context.SetTarget("tgt", target.ToElement(schema));
+        context.SetTargetResource("tgt", target);
+
+        var mutator = new JsonNodeMutator(fhirPathEvaluator, fhirPathParser, () => schema);
+        new MappingEvaluator(MappingEvaluatorOptions.Default, mutator).Execute(map, context);
+
+        context.Errors.ShouldBeEmpty(
+            context.Errors.Count == 0
+                ? string.Empty
+                : "Execution accumulated errors:" + Environment.NewLine +
+                  string.Join(Environment.NewLine, context.Errors.Select(e => e.ToString())));
+
+        var expected = CanonicalJson.Canonicalize(File.ReadAllText(Path.Combine(directory, oracleCase.OutputFile), Encoding.UTF8));
+        var actual = CanonicalJson.Canonicalize(target.MutableNode().ToJsonString());
+
+        output.WriteLine("EXPECTED:");
+        output.WriteLine(expected);
+        output.WriteLine("ACTUAL:");
+        output.WriteLine(actual);
+
+        actual.ShouldBe(expected);
+    }
+
+    private static string DetermineTargetType(MapExpression map)
+    {
+        var targetUses = map.Uses.FirstOrDefault(u => u.Mode == ModelMode.Target)
+            ?? throw new InvalidDataException($"Map '{map.Url}' declares no target 'uses' statement.");
+
+        return targetUses.Url.Split('/').Last();
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlValidatorCorpusParseTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Conformance/FmlValidatorCorpusParseTests.cs
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ignixa.FhirMappingLanguage.Expressions;
+using Ignixa.FhirMappingLanguage.Parser;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Conformance;
+
+/// <summary>
+/// Parse ratchet over the two official <c>validator</c>-directory FML files. These exercise
+/// parser constructs — a group <c>extends</c> target with a <c>&lt;&lt;type+&gt;&gt;</c> annotation
+/// and a parenthesized FHIRPath transform — that appear nowhere in the <c>structure-mapping</c>
+/// corpus, so pinning their parse output guards several parser fixes against regression.
+/// </summary>
+public class FmlValidatorCorpusParseTests(ITestOutputHelper output)
+{
+    private const string AddressFile = "map-general-test.fml";
+    private const string SyntaxFile = "map-general-test2.fml";
+
+    [Fact]
+    public void GivenMapGeneralTest_WhenParsed_ThenHeaderAndDeclarationCountsMatch()
+    {
+        var map = ParseValidatorFile(AddressFile);
+
+        map.Url.ShouldBe("http://hl7.org/fhir/StructureMap/Address4to3");
+        map.Groups.Count.ShouldBe(1);
+        map.Uses.Count.ShouldBe(2);
+        map.Imports.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenMapGeneralTest_WhenParsingTheGroup_ThenExtendsTargetAndTypeModeSurvive()
+    {
+        var map = ParseValidatorFile(AddressFile);
+
+        var group = map.Groups.ShouldHaveSingleItem();
+        group.Extends.ShouldBe("Element");
+        group.TypeMode.ShouldBe(GroupTypeMode.TypeAndTypes);
+    }
+
+    [Fact]
+    public void GivenMapGeneralTest2_WhenParsed_ThenHeaderAndDeclarationCountsMatch()
+    {
+        var map = ParseValidatorFile(SyntaxFile);
+
+        map.Url.ShouldBe("http://github.com/FHIR/fhir-test-cases/r5/fml/syntax");
+        map.Groups.Count.ShouldBe(2);
+        map.Uses.Count.ShouldBe(2);
+        map.Imports.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GivenMapGeneralTest2_WhenParsingTheRootUuidRule_ThenParenthesizedFhirPathTransformSurvives()
+    {
+        var map = ParseValidatorFile(SyntaxFile);
+
+        var rule = map.Groups
+            .SelectMany(g => g.Rules)
+            .Single(r => r.Name == "rootuuid");
+
+        var transform = rule.Targets
+            .Select(t => t.Transform)
+            .OfType<FhirPathExpression>()
+            .ShouldHaveSingleItem();
+
+        transform.PathExpression.ShouldBe("'urn:uuid:' + r.lower()");
+    }
+
+    private MapExpression ParseValidatorFile(string fileName)
+    {
+        var path = Path.Combine(FmlTestCasesLocator.ValidatorDirectory(), fileName);
+
+        File.Exists(path).ShouldBeTrue(
+            $"Validator corpus file not found: {path}. Verify the fhir-test-cases download completed.");
+
+        output.WriteLine($"Parsing {path}");
+        return new MappingParser().Parse(File.ReadAllText(path, Encoding.UTF8));
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Ignixa.FhirMappingLanguage.Tests.csproj
@@ -24,5 +24,38 @@
     <ProjectReference Include="..\Ignixa.Serialization.TestSupport\Ignixa.Serialization.TestSupport.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <FhirTestCasesVersion>1.7.46</FhirTestCasesVersion>
+    <FhirTestCasesUrl>https://github.com/FHIR/fhir-test-cases/releases/download/$(FhirTestCasesVersion)/testcases.zip</FhirTestCasesUrl>
+    <FhirTestCasesZip>$(MSBuildProjectDirectory)\TestData\testcases.zip</FhirTestCasesZip>
+    <FhirTestCasesDir>$(MSBuildProjectDirectory)\TestData\fhir-test-cases</FhirTestCasesDir>
+    <FhirTestCasesTempDir>$(MSBuildProjectDirectory)\TestData\temp-extract</FhirTestCasesTempDir>
+    <FhirTestCasesMarker>$(FhirTestCasesDir)\.downloaded</FhirTestCasesMarker>
+  </PropertyGroup>
+
+  <!-- Runs once in the outer (multi-targeting) build via DispatchToInnerBuilds so the parallel
+       per-TFM inner builds don't race on the shared testcases.zip; BeforeBuild covers single-TFM builds. -->
+  <Target Name="DownloadFhirTestCases" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="!Exists('$(FhirTestCasesMarker)')">
+    <Message Text="Downloading FHIR test cases from $(FhirTestCasesUrl)..." Importance="high" />
+    <MakeDir Directories="$(MSBuildProjectDirectory)\TestData" />
+    <DownloadFile SourceUrl="$(FhirTestCasesUrl)" DestinationFolder="$(MSBuildProjectDirectory)\TestData" DestinationFileName="testcases.zip" SkipUnchangedFiles="true" />
+
+    <Message Text="Extracting FHIR test cases to temporary location..." Importance="high" />
+    <RemoveDir Directories="$(FhirTestCasesTempDir)" Condition="Exists('$(FhirTestCasesTempDir)')" />
+    <Unzip SourceFiles="$(FhirTestCasesZip)" DestinationFolder="$(FhirTestCasesTempDir)" OverwriteReadOnlyFiles="true" />
+
+    <ItemGroup>
+      <ExtractedFiles Include="$(FhirTestCasesTempDir)\fhir-test-cases\**\*.*" />
+    </ItemGroup>
+
+    <Message Text="Moving extracted files from nested directory to $(FhirTestCasesDir)..." Importance="high" />
+    <RemoveDir Directories="$(FhirTestCasesDir)" Condition="Exists('$(FhirTestCasesDir)')" />
+    <Move SourceFiles="@(ExtractedFiles)" DestinationFolder="$(FhirTestCasesDir)\%(RecursiveDir)" />
+
+    <RemoveDir Directories="$(FhirTestCasesTempDir)" />
+    <Touch Files="$(FhirTestCasesMarker)" AlwaysCreate="true" />
+    <Message Text="FHIR test cases downloaded and extracted successfully." Importance="high" />
+  </Target>
+
 </Project>
 

--- a/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
@@ -406,6 +406,67 @@ public class MappingTokenizerTests
         kinds.ShouldBe(new[] { MappingTokenKind.LineComment });
     }
 
+    #region Metadata declaration tokenization (Task 5)
+
+    [Fact]
+    public void GivenMetadataDeclarationLine_WhenTokenizingWithCreate_ThenItIsMetadataLine()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.Create();
+
+        // Act
+        var result = tokenizer.Tokenize("/// url = 'http://example.org'").ToList();
+
+        // Assert — the '///' line is preserved as a single MetadataLine token in standard mode
+        result.ShouldHaveSingleItem();
+        result[0].Kind.ShouldBe(MappingTokenKind.MetadataLine);
+    }
+
+    [Fact]
+    public void GivenMetadataDeclarationLine_WhenTokenizingWithCreateWithTrivia_ThenItIsMetadataLine()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+
+        // Act
+        var result = tokenizer.Tokenize("/// url = 'http://example.org'").ToList();
+
+        // Assert — the '///' line is preserved as a single MetadataLine token in trivia mode
+        result.ShouldContain(t => t.Kind == MappingTokenKind.MetadataLine);
+        result[0].Kind.ShouldBe(MappingTokenKind.MetadataLine);
+    }
+
+    [Fact]
+    public void GivenMetadataLineFollowedByNormalComment_WhenTokenizingWithCreate_ThenEachIsClassifiedCorrectly()
+    {
+        // Arrange — '///' is MetadataLine; '//' is ignored in standard mode
+        var tokenizer = MappingTokenizer.Create();
+        var input = "/// key = 'value'\n// ordinary comment\nmap";
+
+        // Act
+        var kinds = tokenizer.Tokenize(input).Select(t => t.Kind).ToList();
+
+        // Assert — only MetadataLine and Map survive (ordinary comment is ignored)
+        kinds.ShouldBe(new[] { MappingTokenKind.MetadataLine, MappingTokenKind.Map });
+    }
+
+    [Fact]
+    public void GivenMetadataLineFollowedByNormalComment_WhenTokenizingWithCreateWithTrivia_ThenEachIsClassifiedCorrectly()
+    {
+        // Arrange — '///' is MetadataLine; '//' is LineComment in trivia mode
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+        var input = "/// key = 'value'\n// ordinary comment";
+
+        // Act
+        var kinds = tokenizer.Tokenize(input).Where(t => t.Kind != MappingTokenKind.Whitespace).Select(t => t.Kind).ToList();
+
+        // Assert — MetadataLine precedes LineComment, not the other way around
+        kinds[0].ShouldBe(MappingTokenKind.MetadataLine);
+        kinds[1].ShouldBe(MappingTokenKind.LineComment);
+    }
+
+    #endregion
+
     #endregion
 
     #region Whitespace Tests

--- a/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
@@ -139,6 +139,50 @@ public class MappingTokenizerTests
 
     // NOTE: DoubleColon (::) test removed - not part of FHIR Mapping Language spec
 
+    [Theory]
+    [InlineData("+", MappingTokenKind.Plus)]
+    [InlineData("-", MappingTokenKind.Minus)]
+    [InlineData("%", MappingTokenKind.Percent)]
+    [InlineData("/", MappingTokenKind.Slash)]
+    [InlineData("|", MappingTokenKind.Pipe)]
+    [InlineData("&", MappingTokenKind.Ampersand)]
+    [InlineData("<=", MappingTokenKind.LessOrEqual)]
+    [InlineData(">=", MappingTokenKind.GreaterOrEqual)]
+    public void GivenAnOperator_WhenTokenizing_ThenTheOperatorTokenIsProduced(string input, MappingTokenKind expected)
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.Create();
+
+        // Act
+        var tokens = tokenizer.Tokenize(input).ToList();
+
+        // Assert
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("+", MappingTokenKind.Plus)]
+    [InlineData("-", MappingTokenKind.Minus)]
+    [InlineData("%", MappingTokenKind.Percent)]
+    [InlineData("/", MappingTokenKind.Slash)]
+    [InlineData("|", MappingTokenKind.Pipe)]
+    [InlineData("&", MappingTokenKind.Ampersand)]
+    [InlineData("<=", MappingTokenKind.LessOrEqual)]
+    [InlineData(">=", MappingTokenKind.GreaterOrEqual)]
+    public void GivenAnOperator_WhenTokenizingWithTrivia_ThenTheOperatorTokenIsProduced(string input, MappingTokenKind expected)
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+
+        // Act
+        var tokens = tokenizer.Tokenize(input).ToList();
+
+        // Assert
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(expected);
+    }
+
     #endregion
 
     #region Literal Tests
@@ -323,6 +367,19 @@ public class MappingTokenizerTests
         result[0].Kind.ShouldBe(MappingTokenKind.Map);
     }
 
+    [Fact]
+    public void GivenALineComment_WhenTokenizingWithTrivia_ThenItIsStillACommentNotTwoSlashes()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+
+        // Act
+        var kinds = tokenizer.Tokenize("// hello").Select(t => t.Kind).ToList();
+
+        // Assert
+        kinds.ShouldBe(new[] { MappingTokenKind.LineComment });
+    }
+
     #endregion
 
     #region Whitespace Tests
@@ -436,6 +493,44 @@ public class MappingTokenizerTests
         result[4].Kind.ShouldBe(MappingTokenKind.Identifier); // tgt
         result[5].Kind.ShouldBe(MappingTokenKind.Dot);
         result[6].Kind.ShouldBe(MappingTokenKind.Identifier); // name
+    }
+
+    [Fact]
+    public void GivenAPercentConstantWithDateArithmetic_WhenTokenizing_ThenAllTokensAreProduced()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.Create();
+
+        // Act
+        var kinds = tokenizer.Tokenize("%value + 5 days").Select(t => t.Kind).ToList();
+
+        // Assert
+        kinds.ShouldBe(new[]
+        {
+            MappingTokenKind.Percent,
+            MappingTokenKind.Identifier,
+            MappingTokenKind.Plus,
+            MappingTokenKind.IntegerLiteral,
+            MappingTokenKind.Identifier
+        });
+    }
+
+    [Fact]
+    public void GivenAnArrow_WhenTokenizing_ThenItIsStillASingleArrowNotMinus()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.Create();
+
+        // Act
+        var kinds = tokenizer.Tokenize("src -> tgt").Select(t => t.Kind).ToList();
+
+        // Assert
+        kinds.ShouldBe(new[]
+        {
+            MappingTokenKind.Identifier,
+            MappingTokenKind.Arrow,
+            MappingTokenKind.Identifier
+        });
     }
 
     #endregion

--- a/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Lexer/MappingTokenizerTests.cs
@@ -257,6 +257,34 @@ public class MappingTokenizerTests
         result.First().Kind.ShouldBe(expectedKind);
     }
 
+    [Fact]
+    public void GivenADoubleQuotedString_WhenTokenizing_ThenItIsADoubleQuotedString()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.Create();
+
+        // Act
+        var result = tokenizer.Tokenize("\"quoted identifier\"");
+
+        // Assert
+        result.Count().ShouldBe(1);
+        result.First().Kind.ShouldBe(MappingTokenKind.DoubleQuotedString);
+    }
+
+    [Fact]
+    public void GivenADoubleQuotedString_WhenTokenizingWithTrivia_ThenItIsADoubleQuotedString()
+    {
+        // Arrange
+        var tokenizer = MappingTokenizer.CreateWithTrivia();
+
+        // Act
+        var tokens = tokenizer.Tokenize("\"quoted identifier\"").ToList();
+
+        // Assert
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(MappingTokenKind.DoubleQuotedString);
+    }
+
     #endregion
 
     #region Identifier Tests
@@ -282,20 +310,18 @@ public class MappingTokenizerTests
         result.First().ToStringValue().ShouldBe(identifier);
     }
 
-    [Theory]
-    [InlineData("`escaped identifier`")]
-    [InlineData("\"quoted identifier\"")]
-    public void GivenDelimitedIdentifier_WhenTokenizing_ThenReturnsDelimitedIdentifierToken(string identifier)
+    [Fact]
+    public void GivenABacktickDelimitedIdentifier_WhenTokenizing_ThenItIsADelimitedIdentifier()
     {
         // Arrange
         var tokenizer = MappingTokenizer.Create();
 
         // Act
-        var result = tokenizer.Tokenize(identifier);
+        var tokens = tokenizer.Tokenize("`quoted identifier`").ToList();
 
         // Assert
-        result.Count().ShouldBe(1);
-        result.First().Kind.ShouldBe(MappingTokenKind.DelimitedIdentifier);
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(MappingTokenKind.DelimitedIdentifier);
     }
 
     #endregion

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -4,6 +4,7 @@
 
 using Ignixa.FhirMappingLanguage.Expressions;
 using Ignixa.FhirMappingLanguage.Parser;
+using Ignixa.FhirMappingLanguage.Serialization;
 using Shouldly;
 using Xunit;
 
@@ -145,5 +146,66 @@ public class FmlSyntaxCoverageTests
         // Assert
         map.ConceptMaps.Count.ShouldBe(1);
         map.ConceptMaps[0].Identifier.ShouldBe("#cm");
+    }
+
+    [Theory]
+    [InlineData("<<types>>", GroupTypeMode.Types)]
+    [InlineData("<<type+>>", GroupTypeMode.TypeAndTypes)]
+    public void GivenAGroupTypeModeAnnotation_WhenParsing_ThenTheModeIsCaptured(string annotation, GroupTypeMode expected)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {{annotation}} {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(fml);
+
+        // Assert
+        map.Groups[0].TypeMode.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenNoTypeModeAnnotation_WhenParsing_ThenTheModeIsNone()
+    {
+        // Arrange
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Groups[0].TypeMode.ShouldBe(GroupTypeMode.None);
+    }
+
+    [Theory]
+    [InlineData("<<types>>")]
+    [InlineData("<<type+>>")]
+    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(string annotation)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {{annotation}} {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var reparsed = new MappingParser().Parse(new FmlSerializer().Serialize(new MappingParser().Parse(fml)));
+
+        // Assert
+        reparsed.Groups[0].TypeMode.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode);
     }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, Ignixa Contributors
+ */
+
+using Ignixa.FhirMappingLanguage.Expressions;
+using Ignixa.FhirMappingLanguage.Parser;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.FhirMappingLanguage.Tests.Parser;
+
+/// <summary>
+/// Regression coverage for FML syntax found in the official HL7 structure-mapping corpus.
+/// Each test targets one previously unsupported construct.
+/// </summary>
+public class FmlSyntaxCoverageTests
+{
+    [Theory]
+    [InlineData("where linkId.value in ('patient.sex') -> tgt.gender = 'x'", false, "linkId.value in ('patient.sex')")]
+    [InlineData("where (linkId.value in ('patient.sex')) -> tgt.gender = 'x'", false, "linkId.value in ('patient.sex')")]
+    [InlineData("where %value + 5 days -> tgt.gender = 'x'", false, "%value + 5 days")]
+    [InlineData("check (%value + 5 days > 3) -> tgt.gender = 'x'", true, "%value + 5 days > 3")]
+    public void GivenEmbeddedFhirPathWithSignificantWhitespace_WhenParsing_ThenTheOriginalSpacingIsPreserved(
+        string clause, bool isCheck, string expected)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/Test' = 'Test'
+
+            group Main(source src, target tgt) {
+              src.item as item {{clause}};
+            }
+            """;
+
+        var parser = new MappingParser();
+
+        // Act
+        var map = parser.Parse(fml);
+
+        // Assert
+        var source = map.Groups[0].Rules[0].Sources[0];
+        var expr = isCheck ? source.Check : source.Condition;
+        expr.ShouldNotBeNull();
+        expr.ShouldBeOfType<FhirPathExpression>();
+        ((FhirPathExpression)expr!).PathExpression.ShouldBe(expected);
+    }
+}

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -189,9 +189,10 @@ public class FmlSyntaxCoverageTests
     }
 
     [Theory]
-    [InlineData("<<types>>")]
-    [InlineData("<<type+>>")]
-    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(string annotation)
+    [InlineData("<<types>>", GroupTypeMode.Types)]
+    [InlineData("<<type+>>", GroupTypeMode.TypeAndTypes)]
+    public void GivenAGroupTypeModeAnnotation_WhenRoundTripping_ThenTheAnnotationSurvives(
+        string annotation, GroupTypeMode expected)
     {
         // Arrange
         var fml = $$"""
@@ -206,7 +207,26 @@ public class FmlSyntaxCoverageTests
         var reparsed = new MappingParser().Parse(new FmlSerializer().Serialize(new MappingParser().Parse(fml)));
 
         // Assert
-        reparsed.Groups[0].TypeMode.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode);
+        reparsed.Groups[0].TypeMode.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenNoTypeModeAnnotation_WhenSerializing_ThenNoAnnotationIsEmitted()
+    {
+        // Arrange
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var serialized = new FmlSerializer().Serialize(new MappingParser().Parse(Fml));
+
+        // Assert
+        serialized.ShouldNotContain("<<");
     }
 
     [Fact]

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -44,4 +44,106 @@ public class FmlSyntaxCoverageTests
         expr.ShouldBeOfType<FhirPathExpression>();
         ((FhirPathExpression)expr!).PathExpression.ShouldBe(expected);
     }
+
+    [Fact]
+    public void GivenADoubleQuotedMapHeader_WhenParsing_ThenTheUrlAndNameAreRead()
+    {
+        // Arrange
+        const string Fml = """
+            map "http://hl7.org/fhir/StructureMap/tutorial" = "tutorial"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Url.ShouldBe("http://hl7.org/fhir/StructureMap/tutorial");
+        map.Identifier.ShouldBe("tutorial");
+    }
+
+    [Fact]
+    public void GivenADoubleQuotedStringWithAnEscapedQuote_WhenParsing_ThenTheEscapeIsResolved()
+    {
+        // Arrange
+        const string Fml = """
+            map "http://example.org/T" = "a \" b"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Identifier.ShouldBe("a \" b");
+    }
+
+    [Fact]
+    public void GivenADoubleQuotedStringWithAnEscapedBackslash_WhenParsing_ThenTheEscapeIsResolved()
+    {
+        // Arrange
+        const string Fml = """
+            map "http://example.org/T" = "a \\ b"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Identifier.ShouldBe(@"a \ b");
+    }
+
+    [Fact]
+    public void GivenADoubleQuotedStringWithBackslashThenEscapedQuote_WhenParsing_ThenBothEscapesAreResolved()
+    {
+        // Arrange
+        const string Fml = """
+            map "http://example.org/T" = "a \\\" b"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Identifier.ShouldBe("a \\\" b");
+    }
+
+    [Fact]
+    public void GivenAConceptMapWithADoubleQuotedId_WhenParsing_ThenTheIdIsUnquoted()
+    {
+        // Arrange
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            conceptmap "#cm" {
+              prefix s = 'http://a'
+              prefix t = 'http://b'
+
+              s:x == t:y
+            }
+
+            group Main(source src, target tgt) { src.a as a -> tgt.a = a; }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.ConceptMaps.Count.ShouldBe(1);
+        map.ConceptMaps[0].Identifier.ShouldBe("#cm");
+    }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -331,5 +331,56 @@ public class FmlSyntaxCoverageTests
         map.Metadata["title"].ShouldBe("A Title From Metadata");
     }
 
+    [Fact]
+    public void GivenDuplicateNonSpecialMetadataKey_WhenParsing_ThenLastValueWins()
+    {
+        // Arrange — two /// title declarations; last-wins must apply and no exception may be thrown
+        const string Fml = """
+            /// title = 'First title'
+            /// title = 'Second title'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Metadata["title"].ShouldBe("Second title");
+    }
+
+    [Fact]
+    public void GivenDuplicateUrlMetadataKey_WhenParsing_ThenLastValueWinsAndUrlIsPopulated()
+    {
+        // Arrange — two /// url declarations; the later one must win for MapExpression.Url
+        const string Fml = """
+            /// url = 'http://example.org/First'
+            /// url = 'http://example.org/Second'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Url.ShouldBe("http://example.org/Second");
+    }
+
+    [Fact]
+    public void GivenMetadataWithoutUrlOrGroups_WhenParsing_ThenExceptionMessageDescribesActualCondition()
+    {
+        // Arrange — title metadata is present but url/name are absent and there are no groups
+        const string Fml = "/// title = 'Only a title'";
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldBe("The input has no groups and no url or name from a map header or metadata declarations.");
+    }
+
     #endregion
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -372,14 +372,172 @@ public class FmlSyntaxCoverageTests
     }
 
     [Fact]
-    public void GivenMetadataWithoutUrlOrGroups_WhenParsing_ThenExceptionMessageDescribesActualCondition()
+    public void GivenMetadataWithNoGroups_WhenParsing_ThenExceptionMessageDescribesActualCondition()
     {
-        // Arrange — title metadata is present but url/name are absent and there are no groups
+        // Arrange — title metadata is present but there are no groups; groups are mandatory per spec
+        // Classification (a): old guard checked url+identifier conjuncts, which was non-conformant;
+        // groupDeclaration+ in the official grammar means groups are the only required element.
         const string Fml = "/// title = 'Only a title'";
 
         // Act & Assert
         var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
-        ex.Message.ShouldBe("The input has no groups and no url or name from a map header or metadata declarations.");
+        ex.Message.ShouldBe("The input has no group declarations; at least one group is required.");
+    }
+
+    // ── FIX 1: malformed metadata declarations ──────────────────────────────────
+
+    [Fact]
+    public void GivenMetadataLineWithMissingEquals_WhenParsing_ThenThrowsWithLineInfo()
+    {
+        // Arrange — '/// url value' has no '='; must be rejected with position, not silently dropped
+        const string Fml = """
+            /// url 'http://example.org/ShouldNotBeSilentlyDropped'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldContain("Malformed metadata declaration");
+        ex.Message.ShouldContain("at line 1");
+    }
+
+    [Fact]
+    public void GivenMetadataKeyStartingWithDigit_WhenParsing_ThenThrowsWithLineInfo()
+    {
+        // Arrange — '/// 1title = x' has a key starting with a digit, violating the key grammar
+        const string Fml = """
+            /// 1title = 'x'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldContain("Malformed metadata declaration");
+        ex.Message.ShouldContain("at line 1");
+    }
+
+    [Fact]
+    public void GivenFourSlashPrefix_WhenParsing_ThenThrowsWithLineInfo()
+    {
+        // Arrange — '////' is not a valid metadata prefix (no whitespace after ///)
+        const string Fml = """
+            //// url = 'http://example.org'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldContain("Malformed metadata declaration");
+        ex.Message.ShouldContain("at line 1");
+    }
+
+    [Fact]
+    public void GivenNoSpaceAfterTripleSlash_WhenParsing_ThenThrowsWithLineInfo()
+    {
+        // Arrange — '///url = x' omits required whitespace between /// and key
+        const string Fml = """
+            ///url = 'http://example.org'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldContain("Malformed metadata declaration");
+        ex.Message.ShouldContain("at line 1");
+    }
+
+    [Fact]
+    public void GivenMetadataWithEmptyValue_WhenParsing_ThenValueIsEmptyString()
+    {
+        // Arrange — the grammar makes the value optional; '/// title =' is valid with value = ""
+        const string Fml = """
+            /// title =
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Metadata["title"].ShouldBe("");
+    }
+
+    // ── FIX 3: UnescapeString path pinning ──────────────────────────────────────
+
+    [Fact]
+    public void GivenUnquotedMetadataValue_WhenParsing_ThenValueIsReturnedLiterally()
+    {
+        // Arrange — bare unquoted value is returned as-is by UnescapeString
+        const string Fml = """
+            /// status = draft
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Metadata["status"].ShouldBe("draft");
+    }
+
+    [Fact]
+    public void GivenDoubleQuotedMetadataValue_WhenParsing_ThenQuotesAreStripped()
+    {
+        // Arrange — double-quoted value has its surrounding quotes removed by UnescapeString
+        const string Fml = """
+            /// title = "Hello World"
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Metadata["title"].ShouldBe("Hello World");
+    }
+
+    // ── FIX 4: Ordinal case-sensitivity pin ─────────────────────────────────────
+
+    [Fact]
+    public void GivenUpperCaseMetadataUrlKey_WhenParsing_ThenKeyPreservedAndMapUrlRemainsEmpty()
+    {
+        // Arrange — 'URL' (uppercase) is a different key from 'url' (lowercase) under Ordinal compare;
+        // GetValueOrDefault("url") must NOT find it, so MapExpression.Url stays empty.
+        const string Fml = """
+            /// URL = 'http://example.org/UpperCase'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Metadata["URL"].ShouldBe("http://example.org/UpperCase");
+        map.Url.ShouldBe("");
     }
 
     #endregion

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -541,4 +541,98 @@ public class FmlSyntaxCoverageTests
     }
 
     #endregion
+
+    [Fact]
+    public void GivenSimpleParenthesizedTransform_WhenParsing_ThenPathExpressionIsExtracted()
+    {
+        // Arrange — corpus line: tgt.gender = (item.answer.valueString)
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.item as item -> tgt.gender = (item.answer.valueString);
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        var target = map.Groups[0].Rules[0].Targets[0];
+        var expr = target.Transform.ShouldBeOfType<FhirPathExpression>();
+        expr.PathExpression.ShouldBe("item.answer.valueString");
+    }
+
+    [Fact]
+    public void GivenParenthesizedTransformWithOperator_WhenParsing_ThenFullExpressionTextIsExtracted()
+    {
+        // Arrange — corpus line: ext.system = ('urn:uuid:' + r.lower()) "rootuuid"
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src -> tgt.identifer as ext, ext.system = ('urn:uuid:' + r.lower()) "rootuuid";
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        var rule = map.Groups[0].Rules[0];
+        var target = rule.Targets[1];
+        var expr = target.Transform.ShouldBeOfType<FhirPathExpression>();
+        expr.PathExpression.ShouldBe("'urn:uuid:' + r.lower()");
+        rule.Name.ShouldBe("rootuuid");
+    }
+
+    [Fact]
+    public void GivenParenthesizedTransformWithExternalConstantAndQuantity_WhenParsing_ThenFullExpressionTextIsExtracted()
+    {
+        // Arrange — corpus line: tgt.birthDate = (%value + 5 days) "plus"
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              ext.value as value -> tgt.birthDate = (%value + 5 days) "plus";
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        var rule = map.Groups[0].Rules[0];
+        var target = rule.Targets[0];
+        var expr = target.Transform.ShouldBeOfType<FhirPathExpression>();
+        expr.PathExpression.ShouldBe("%value + 5 days");
+        rule.Name.ShouldBe("plus");
+    }
+
+    [Fact]
+    public void GivenNonParenthesizedTargetWithAsAndRuleName_WhenParsing_ThenVariableAndNameAreNotSwallowedByFhirPath()
+    {
+        // Arrange — regression guard: verifies ParenthesizedFhirPathExpression was used, not the
+        // greedy FhirPathExpression, which would consume 'as v "name"' as part of the expression.
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.x = foo as v "name";
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert — the greedy FhirPathExpression would swallow 'as v "name"' into the expression;
+        // ParenthesizedFhirPathExpression cannot start with an Identifier so it falls through,
+        // leaving QualifiedIdentifier to bind 'foo' and the rule machinery to bind 'v' and 'name'.
+        var rule = map.Groups[0].Rules[0];
+        var target = rule.Targets[0];
+        target.Variable.ShouldBe("v");
+        rule.Name.ShouldBe("name");
+        target.Transform.ShouldBeOfType<IdentifierExpression>()
+            .Name.ShouldBe("foo");
+    }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -208,4 +208,44 @@ public class FmlSyntaxCoverageTests
         // Assert
         reparsed.Groups[0].TypeMode.ShouldBe(new MappingParser().Parse(fml).Groups[0].TypeMode);
     }
+
+    [Fact]
+    public void GivenABareTypeAnnotation_WhenParsing_ThenItIsRejected()
+    {
+        // Arrange
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) <<type>> {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+        ex.Message.ShouldContain("expected plus");
+    }
+
+    [Theory]
+    [InlineData("<<types>>", GroupTypeMode.Types)]
+    [InlineData("<<type+>>", GroupTypeMode.TypeAndTypes)]
+    public void GivenAGroupWithExtendsAndTypeModeAnnotation_WhenRoundTripping_ThenBothSurvive(
+        string annotation, GroupTypeMode expectedMode)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) extends Base {{annotation}} {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var reparsed = new MappingParser().Parse(new FmlSerializer().Serialize(new MappingParser().Parse(fml)));
+
+        // Assert
+        reparsed.Groups[0].Extends.ShouldBe("Base");
+        reparsed.Groups[0].TypeMode.ShouldBe(expectedMode);
+    }
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/FmlSyntaxCoverageTests.cs
@@ -268,4 +268,68 @@ public class FmlSyntaxCoverageTests
         reparsed.Groups[0].Extends.ShouldBe("Base");
         reparsed.Groups[0].TypeMode.ShouldBe(expectedMode);
     }
+
+    #region R6 metadata-declaration form (Task 5)
+
+    [Fact]
+    public void GivenMetadataDeclarationsInsteadOfAMapHeader_WhenParsing_ThenUrlAndNameAreDerivedFromMetadata()
+    {
+        // Arrange
+        const string Fml = """
+            /// url = 'http://hl7.org/fhir/uv/xver/StructureMap/Element4to6'
+            /// name = 'Element4to6'
+            /// title = 'Element Transforms: R4 to R6'
+
+            group Element(source src, target tgt) {
+              src.id as v -> tgt.id = v;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert
+        map.Url.ShouldBe("http://hl7.org/fhir/uv/xver/StructureMap/Element4to6");
+        map.Identifier.ShouldBe("Element4to6");
+        map.Metadata["title"].ShouldBe("Element Transforms: R4 to R6");
+    }
+
+    [Fact]
+    public void GivenOnlyCommentsAndWhitespace_WhenParsing_ThenAParseExceptionIsThrown()
+    {
+        // Arrange
+        const string Fml = """
+            // nothing to see here
+            """;
+
+        // Act & Assert
+        Should.Throw<ParseException>(() => new MappingParser().Parse(Fml));
+    }
+
+    [Fact]
+    public void GivenBothExplicitHeaderAndMetadata_WhenParsing_ThenExplicitHeaderWinsForUrlAndName()
+    {
+        // Arrange — explicit 'map' header overrides any metadata declarations with the same keys
+        const string Fml = """
+            /// url = 'http://metadata.example.org/ShouldNotWin'
+            /// name = 'MetadataName'
+            /// title = 'A Title From Metadata'
+            map 'http://header.example.org/ShouldWin' = 'HeaderName'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+            """;
+
+        // Act
+        var map = new MappingParser().Parse(Fml);
+
+        // Assert — explicit header values win
+        map.Url.ShouldBe("http://header.example.org/ShouldWin");
+        map.Identifier.ShouldBe("HeaderName");
+        // Metadata dict still populated (title is metadata-only)
+        map.Metadata["title"].ShouldBe("A Title From Metadata");
+    }
+
+    #endregion
 }

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
@@ -728,13 +728,14 @@ group PatientToBundle(source src : Patient, target bundle : Bundle) {
     public void GivenUnconsumedTrailingTokens_WhenParsing_ThenThrowsParseException()
     {
         // Arrange
-        // The leading 'map' keyword is optional since R6; the failure comes from the unconsumed '= 'Test'' tokens.
+        // The 'map' keyword is optional since R6; no grammar rule consumes a bare string literal,
+        // so .AtEnd() rejects the input regardless of what follows it.
         var mappingText = "'http://example.org' = 'Test'";
         var compiler = new MappingParser();
 
         // Act & Assert
-        var act = () => compiler.Parse(mappingText);
-        Should.Throw<ParseException>(act);
+        var ex = Should.Throw<ParseException>(() => compiler.Parse(mappingText));
+        ex.Message.ShouldStartWith("Failed to parse mapping expression at line 1, column 1:");
     }
 
     [Fact]

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
@@ -38,19 +38,18 @@ group Main(source src : Patient, target tgt : Bundle) {
     }
 
     [Fact]
-    public void GivenMapWithNoGroups_WhenParsing_ThenReturnsMapWithEmptyGroups()
+    public void GivenMapWithNoGroups_WhenParsing_ThenThrowsParseException()
     {
         // Arrange
+        // Classification (a): the official FML grammar has groupDeclaration+, so zero groups is invalid.
+        // The old test asserted empty-groups parse success, which was always wrong per spec.
         var mappingText = @"
 map 'http://example.org/fhir/StructureMap/Empty' = 'EmptyMap'
 ";
         var compiler = new MappingParser();
 
-        // Act
-        var result = compiler.Parse(mappingText);
-
-        // Assert
-        result.Groups.ShouldBeEmpty();
+        // Act & Assert
+        Should.Throw<ParseException>(() => compiler.Parse(mappingText));
     }
 
     #endregion
@@ -736,6 +735,26 @@ group PatientToBundle(source src : Patient, target bundle : Bundle) {
         // Act & Assert
         var ex = Should.Throw<ParseException>(() => compiler.Parse(mappingText));
         ex.Message.ShouldStartWith("Failed to parse mapping expression at line 1, column 1:");
+    }
+
+    [Fact]
+    public void GivenCompleteValidMapWithTrailingJunk_WhenParsing_ThenThrowsParseException()
+    {
+        // Arrange — a fully valid map (header + group) followed by tokens no rule consumes
+        const string Fml = """
+            map 'http://example.org/T' = 'T'
+
+            group Main(source src, target tgt) {
+              src.a as a -> tgt.a = a;
+            }
+
+            extra
+            """;
+        var compiler = new MappingParser();
+
+        // Act & Assert
+        var ex = Should.Throw<ParseException>(() => compiler.Parse(Fml));
+        ex.Message.ShouldStartWith("Failed to parse mapping expression at line");
     }
 
     [Fact]

--- a/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Parser/MappingGrammarTests.cs
@@ -725,9 +725,10 @@ group PatientToBundle(source src : Patient, target bundle : Bundle) {
     #region Error Cases Tests
 
     [Fact]
-    public void GivenMissingMapKeyword_WhenParsing_ThenThrowsParseException()
+    public void GivenUnconsumedTrailingTokens_WhenParsing_ThenThrowsParseException()
     {
         // Arrange
+        // The leading 'map' keyword is optional since R6; the failure comes from the unconsumed '= 'Test'' tokens.
         var mappingText = "'http://example.org' = 'Test'";
         var compiler = new MappingParser();
 

--- a/test/Ignixa.FhirMappingLanguage.Tests/Serialization/StructureMapBuilderVersionTests.cs
+++ b/test/Ignixa.FhirMappingLanguage.Tests/Serialization/StructureMapBuilderVersionTests.cs
@@ -251,4 +251,90 @@ public class StructureMapBuilderVersionTests
         // Assert
         structureMap.SupportsConstants().ShouldBeFalse();
     }
+
+    [Fact]
+    public void GivenR4Builder_WhenBuildingGroupWithNoTypeMode_ThenTypeModeIsNoneInJson()
+    {
+        // Arrange
+        var fml = """
+            map 'http://example.org/test' = 'TestMap'
+
+            group Main(source src, target tgt) {
+            }
+            """;
+        var ast = _parser.Parse(fml);
+        var builder = new StructureMapBuilder(FhirVersion.R4);
+
+        // Act
+        var structureMap = builder.Build(ast);
+
+        // Assert
+        structureMap.Group[0].MutableNode()["typeMode"]!.GetValue<string>().ShouldBe("none");
+    }
+
+    [Theory]
+    [InlineData("<<types>>", "types")]
+    [InlineData("<<type+>>", "type-and-types")]
+    public void GivenR4Builder_WhenBuildingAnnotatedGroup_ThenTypeModeIsEmittedInJson(
+        string annotation, string expectedWireValue)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/test' = 'TestMap'
+
+            group Main(source src, target tgt) {{annotation}} {
+            }
+            """;
+        var ast = _parser.Parse(fml);
+        var builder = new StructureMapBuilder(FhirVersion.R4);
+
+        // Act
+        var structureMap = builder.Build(ast);
+
+        // Assert
+        structureMap.Group[0].MutableNode()["typeMode"]!.GetValue<string>().ShouldBe(expectedWireValue);
+    }
+
+    [Fact]
+    public void GivenR5Builder_WhenBuildingGroupWithNoTypeMode_ThenTypeModeIsOmittedFromJson()
+    {
+        // Arrange
+        var fml = """
+            map 'http://example.org/test' = 'TestMap'
+
+            group Main(source src, target tgt) {
+            }
+            """;
+        var ast = _parser.Parse(fml);
+        var builder = new StructureMapBuilder(FhirVersion.R5);
+
+        // Act
+        var structureMap = builder.Build(ast);
+
+        // Assert
+        structureMap.Group[0].MutableNode().ContainsKey("typeMode").ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("<<types>>", "types")]
+    [InlineData("<<type+>>", "type-and-types")]
+    public void GivenR5Builder_WhenBuildingAnnotatedGroup_ThenTypeModeIsEmittedInJson(
+        string annotation, string expectedWireValue)
+    {
+        // Arrange
+        var fml = $$"""
+            map 'http://example.org/test' = 'TestMap'
+
+            group Main(source src, target tgt) {{annotation}} {
+            }
+            """;
+        var ast = _parser.Parse(fml);
+        var builder = new StructureMapBuilder(FhirVersion.R5);
+
+        // Act
+        var structureMap = builder.Build(ast);
+
+        // Assert
+        structureMap.Group[0].MutableNode()["typeMode"]!.GetValue<string>().ShouldBe(expectedWireValue);
+    }
 }


### PR DESCRIPTION
## Summary

Grades Ignixa's FML engine against the official HL7 `fhir-test-cases` corpus. An evidence probe found the parser could read **0 of 27** official `.map` files, which inverted the deliverable: the first thing needed was not a harness but parser fixes, with the corpora as their acceptance tests.

**Part A — six parser defects fixed** (`src/Core/Ignixa.FhirMappingLanguage/`)

| # | Defect | Found by |
|---|---|---|
| 1 | Operator tokens (`+ - % / \| & <= >=`) absent from the tokenizer | investigation |
| 2 | Group type-mode `<<types>>` / `<<type+>>` unsupported | investigation |
| 3 | Double-quoted string literals lexed as `DelimitedIdentifier` | investigation |
| 4 | `///` metadata declarations swallowed as comments; `map` header mandatory | investigation |
| 5 | Embedded FHIRPath re-serialised from tokens, gluing them together and corrupting the expression | planning |
| 6 | Parenthesized FHIRPath transforms `('urn:uuid:' + r.lower())` rejected | the corpus gate itself |

Defects 5 and 6 were surfaced *by the gate*, not by inspection — the main argument for keeping it.

**Part B — oracle harness** (test-only, `test/Ignixa.FhirMappingLanguage.Tests/Conformance/`)

Corpus vendored via the existing `DownloadFhirTestCases` MSBuild pattern (pinned 1.7.46, gitignored, never committed). Manifest loader for the official `<fml-tests>` XML, canonical JSON comparison, a parse-rate ratchet, and an end-to-end transform oracle.

## Measured results

| Metric | Before | After |
|---|---:|---:|
| `r5` `structure-mapping` `.map` parsed | 0/15 | **14/15** |
| `r4b` `structure-mapping` `.map` parsed | 0/12 | **11/12** |
| `validator` `.fml` parsed | 0/2 | **2/2** |
| Transform oracle, in-scope cases passing | — | **2/12** |
| `Ignixa.FhirMappingLanguage.Tests` | 546 | **656** |

The sole parse failure is `qr2cda-eval.map` (both versions): a nested `evaluate(src, iif(...))` transform, deferred with a written reason — it produces CDA XML that the oracle excludes anyway.

**2/12 is a baseline, not a success metric.** What the harness exposed is that `MappingEvaluator` is substantially less complete than `MappingParser` now is. The ten failures reduce to five distinct evaluator defects, now reproducible, named, and individually tracked: #372 (target alias binds to source), #373 (nested/recursive `then` groups), #374 (`create()`/`reference()` target registration), #375 (FHIRPath `conformsTo()`).

## Design notes

**Two frozen lists with opposite polarity, deliberately not merged.**
`FmlOracleExclusions` = "cannot compare at all" (4 CDA/XML-output cases × 2 versions). `FmlKnownEvaluatorGaps` = "we DO execute and compare, and we know it currently fails" — these assert the case is *still broken*, so fixing one **fails the test** and demands the entry be deleted. A guard test asserts every excluded case has an XML output file, so the exclusion list cannot absorb a hard-but-comparable JSON case to make the number go up.

**Behaviour change to watch on merge.** Fixing defect 4 *tightens* the accepted input surface: `///` used to lex as an ordinary comment and be ignored, and must now be a well-formed `/// key = value` declaration. This matches the HL7 grammar (`METADATA_PREFIX : '/// '`, `LINE_COMMENT : '//' ~[/]`) and is covered by malformed-input tests, but it is the only change here that can reject input that previously parsed. Everything else is strictly more permissive.

**Two premises were measured false and the plan amended rather than forced.** The FML validation *diagnostic* oracle turned out to be unreachable through `ValidatorConformanceRunner` on four independent counts — most damningly, the runner `JsonNode.Parse`es its input and scores a `JsonException` as `Invalid`, so FML files would have appeared to pass *because JSON parsing failed*. Reduced to a parse ratchet; the real work is #376. Separately, #377 records that `StructureMapParser` drops `typeMode` on the StructureMap-JSON → FML direction (found by final review; the FML-text and FML → StructureMap directions are both correct and tested).

## Test Plan

- [x] `dotnet test All.sln` — green on `net9.0` and `net10.0`, twice
- [x] `Ignixa.FhirMappingLanguage.Tests` 656 passed / 0 failed / 1 skipped, both TFMs
- [x] Independent final review: **APPROVED** — three production mutations (token-glue regression, `StructureMapBuilder` typeMode code, empty-group guard) each killed real tests; no mutation killed nothing; no test found that cannot fail
- [x] Ratchets mutation-verified: changing one gap key produced exactly 6 failures; appending `.absent` to a corpus filename produced exactly 2
- [x] Pre-existing unrelated failures confirmed present on `main` too: `RepoGuards` 9×2 (`Packages/` gitignore paths), `SqlOnFhir` 2×2

Documented in `docs/features/structuremap/investigations/fml-oracle-conformance-corpus.md`; execution spec in `docs/superpowers/plans/2026-07-28-fml-parser-conformance-and-oracle-tests.md`.