### PR TITLE
Four compiler fixes found during the FHIR Server SQL cutover

### DIFF
--- a/docs/site/docs/core-sdk/search.md
+++ b/docs/site/docs/core-sdk/search.md
@@ -77,7 +77,20 @@ var supported = supportedManager.GetSearchParameters("Patient");
 // Only returns parameters marked as searchable
 var searchableManager = new SearchableSearchParameterDefinitionManager(manager);
 var searchable = searchableManager.GetSearchParameters("Patient");
+
+// Optionally admit parameters that are registered but not yet reindexed ("partially indexed").
+// The delegate is consulted per call; omitting it defaults to refusing them.
+var partial = new SearchableSearchParameterDefinitionManager(manager, () => true);
 ```
+
+:::warning Partially indexed parameters
+
+Opting in makes results **wrong in both directions**, not merely incomplete. A resource that has not been
+reindexed yet has no index rows for the parameter, so a positive filter omits it while a negated one
+(`:not`, `:missing=true`) returns it as a match. Nothing in the response bundle distinguishes such a
+result from a complete one, so only enable this when the caller has explicitly asked for partial results.
+
+:::
 
 ## SearchParameterInfo
 

--- a/docs/site/docs/core-sdk/search.md
+++ b/docs/site/docs/core-sdk/search.md
@@ -79,16 +79,18 @@ var searchableManager = new SearchableSearchParameterDefinitionManager(manager);
 var searchable = searchableManager.GetSearchParameters("Patient");
 
 // Optionally admit parameters that are registered but not yet reindexed ("partially indexed").
-// The delegate is consulted per call; omitting it defaults to refusing them.
+// Each accessor invokes the delegate exactly once and applies that answer to every result it
+// returns; omitting the delegate defaults to refusing them.
 var partial = new SearchableSearchParameterDefinitionManager(manager, () => true);
 ```
 
 :::warning Partially indexed parameters
 
 Opting in makes results **wrong in both directions**, not merely incomplete. A resource that has not been
-reindexed yet has no index rows for the parameter, so a positive filter omits it while a negated one
-(`:not`, `:missing=true`) returns it as a match. Nothing in the response bundle distinguishes such a
-result from a complete one, so only enable this when the caller has explicitly asked for partial results.
+reindexed yet has no index rows for the parameter, so a positive filter omits it, while a negation
+(`:not`, `:missing=true`) lowers to `Except(every resource of the type, the inner match)` and hands that
+same resource back as a match. Nothing in the response bundle distinguishes such a result from a complete
+one, so only enable this when the caller has explicitly asked for partial results.
 
 :::
 
@@ -124,11 +126,11 @@ public class SearchParameterInfo
     // Components (for composite parameters)
     public IReadOnlyList<SearchParameterComponentInfo> Component { get; }
 
-    // Whether this parameter is searchable
-    public bool IsSearchable { get; }
+    // Whether this parameter is searchable (mutated in place as reindexing progresses)
+    public bool IsSearchable { get; set; }
 
-    // Whether this parameter is supported
-    public bool IsSupported { get; }
+    // Whether this parameter is supported (mutated in place as reindexing progresses)
+    public bool IsSupported { get; set; }
 }
 ```
 

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -296,6 +296,30 @@ internal static class SqlBuilder
                 $"{offsetSpec.Offset} and Limit {offsetSpec.Limit}. OFFSET/FETCH rejects both at runtime.");
         }
 
+        // Guarded independently of Lower.Run because QueryPlan is a public construction surface. Every node
+        // that carries a resource-type list renders it as an OR of equalities and interpolates the joined
+        // string straight into its WHERE clause, so joining zero of them leaves the clause empty and the
+        // statement does not parse -- an opaque SQL Server error rather than a diagnosis here.
+        for (var i = 0; i < plan.Ctes.Count; i++)
+        {
+            var emptyTypeList = plan.Ctes[i] switch
+            {
+                CteDefinition.ChainJoin { OutputResourceTypeIds.Count: 0 } => nameof(CteDefinition.ChainJoin.OutputResourceTypeIds),
+                CteDefinition.ReferencedTypeExpansion { OutputResourceTypeIds.Count: 0 } => nameof(CteDefinition.ReferencedTypeExpansion.OutputResourceTypeIds),
+                CteDefinition.CompartmentSource { ResourceTypeIds.Count: 0 } => nameof(CteDefinition.CompartmentSource.ResourceTypeIds),
+                _ => null,
+            };
+
+            if (emptyTypeList is not null)
+            {
+                throw new NotSupportedException(
+                    $"Ctes[{i}].{emptyTypeList} names no resource type. The list is rendered as an OR of type-id " +
+                    "equalities and interpolated unconditionally into the WHERE clause, so an empty one emits no " +
+                    "filter text and the statement does not parse. Name the types the node should match, or remove " +
+                    "the node -- a node that should match nothing is not expressible as an absent filter.");
+            }
+        }
+
         // All three page guards below describe ways the emitted seek would disagree with the emitted ORDER BY.
         // A count emits neither -- EmitCountOnlyShape never reads Page -- so one exemption covers all three
         // rather than each restating it. Options-level callers cannot reach this at all: SearchPaging hangs off

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -331,8 +331,7 @@ internal static class Lower
         return context.Intersect(match, baseSet);
     }
 
-    /// <summary>Dispatches one expression node to the lowering path for its kind (leaf, missing, composite, AND, OR,
-    /// union, chain, or compartment).
+    /// <summary>Dispatches one expression node to the lowering path for its kind.
     /// A null <paramref name="resourceType"/> reaches here only under system-level search. Chain carries its own
     /// resource types rather than consuming the ambient one — a reverse chain scopes its inner expression against
     /// its single referencing type and emits its target types, a forward chain the mirror image — so it needs no
@@ -343,14 +342,10 @@ internal static class Lower
     /// <para>
     /// <see cref="UnionExpression"/> and an OR both lower to the same set union. They are distinct nodes because
     /// they say different things about their operands - an OR combines alternative <em>values</em> of one
-    /// parameter, a union combines independent row-producing <em>legs</em> (the shape a SMART compartment expands
-    /// to, where one leg is a compartment traversal, another a type filter, another an orphan scan) - but once
-    /// each operand has become a CTE that distinction has no expression left in the plan. A union is lowered
-    /// leg-by-leg through <see cref="LowerScopedExpression"/>, which handles a null (system-level) scope as well
-    /// as a concrete one - the scope a SMART compartment search needs, where the whole union sits under no single
-    /// target type.
-    /// </para>
-    /// <para>
+    /// parameter, a union combines independent row-producing <em>legs</em> - but once each operand has become a
+    /// CTE that distinction has no expression left in the plan. A union is lowered leg-by-leg through
+    /// <see cref="LowerScopedExpression"/>, which handles a null (system-level) scope as well as a concrete one,
+    /// so the whole union may sit under no single target type.
     /// <see cref="UnionExpression.Operator"/> is deliberately not consulted. A CTE here yields a set of
     /// <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is the same row admitted by two
     /// legs, never two distinct results. UNION ALL would let such a row be counted twice by <c>_total</c> and

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -18,7 +18,8 @@ internal static class Lower
     /// <summary>Lowers a whole search into a QueryPlan: extracts resource-column predicates into an outer WHERE,
     /// lowers the remaining expression (or a bare resource source) into the CTE graph, then attaches includes,
     /// sort, and paging. A null target type is allowed only for a wildcard compartment or system-level search;
-    /// chain, :not/:missing=true, _not-referenced, :text, _include/_revinclude and _sort still require one and throw.</summary>
+    /// :not/:missing=true, _not-referenced, :text, _include/_revinclude and _sort still require one and throw. A
+    /// chain does not: it names its own types (see <see cref="LowerNode"/>).</summary>
     internal static LoweredPlan Run(CompilationContext context, SymbolTable symbols)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -331,26 +332,18 @@ internal static class Lower
         return context.Intersect(match, baseSet);
     }
 
-    /// <summary>Dispatches one expression node to the lowering path for its kind.
-    /// A null <paramref name="resourceType"/> reaches here only under system-level search. Chain carries its own
-    /// resource types rather than consuming the ambient one — a reverse chain scopes its inner expression against
-    /// its single referencing type and emits its target types, a forward chain the mirror image — so it needs no
-    /// ambient scope and none is passed to <see cref="StructuralContext.LowerChain"/>. The identities a ChainJoin
-    /// yields are always over concrete types, so an enclosing cross-type intersection stays well-typed. The
-    /// ambiguity that would genuinely break a chain (more than one type on the side that must be single) is
-    /// guarded inside <c>LowerChain</c> itself, where both directions reach it.
-    /// <para>
-    /// <see cref="UnionExpression"/> and an OR both lower to the same set union. They are distinct nodes because
-    /// they say different things about their operands - an OR combines alternative <em>values</em> of one
-    /// parameter, a union combines independent row-producing <em>legs</em> - but once each operand has become a
-    /// CTE that distinction has no expression left in the plan. A union is lowered leg-by-leg through
-    /// <see cref="LowerScopedExpression"/>, which handles a null (system-level) scope as well as a concrete one,
-    /// so the whole union may sit under no single target type.
-    /// <see cref="UnionExpression.Operator"/> is deliberately not consulted. A CTE here yields a set of
-    /// <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is the same row admitted by two
-    /// legs, never two distinct results. UNION ALL would let such a row be counted twice by <c>_total</c> and
-    /// consume two slots of a page, so the distinct union is the only correct emission for either operator.
-    /// </para></summary>
+    /// <summary>Dispatches one expression node to the lowering path for its kind. A null
+    /// <paramref name="resourceType"/> reaches here only under system-level search, and a chain tolerates it: a
+    /// chain names its own types — a reverse chain scopes its inner expression against its single referencing
+    /// type and emits its target types, a forward chain the mirror image — so the ambient scope is unused and
+    /// none is passed on. The guard for a side that resolved to anything other than exactly one type therefore
+    /// lives in <see cref="StructuralContext.LowerChain"/>, where both directions reach it. Those type names come
+    /// from the IR and resolve to concrete ids (or <see cref="SymbolTable.UnmatchableResourceTypeId"/> for a name
+    /// the resolver could not find), never to an absent type filter, so an enclosing cross-type intersection
+    /// stays well-typed. <see cref="UnionExpression"/> documents why either union operator lowers to a distinct
+    /// union; note the OR and union arms below are not interchangeable — a union leg goes through
+    /// <see cref="LowerScopedExpression"/>, which can recover a per-leg type under a null scope, while an OR's
+    /// operands are alternative values of one parameter and lower with the ambient scope as-is.</summary>
     private static CteRef LowerNode(Expression expression, StructuralContext context, string? resourceType) => expression switch
     {
         SearchParameterPredicateExpression { Modifier.SearchModifierCode: SearchModifierCode.Not } => throw new NotSupportedException(

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -17,9 +17,12 @@ internal static class Lower
 {
     /// <summary>Lowers a whole search into a QueryPlan: extracts resource-column predicates into an outer WHERE,
     /// lowers the remaining expression (or a bare resource source) into the CTE graph, then attaches includes,
-    /// sort, and paging. A null target type is allowed only for a wildcard compartment or system-level search;
-    /// :not/:missing=true, _not-referenced, :text, _include/_revinclude and _sort still require one and throw. A
-    /// chain does not: it names its own types (see <see cref="LowerNode"/>).</summary>
+    /// sort, and paging. A null target type is allowed only for a wildcard compartment or system-level search,
+    /// and the two differ. A wildcard compartment search admits a CompartmentSearchExpression and
+    /// resource-column predicates only — every other residue throws, a chain included — and rejects _sort. A
+    /// system-level search lowers its leaves cross-type and accepts both _sort and a chain (which names its own
+    /// types, see <see cref="LowerNode"/>), but still rejects :not/:missing=true, _not-referenced, :text and
+    /// $everything. _include/_revinclude throws under either.</summary>
     internal static LoweredPlan Run(CompilationContext context, SymbolTable symbols)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -334,16 +337,12 @@ internal static class Lower
 
     /// <summary>Dispatches one expression node to the lowering path for its kind. A null
     /// <paramref name="resourceType"/> reaches here only under system-level search, and a chain tolerates it: a
-    /// chain names its own types — a reverse chain scopes its inner expression against its single referencing
-    /// type and emits its target types, a forward chain the mirror image — so the ambient scope is unused and
-    /// none is passed on. The guard for a side that resolved to anything other than exactly one type therefore
-    /// lives in <see cref="StructuralContext.LowerChain"/>, where both directions reach it. Those type names come
-    /// from the IR and resolve to concrete ids (or <see cref="SymbolTable.UnmatchableResourceTypeId"/> for a name
-    /// the resolver could not find), never to an absent type filter, so an enclosing cross-type intersection
-    /// stays well-typed. <see cref="UnionExpression"/> documents why either union operator lowers to a distinct
-    /// union; note the OR and union arms below are not interchangeable — a union leg goes through
-    /// <see cref="LowerScopedExpression"/>, which can recover a per-leg type under a null scope, while an OR's
-    /// operands are alternative values of one parameter and lower with the ambient scope as-is.</summary>
+    /// chain names its own types (a reverse chain scopes its inner expression against its referencing type and
+    /// emits its target types, a forward chain the mirror image), so the ambient scope is unused and none is
+    /// passed on. Every guard on those types therefore lives in <see cref="StructuralContext.LowerChain"/>,
+    /// where both directions reach it. The OR and union arms below look mergeable and are not: a union leg goes
+    /// through <see cref="LowerScopedExpression"/>, which can recover a per-leg type under a null scope, while
+    /// an OR's operands are alternative values of one parameter and lower with the ambient scope as-is.</summary>
     private static CteRef LowerNode(Expression expression, StructuralContext context, string? resourceType) => expression switch
     {
         SearchParameterPredicateExpression { Modifier.SearchModifierCode: SearchModifierCode.Not } => throw new NotSupportedException(

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -331,10 +331,31 @@ internal static class Lower
         return context.Intersect(match, baseSet);
     }
 
-    /// <summary>Dispatches one expression node to the lowering path for its kind. A null <paramref name="resourceType"/>
-    /// reaches here only under system-level search; chain carries its own types, so it needs an explicit guard or
-    /// a type-less chain would slip past every null-type guard in <see cref="Run"/>. UnionExpression and OR both
-    /// lower to a distinct set union (UNION ALL would double-count a row admitted by two legs).</summary>
+    /// <summary>Dispatches one expression node to the lowering path for its kind (leaf, missing, composite, AND, OR,
+    /// union, chain, or compartment).
+    /// A null <paramref name="resourceType"/> reaches here only under system-level search. Chain carries its own
+    /// resource types rather than consuming the ambient one — a reverse chain scopes its inner expression against
+    /// its single referencing type and emits its target types, a forward chain the mirror image — so it needs no
+    /// ambient scope and none is passed to <see cref="StructuralContext.LowerChain"/>. The identities a ChainJoin
+    /// yields are always over concrete types, so an enclosing cross-type intersection stays well-typed. The
+    /// ambiguity that would genuinely break a chain (more than one type on the side that must be single) is
+    /// guarded inside <c>LowerChain</c> itself, where both directions reach it.
+    /// <para>
+    /// <see cref="UnionExpression"/> and an OR both lower to the same set union. They are distinct nodes because
+    /// they say different things about their operands - an OR combines alternative <em>values</em> of one
+    /// parameter, a union combines independent row-producing <em>legs</em> (the shape a SMART compartment expands
+    /// to, where one leg is a compartment traversal, another a type filter, another an orphan scan) - but once
+    /// each operand has become a CTE that distinction has no expression left in the plan. A union is lowered
+    /// leg-by-leg through <see cref="LowerScopedExpression"/>, which handles a null (system-level) scope as well
+    /// as a concrete one - the scope a SMART compartment search needs, where the whole union sits under no single
+    /// target type.
+    /// </para>
+    /// <para>
+    /// <see cref="UnionExpression.Operator"/> is deliberately not consulted. A CTE here yields a set of
+    /// <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is the same row admitted by two
+    /// legs, never two distinct results. UNION ALL would let such a row be counted twice by <c>_total</c> and
+    /// consume two slots of a page, so the distinct union is the only correct emission for either operator.
+    /// </para></summary>
     private static CteRef LowerNode(Expression expression, StructuralContext context, string? resourceType) => expression switch
     {
         SearchParameterPredicateExpression { Modifier.SearchModifierCode: SearchModifierCode.Not } => throw new NotSupportedException(
@@ -350,11 +371,6 @@ internal static class Lower
             or.Expressions.Select(e => LowerNode(e, context, resourceType)).ToList()),
         UnionExpression union => context.Union(
             union.Expressions.Select(leg => LowerScopedExpression(leg, context, resourceType)).ToList()),
-        ChainedExpression when resourceType is null => throw new NotSupportedException(
-            "Chain is not supported in system-level search in this phase -- a chain resolves and joins against " +
-            "a concrete referencing/target type, which a cross-type search has no single value for. Guarding at " +
-            "the chain dispatch choke point covers a top-level chain and one nested in an AND equally; a chain " +
-            "reached inside another chain's scope always has a concrete type and never trips this."),
         ChainedExpression chain => context.LowerChain(chain, LowerScopedExpression),
         CompartmentSearchExpression compartment => context.LowerCompartment(compartment),
         NotReferencedExpression notReferenced => context.LowerNotReferenced(notReferenced, resourceType),

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -356,16 +356,13 @@ internal sealed class StructuralContext
         }
     }
 
-    /// <summary>The refusal for a chain whose <em>output</em> side named no resource type. Unlike the
-    /// must-be-single sides, an empty output list is not an ambiguity but a silent malformation: the emitter
-    /// renders the output types as an OR of equalities, and joining zero of them yields an empty string
-    /// interpolated into the WHERE clause, so the query fails at SQL Server as an opaque 500 rather than here
-    /// with a diagnosis.</summary>
+    /// <summary>The refusal for a chain whose <em>output</em> side named no resource type — a malformation
+    /// rather than the ambiguity the must-be-single sides guard against.</summary>
     private static string EmptyOutputSideMessage(string direction, string side, string binderMethod)
         => $"{direction} chain's {side} side resolved to 0 resource types -- a chain join filters its output rows to " +
-           "those types, and an empty list emits no filter at all rather than matching nothing. The real binder " +
-           $"never produces this shape ({binderMethod}), so this guard covers IR built directly against the " +
-           "compiler API.";
+           "those types by interpolating an OR of type-id equalities into its WHERE clause, so an empty list emits " +
+           "no filter text at all and the statement does not parse. The real binder never produces this shape " +
+           $"({binderMethod}), so this guard covers IR built directly against the compiler API.";
 
     public CteRef LowerCompartment(CompartmentSearchExpression expression)
         => LowerCompartmentCore(expression.CompartmentType, expression.CompartmentId, expression.FilteredResourceTypes);

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -306,16 +306,21 @@ internal sealed class StructuralContext
                 {
                     [var single] => single,
                     _ => throw new NotSupportedException(
-                        $"Reverse chain's referencing side resolved to {chain.ResourceTypes.Length} types -- the real binder " +
-                        "always binds a reverse chain's target expression against a single referencing type " +
-                        "(SearchKeyBinder.BindReverse's syntax.SourceResourceType), so this is unexpected input."),
+                        $"Reverse chain's referencing side resolved to {chain.ResourceTypes.Length} types -- a reverse chain " +
+                        "scopes its inner expression against exactly one referencing type, and the real binder binds it " +
+                        "that way (SearchKeyBinder.BindReverse's syntax.SourceResourceType). This is the only guard on " +
+                        "that shape for IR built directly against the compiler API, so it refuses rather than guessing."),
                 };
 
                 var innerMatch = lowerNode(chain.Expression, this, referencingResourceType);
                 innerMatch = _accessConstraints.Apply(innerMatch, referencingResourceType, this, lowerNode);
                 var referenceSearchParamId = _leafContext.SearchParamId(chain.ReferenceSearchParameter);
                 var innerResourceTypeId = _leafContext.ResourceTypeId(referencingResourceType);
-                var outputResourceTypeIds = chain.TargetResourceTypes.Select(_leafContext.ResourceTypeId).ToList();
+                var outputResourceTypeIds = chain.TargetResourceTypes switch
+                {
+                    { Length: > 0 } targets => targets.Select(_leafContext.ResourceTypeId).ToList(),
+                    _ => throw new NotSupportedException(EmptyOutputSideMessage("Reverse", "target", "SearchKeyBinder.BindReverse")),
+                };
 
                 _ctes.Add(new CteDefinition.ChainJoin(innerMatch, referenceSearchParamId, innerResourceTypeId, outputResourceTypeIds, ChainDirection.Reverse));
                 return new CteRef(_ctes.Count - 1);
@@ -325,16 +330,22 @@ internal sealed class StructuralContext
             {
                 [var single] => single,
                 _ => throw new NotSupportedException(
-                    $"Forward chain resolved to {chain.TargetResourceTypes.Length} candidate target types -- the real binder " +
-                    "always resolves forward chains to exactly one target type before this point (SearchKeyBinder.BindForward " +
-                    "throws ChainedParameterSpecifyType on genuine ambiguity), so this is unexpected input."),
+                    $"Forward chain resolved to {chain.TargetResourceTypes.Length} candidate target types -- a forward chain " +
+                    "scopes its inner expression against exactly one target type, and the real binder resolves it that way " +
+                    "before this point (SearchKeyBinder.BindForward throws ChainedParameterSpecifyType on genuine " +
+                    "ambiguity). This is the only guard on that shape for IR built directly against the compiler API, so " +
+                    "it refuses rather than guessing."),
             };
 
             var forwardInnerMatch = lowerNode(chain.Expression, this, targetResourceType);
             forwardInnerMatch = _accessConstraints.Apply(forwardInnerMatch, targetResourceType, this, lowerNode);
             var forwardReferenceSearchParamId = _leafContext.SearchParamId(chain.ReferenceSearchParameter);
             var forwardInnerResourceTypeId = _leafContext.ResourceTypeId(targetResourceType);
-            var forwardOutputResourceTypeIds = chain.ResourceTypes.Select(_leafContext.ResourceTypeId).ToList();
+            var forwardOutputResourceTypeIds = chain.ResourceTypes switch
+            {
+                { Length: > 0 } referencing => referencing.Select(_leafContext.ResourceTypeId).ToList(),
+                _ => throw new NotSupportedException(EmptyOutputSideMessage("Forward", "referencing", "SearchKeyBinder.BindForward")),
+            };
 
             _ctes.Add(new CteDefinition.ChainJoin(forwardInnerMatch, forwardReferenceSearchParamId, forwardInnerResourceTypeId, forwardOutputResourceTypeIds, ChainDirection.Forward));
             return new CteRef(_ctes.Count - 1);
@@ -344,6 +355,17 @@ internal sealed class StructuralContext
             _chainDepth--;
         }
     }
+
+    /// <summary>The refusal for a chain whose <em>output</em> side named no resource type. Unlike the
+    /// must-be-single sides, an empty output list is not an ambiguity but a silent malformation: the emitter
+    /// renders the output types as an OR of equalities, and joining zero of them yields an empty string
+    /// interpolated into the WHERE clause, so the query fails at SQL Server as an opaque 500 rather than here
+    /// with a diagnosis.</summary>
+    private static string EmptyOutputSideMessage(string direction, string side, string binderMethod)
+        => $"{direction} chain's {side} side resolved to 0 resource types -- a chain join filters its output rows to " +
+           "those types, and an empty list emits no filter at all rather than matching nothing. The real binder " +
+           $"never produces this shape ({binderMethod}), so this guard covers IR built directly against the " +
+           "compiler API.";
 
     public CteRef LowerCompartment(CompartmentSearchExpression expression)
         => LowerCompartmentCore(expression.CompartmentType, expression.CompartmentId, expression.FilteredResourceTypes);

--- a/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -16,12 +16,23 @@ namespace Ignixa.Search.Definition;
 public class SearchableSearchParameterDefinitionManager : ISearchParameterDefinitionManager
 {
     private readonly SearchParameterDefinitionManager _inner;
+    private readonly Func<bool> _includePartiallyIndexedSearchParameters;
 
-    public SearchableSearchParameterDefinitionManager(SearchParameterDefinitionManager inner)
+    /// <param name="inner">The definition manager holding every known parameter, searchable or not.</param>
+    /// <param name="includePartiallyIndexedSearchParameters">
+    /// Decides, per call, whether parameters that are merely <em>supported</em> - registered but not yet
+    /// reindexed - should be admitted alongside searchable ones. Applying such a parameter filters on an
+    /// index that is still being populated, so it returns too few resources; it is only correct when the
+    /// caller has explicitly asked for partially indexed results. Defaults to refusing them.
+    /// </param>
+    public SearchableSearchParameterDefinitionManager(
+        SearchParameterDefinitionManager inner,
+        Func<bool> includePartiallyIndexedSearchParameters = null)
     {
         EnsureArg.IsNotNull(inner, nameof(inner));
 
         _inner = inner;
+        _includePartiallyIndexedSearchParameters = includePartiallyIndexedSearchParameters ?? (() => false);
     }
 
     public IEnumerable<SearchParameterInfo> AllSearchParameters => GetAllSearchParameters();
@@ -30,6 +41,12 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
     {
+        if (_includePartiallyIndexedSearchParameters())
+        {
+            return _inner.GetSearchParameters(resourceType)
+                .Where(x => x.IsSupported);
+        }
+
         return _inner.GetSearchParameters(resourceType)
             .Where(x => x.IsSearchable);
     }
@@ -40,7 +57,9 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
         if (_inner.TryGetSearchParameters(resourceType, out IEnumerable<SearchParameterInfo> innerSearchParameters))
         {
-            searchParameters = innerSearchParameters.Where(x => x.IsSearchable);
+            searchParameters = _includePartiallyIndexedSearchParameters()
+                ? innerSearchParameters.Where(x => x.IsSupported)
+                : innerSearchParameters.Where(x => x.IsSearchable);
             return true;
         }
 
@@ -100,15 +119,15 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
     {
-        _inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter);
+        value = null;
 
-        if (parameter.IsSearchable || UsePartialSearchParams(parameter))
+        if (_inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter) &&
+            (parameter.IsSearchable || UsePartialSearchParams(parameter)))
         {
             value = parameter;
             return true;
         }
 
-        value = null;
         return false;
     }
 
@@ -119,11 +138,16 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     private IEnumerable<SearchParameterInfo> GetAllSearchParameters()
     {
+        if (_includePartiallyIndexedSearchParameters())
+        {
+            return _inner.AllSearchParameters.Where(x => x.IsSupported);
+        }
+
         return _inner.AllSearchParameters.Where(x => x.IsSearchable);
     }
 
     private bool UsePartialSearchParams(SearchParameterInfo parameter)
     {
-        return parameter.IsSupported;
+        return _includePartiallyIndexedSearchParameters() && parameter.IsSupported;
     }
 }

--- a/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -11,7 +11,8 @@ using Ignixa.Abstractions;
 namespace Ignixa.Search.Definition;
 
 /// <summary>
-/// A SearchParameterDefinitionManager that only returns actively searchable parameters.
+/// A SearchParameterDefinitionManager that hides parameters whose index is not usable. Searchable parameters
+/// always pass; merely <em>supported</em> ones pass only when the caller opts in through the constructor.
 /// </summary>
 public class SearchableSearchParameterDefinitionManager : ISearchParameterDefinitionManager
 {
@@ -20,18 +21,17 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     /// <param name="inner">The definition manager holding every known parameter, searchable or not.</param>
     /// <param name="includePartiallyIndexedSearchParameters">
-    /// Decides, per call, whether parameters that are merely <em>supported</em> - registered but not yet
-    /// reindexed - are admitted alongside searchable ones. The index behind such a parameter is half
-    /// populated, which makes the result set wrong in both directions rather than merely short: a positive
-    /// filter misses resources whose rows do not exist yet, while a negated one (<c>:not</c>,
-    /// <c>:missing=true</c>) lowers to the negation of that same presence set and so returns those
-    /// not-yet-reindexed resources as matches. Nothing in the response distinguishes such a bundle from a
-    /// complete one. Defaults to refusing them.
+    /// Decides whether parameters that are merely <em>supported</em> - registered but not yet reindexed - are
+    /// admitted alongside searchable ones. The index behind such a parameter is half populated, which makes the
+    /// result set wrong in both directions rather than merely short: a positive filter misses resources whose
+    /// rows do not exist yet, while a negation (<c>:not</c>, <c>:missing=true</c>) lowers to
+    /// <c>Except(every resource of the type, the inner match)</c> and so hands those same not-yet-indexed
+    /// resources back as matches. Nothing in the response distinguishes such a bundle from a complete one.
+    /// Defaults to refusing them.
     /// <para>
-    /// No production code constructs this class today - the resolver registrations in
-    /// SearchServicesRegistration and SearchOptionsBuilderFactory hand back the raw
-    /// <see cref="SearchParameterDefinitionManager"/>, which applies no visibility filter at all - so this
-    /// switch currently reaches only tests and direct callers.
+    /// Every public accessor invokes this exactly once and applies the answer to all of its results, so a
+    /// deferred sequence cannot change its mind part-way through an enumeration, and a delegate that throws
+    /// does so at the accessor call rather than at some later <c>MoveNext</c>.
     /// </para>
     /// </param>
     public SearchableSearchParameterDefinitionManager(
@@ -50,16 +50,19 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
     {
-        return _inner.GetSearchParameters(resourceType).Where(IsVisible);
+        bool includePartiallyIndexed = _includePartiallyIndexedSearchParameters();
+
+        return _inner.GetSearchParameters(resourceType).Where(p => IsVisible(p, includePartiallyIndexed));
     }
 
     public bool TryGetSearchParameters(string resourceType, out IEnumerable<SearchParameterInfo> searchParameters)
     {
         searchParameters = null;
+        bool includePartiallyIndexed = _includePartiallyIndexedSearchParameters();
 
         if (_inner.TryGetSearchParameters(resourceType, out IEnumerable<SearchParameterInfo> innerSearchParameters))
         {
-            searchParameters = innerSearchParameters.Where(IsVisible);
+            searchParameters = innerSearchParameters.Where(p => IsVisible(p, includePartiallyIndexed));
             return true;
         }
 
@@ -70,7 +73,8 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         searchParameter = null;
 
-        if (_inner.TryGetSearchParameter(resourceType, code, out SearchParameterInfo parameter) && IsVisible(parameter))
+        if (_inner.TryGetSearchParameter(resourceType, code, out SearchParameterInfo parameter)
+            && IsVisible(parameter, _includePartiallyIndexedSearchParameters()))
         {
             searchParameter = parameter;
 
@@ -84,7 +88,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         SearchParameterInfo parameter = _inner.GetSearchParameter(resourceType, code);
 
-        if (IsVisible(parameter))
+        if (IsVisible(parameter, _includePartiallyIndexedSearchParameters()))
         {
             return parameter;
         }
@@ -96,7 +100,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
-        if (IsVisible(parameter)) return parameter;
+        if (IsVisible(parameter, _includePartiallyIndexedSearchParameters())) return parameter;
 
         throw new SearchParameterNotSupportedException(definitionUri);
     }
@@ -120,7 +124,8 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         value = null;
 
-        if (_inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter) && IsVisible(parameter))
+        if (_inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter)
+            && IsVisible(parameter, _includePartiallyIndexedSearchParameters()))
         {
             value = parameter;
             return true;
@@ -136,14 +141,17 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     private IEnumerable<SearchParameterInfo> GetAllSearchParameters()
     {
-        return _inner.AllSearchParameters.Where(IsVisible);
+        bool includePartiallyIndexed = _includePartiallyIndexedSearchParameters();
+
+        return _inner.AllSearchParameters.Where(p => IsVisible(p, includePartiallyIndexed));
     }
 
-    /// <summary>The single visibility rule behind every accessor. <see cref="SearchParameterInfo.IsSearchable"/>
-    /// and <see cref="SearchParameterInfo.IsSupported"/> are independent flags, so any accessor that tested one
-    /// without the other would disagree with the rest about the same parameter.</summary>
-    private bool IsVisible(SearchParameterInfo parameter)
+    /// <summary>The single visibility rule behind every accessor. On the opt-in path the answer depends on both
+    /// <see cref="SearchParameterInfo.IsSearchable"/> and <see cref="SearchParameterInfo.IsSupported"/>, which are
+    /// independent flags that can disagree; routing every accessor through here is what stops one of them from
+    /// testing a different combination of the two than the rest.</summary>
+    private static bool IsVisible(SearchParameterInfo parameter, bool includePartiallyIndexed)
     {
-        return parameter.IsSearchable || (_includePartiallyIndexedSearchParameters() && parameter.IsSupported);
+        return parameter.IsSearchable || (includePartiallyIndexed && parameter.IsSupported);
     }
 }

--- a/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Core/Ignixa.Search/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -21,9 +21,18 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     /// <param name="inner">The definition manager holding every known parameter, searchable or not.</param>
     /// <param name="includePartiallyIndexedSearchParameters">
     /// Decides, per call, whether parameters that are merely <em>supported</em> - registered but not yet
-    /// reindexed - should be admitted alongside searchable ones. Applying such a parameter filters on an
-    /// index that is still being populated, so it returns too few resources; it is only correct when the
-    /// caller has explicitly asked for partially indexed results. Defaults to refusing them.
+    /// reindexed - are admitted alongside searchable ones. The index behind such a parameter is half
+    /// populated, which makes the result set wrong in both directions rather than merely short: a positive
+    /// filter misses resources whose rows do not exist yet, while a negated one (<c>:not</c>,
+    /// <c>:missing=true</c>) lowers to the negation of that same presence set and so returns those
+    /// not-yet-reindexed resources as matches. Nothing in the response distinguishes such a bundle from a
+    /// complete one. Defaults to refusing them.
+    /// <para>
+    /// No production code constructs this class today - the resolver registrations in
+    /// SearchServicesRegistration and SearchOptionsBuilderFactory hand back the raw
+    /// <see cref="SearchParameterDefinitionManager"/>, which applies no visibility filter at all - so this
+    /// switch currently reaches only tests and direct callers.
+    /// </para>
     /// </param>
     public SearchableSearchParameterDefinitionManager(
         SearchParameterDefinitionManager inner,
@@ -41,14 +50,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
     {
-        if (_includePartiallyIndexedSearchParameters())
-        {
-            return _inner.GetSearchParameters(resourceType)
-                .Where(x => x.IsSupported);
-        }
-
-        return _inner.GetSearchParameters(resourceType)
-            .Where(x => x.IsSearchable);
+        return _inner.GetSearchParameters(resourceType).Where(IsVisible);
     }
 
     public bool TryGetSearchParameters(string resourceType, out IEnumerable<SearchParameterInfo> searchParameters)
@@ -57,9 +59,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
         if (_inner.TryGetSearchParameters(resourceType, out IEnumerable<SearchParameterInfo> innerSearchParameters))
         {
-            searchParameters = _includePartiallyIndexedSearchParameters()
-                ? innerSearchParameters.Where(x => x.IsSupported)
-                : innerSearchParameters.Where(x => x.IsSearchable);
+            searchParameters = innerSearchParameters.Where(IsVisible);
             return true;
         }
 
@@ -70,8 +70,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         searchParameter = null;
 
-        if (_inner.TryGetSearchParameter(resourceType, code, out SearchParameterInfo parameter) &&
-            (parameter.IsSearchable || UsePartialSearchParams(parameter)))
+        if (_inner.TryGetSearchParameter(resourceType, code, out SearchParameterInfo parameter) && IsVisible(parameter))
         {
             searchParameter = parameter;
 
@@ -85,7 +84,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         SearchParameterInfo parameter = _inner.GetSearchParameter(resourceType, code);
 
-        if (parameter.IsSearchable || UsePartialSearchParams(parameter))
+        if (IsVisible(parameter))
         {
             return parameter;
         }
@@ -97,7 +96,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
-        if (parameter.IsSearchable || UsePartialSearchParams(parameter)) return parameter;
+        if (IsVisible(parameter)) return parameter;
 
         throw new SearchParameterNotSupportedException(definitionUri);
     }
@@ -121,8 +120,7 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
     {
         value = null;
 
-        if (_inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter) &&
-            (parameter.IsSearchable || UsePartialSearchParams(parameter)))
+        if (_inner.TryGetSearchParameter(definitionUri, out SearchParameterInfo parameter) && IsVisible(parameter))
         {
             value = parameter;
             return true;
@@ -138,16 +136,14 @@ public class SearchableSearchParameterDefinitionManager : ISearchParameterDefini
 
     private IEnumerable<SearchParameterInfo> GetAllSearchParameters()
     {
-        if (_includePartiallyIndexedSearchParameters())
-        {
-            return _inner.AllSearchParameters.Where(x => x.IsSupported);
-        }
-
-        return _inner.AllSearchParameters.Where(x => x.IsSearchable);
+        return _inner.AllSearchParameters.Where(IsVisible);
     }
 
-    private bool UsePartialSearchParams(SearchParameterInfo parameter)
+    /// <summary>The single visibility rule behind every accessor. <see cref="SearchParameterInfo.IsSearchable"/>
+    /// and <see cref="SearchParameterInfo.IsSupported"/> are independent flags, so any accessor that tested one
+    /// without the other would disagree with the rest about the same parameter.</summary>
+    private bool IsVisible(SearchParameterInfo parameter)
     {
-        return _includePartiallyIndexedSearchParameters() && parameter.IsSupported;
+        return parameter.IsSearchable || (_includePartiallyIndexedSearchParameters() && parameter.IsSupported);
     }
 }

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
@@ -300,14 +300,20 @@ internal static class SearchKeySyntaxParser
                 $"expected {expectation}");
         }
 
+        /// <summary>
+        /// FHIR types <c>SearchParameter.code</c> as <c>code</c>, whose regex is <c>[^\s]+</c>, so a
+        /// custom search parameter is free to begin with a digit. The key grammar has no numeric
+        /// literals, so admitting a leading digit introduces no ambiguity — a resource-type position
+        /// that receives one still fails at binding with a name error rather than a syntax error.
+        /// </summary>
         private static bool IsIdentifierStart(char value)
         {
-            return IsAsciiLetter(value) || value == '_';
+            return IsAsciiLetter(value) || IsAsciiDigit(value) || value == '_';
         }
 
         private static bool IsIdentifierPart(char value)
         {
-            return IsIdentifierStart(value) || IsAsciiDigit(value) || value == '-';
+            return IsIdentifierStart(value) || value == '-';
         }
 
         private static bool IsAsciiLetter(char value)

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
@@ -300,23 +300,12 @@ internal static class SearchKeySyntaxParser
         /// </summary>
         private static bool IsIdentifierStart(char value)
         {
-            return IsAsciiLetter(value) || IsAsciiDigit(value) || value == '_';
+            return char.IsAsciiLetterOrDigit(value) || value == '_';
         }
 
         private static bool IsIdentifierPart(char value)
         {
             return IsIdentifierStart(value) || value == '-';
-        }
-
-        private static bool IsAsciiLetter(char value)
-        {
-            return (value >= 'A' && value <= 'Z')
-                || (value >= 'a' && value <= 'z');
-        }
-
-        private static bool IsAsciiDigit(char value)
-        {
-            return value >= '0' && value <= '9';
         }
     }
 }

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
@@ -148,17 +148,7 @@ internal static class SearchKeySyntaxParser
 
         private string? ParseNotReferencedPath()
         {
-            if (ConsumeIf('*'))
-            {
-                return null;
-            }
-
-            if (AtEnd || !IsAsciiLetter(_source[_offset]))
-            {
-                throw CreateError(_offset, "identifier");
-            }
-
-            return ParseIdentifier("identifier");
+            return ConsumeIf('*') ? null : ParseIdentifier("identifier");
         }
 
         private string ParseIdentifier(string expectation)
@@ -302,7 +292,8 @@ internal static class SearchKeySyntaxParser
 
         /// <summary>
         /// FHIR types <c>SearchParameter.code</c> as <c>code</c>, whose regex
-        /// (<c>[^\s]+([\s]?[^\s]+)*</c>) admits any non-whitespace first character, so a custom search
+        /// (<c>[^\s]+(\s[^\s]+)*</c> in R4/R4B/R5, <c>[^\s]+([\s]?[^\s]+)*</c> in DSTU2/STU3 — both admitting
+        /// a leading digit) accepts any non-whitespace first character, so a custom search
         /// parameter is free to begin with a digit. The key grammar has no numeric literals, so admitting
         /// a leading digit introduces no ambiguity — a resource-type position that receives one still
         /// fails at binding with a name error rather than a syntax error.

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeySyntaxParser.cs
@@ -301,10 +301,11 @@ internal static class SearchKeySyntaxParser
         }
 
         /// <summary>
-        /// FHIR types <c>SearchParameter.code</c> as <c>code</c>, whose regex is <c>[^\s]+</c>, so a
-        /// custom search parameter is free to begin with a digit. The key grammar has no numeric
-        /// literals, so admitting a leading digit introduces no ambiguity — a resource-type position
-        /// that receives one still fails at binding with a name error rather than a syntax error.
+        /// FHIR types <c>SearchParameter.code</c> as <c>code</c>, whose regex
+        /// (<c>[^\s]+([\s]?[^\s]+)*</c>) admits any non-whitespace first character, so a custom search
+        /// parameter is free to begin with a digit. The key grammar has no numeric literals, so admitting
+        /// a leading digit introduces no ambiguity — a resource-type position that receives one still
+        /// fails at binding with a name error rather than a syntax error.
         /// </summary>
         private static bool IsIdentifierStart(char value)
         {

--- a/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
+++ b/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
@@ -8,14 +8,23 @@ using EnsureThat;
 namespace Ignixa.Search.Expressions;
 
 /// <summary>
-/// Represents a union expression that combines multiple independent row-producing legs.
-/// Intended for compartment searches; no binder currently produces one, so the SQL lowering support
-/// exists ahead of a caller.
+/// Represents a union expression that combines multiple independent row-producing legs. Intended for
+/// compartment searches; instances are created only through
+/// <see cref="Expression.Union(UnionOperator, IReadOnlyList{Expression})"/>, so that factory's call sites
+/// are the authoritative answer to which binders, if any, produce one.
 /// <para>
-/// <see cref="Operator"/> is advisory. The SQL lowering ignores it and always emits a deduplicated UNION,
-/// because a leg yields <c>(ResourceTypeId, ResourceSurrogateId)</c> identities — a duplicate is the same row
-/// admitted by two legs, never two distinct results, so UNION ALL would double-count it in <c>_total</c> and
-/// in a page.
+/// Every consumer emits a <em>deduplicated</em> union regardless of <see cref="Operator"/>: the SQL lowering,
+/// the Entity Framework query builder and the in-memory interpreter all dedupe. That is not a shortcut —
+/// a leg yields <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is the same row
+/// admitted by two legs and never two distinct results. <c>UNION ALL</c> would therefore double-count that
+/// row in <c>_total</c> and let it consume two slots of a page, which makes the distinct union the only
+/// correct emission for either operator.
+/// </para>
+/// <para>
+/// <see cref="Operator"/> is nonetheless load-bearing outside lowering: it participates in
+/// <see cref="ValueInsensitiveEquals"/> and <see cref="AddValueInsensitiveHashCode"/>, so it is part of the
+/// node's structural identity, and it is rendered by <c>IrProjector</c> and <see cref="ToString"/>. Removing
+/// it would collapse two structurally distinct nodes and drop a field from the diagnostics.
 /// </para>
 /// </summary>
 public class UnionExpression : Expression

--- a/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
+++ b/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
@@ -9,22 +9,13 @@ namespace Ignixa.Search.Expressions;
 
 /// <summary>
 /// Represents a union expression that combines multiple independent row-producing legs. Intended for
-/// compartment searches; instances are created only through
-/// <see cref="Expression.Union(UnionOperator, IReadOnlyList{Expression})"/>, so that factory's call sites
-/// are the authoritative answer to which binders, if any, produce one.
+/// compartment searches.
 /// <para>
-/// Every consumer emits a <em>deduplicated</em> union regardless of <see cref="Operator"/>: the SQL lowering,
-/// the Entity Framework query builder and the in-memory interpreter all dedupe. That is not a shortcut —
-/// a leg yields <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is the same row
-/// admitted by two legs and never two distinct results. <c>UNION ALL</c> would therefore double-count that
-/// row in <c>_total</c> and let it consume two slots of a page, which makes the distinct union the only
-/// correct emission for either operator.
-/// </para>
-/// <para>
-/// <see cref="Operator"/> is nonetheless load-bearing outside lowering: it participates in
-/// <see cref="ValueInsensitiveEquals"/> and <see cref="AddValueInsensitiveHashCode"/>, so it is part of the
-/// node's structural identity, and it is rendered by <c>IrProjector</c> and <see cref="ToString"/>. Removing
-/// it would collapse two structurally distinct nodes and drop a field from the diagnostics.
+/// No consumer honours <see cref="Operator"/>: every one of them emits a <em>deduplicated</em> union. That is
+/// not a shortcut — a leg yields <c>(ResourceTypeId, ResourceSurrogateId)</c> identities, so a duplicate is one
+/// row admitted by two legs and never two distinct results. <c>UNION ALL</c> would double-count that row in
+/// <c>_total</c> and let it consume two slots of a page, which makes the distinct union the only correct
+/// emission for either operator.
 /// </para>
 /// </summary>
 public class UnionExpression : Expression

--- a/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
+++ b/src/Core/Ignixa.Search/Expressions/UnionExpression.cs
@@ -8,8 +8,15 @@ using EnsureThat;
 namespace Ignixa.Search.Expressions;
 
 /// <summary>
-/// Represents a union expression that combines multiple expressions with UNION ALL semantics.
-/// Used for compartment searches to generate efficient SQL UNION queries.
+/// Represents a union expression that combines multiple independent row-producing legs.
+/// Intended for compartment searches; no binder currently produces one, so the SQL lowering support
+/// exists ahead of a caller.
+/// <para>
+/// <see cref="Operator"/> is advisory. The SQL lowering ignores it and always emits a deduplicated UNION,
+/// because a leg yields <c>(ResourceTypeId, ResourceSurrogateId)</c> identities — a duplicate is the same row
+/// admitted by two legs, never two distinct results, so UNION ALL would double-count it in <c>_total</c> and
+/// in a page.
+/// </para>
 /// </summary>
 public class UnionExpression : Expression
 {

--- a/src/Core/Ignixa.Search/Models/SearchParameterInfo.cs
+++ b/src/Core/Ignixa.Search/Models/SearchParameterInfo.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License (MIT).See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -153,6 +153,10 @@ public class SearchParameterInfo : IEquatable<SearchParameterInfo>
     /// </summary>
     public Uri OverridesUrl { get; set; }
 
+    /// <summary>Equality is decided on <see cref="Url"/> alone when one is present: a canonical URL identifies a
+    /// search parameter, and two definitions carrying it are the same parameter however their other fields drift.
+    /// Code/Type/Expression are only consulted for the URL-less case. <see cref="GetHashCode"/> mirrors this
+    /// split exactly -- both must agree, or a HashSet keeps two entries it considers equal.</summary>
     public bool Equals([AllowNull] SearchParameterInfo other)
     {
         if (other == null) return false;
@@ -173,10 +177,15 @@ public class SearchParameterInfo : IEquatable<SearchParameterInfo>
         return Equals(obj as SearchParameterInfo);
     }
 
+    /// <summary>Mirrors <see cref="Equals(SearchParameterInfo)"/>: hashed on Url alone when one is present, on the
+    /// same three fields Equals falls back to when it is not. Combining all four unconditionally would break the
+    /// contract -- two instances sharing a Url but differing in Expression compare equal yet would land in
+    /// different buckets, so a HashSet would retain both and a later ToDictionary on Code would throw.</summary>
     public override int GetHashCode()
     {
+        if (Url != null) return Url.GetHashCode();
+
         return HashCode.Combine(
-            Url?.GetHashCode(),
             Code?.GetHashCode(StringComparison.OrdinalIgnoreCase),
             Type.GetHashCode(),
             Expression?.GetHashCode(StringComparison.OrdinalIgnoreCase));

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa. All rights reserved.
+// Licensed under the MIT License (MIT).
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Search.Models;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Application.Tests.Search.Definition;
+
+public class SearchParameterDefinitionManagerAddTests
+{
+    private readonly R4CoreSchemaProvider _schema = new();
+    private readonly SearchParameterDefinitionManager _manager;
+
+    public SearchParameterDefinitionManagerAddTests()
+    {
+        _manager = new SearchParameterDefinitionManager(_schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+    }
+
+    [Fact]
+    public void GivenASearchParameterAddedAtRuntime_WhenAnotherIsAddedLater_ThenBothAreRegistered()
+    {
+        // A host that registers SearchParameters as they are created calls this once per definition.
+        // The second call must not disturb the definitions the first one produced.
+        _manager.AddNewSearchParameters(new[] { CustomPatientParameter("first", "first-code") });
+        _manager.AddNewSearchParameters(new[] { CustomPatientParameter("second", "second-code") });
+
+        _manager.TryGetSearchParameter("Patient", "first-code", out _).ShouldBeTrue();
+        _manager.TryGetSearchParameter("Patient", "second-code", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenASearchParameterAddedAtRuntime_WhenAnotherIsAddedLater_ThenTheResourceTypeParameterKeepsItsIdentity()
+    {
+        // _type is injected by the builder rather than read from the definition bundle. Re-running the
+        // build must reuse the instance already published: callers hold references to it, and status
+        // changes are applied by mutating that instance.
+        _manager.TryGetSearchParameter("Patient", "_type", out SearchParameterInfo before).ShouldBeTrue();
+
+        _manager.AddNewSearchParameters(new[] { CustomPatientParameter("third", "third-code") });
+
+        _manager.TryGetSearchParameter("Patient", "_type", out SearchParameterInfo after).ShouldBeTrue();
+        after.ShouldBeSameAs(before);
+    }
+
+    [Fact]
+    public void GivenASearchParameterAddedAtRuntime_WhenTheDefinitionsAreRebuilt_ThenResourceTypeIsRegisteredExactlyOnce()
+    {
+        // A second _type instance sharing the canonical Url compares equal but hashes differently, so a
+        // HashSet keeps both and the per-resource rebuild throws on the duplicate code. Assert the count
+        // directly so a duplicate that happens not to throw is still caught.
+        _manager.AddNewSearchParameters(new[] { CustomPatientParameter("fourth", "fourth-code") });
+
+        _manager.GetSearchParameters("Patient").Count(p => p.Code == "_type").ShouldBe(1);
+        _manager.AllSearchParameters.Count(p => p.Code == "_type").ShouldBe(1);
+    }
+
+    private IElement CustomPatientParameter(string id, string code)
+    {
+        string json = $$"""
+            {
+              "resourceType": "SearchParameter",
+              "id": "{{id}}",
+              "url": "http://example.org/fhir/SearchParameter/{{id}}",
+              "name": "{{id}}",
+              "status": "active",
+              "code": "{{code}}",
+              "base": [ "Patient" ],
+              "type": "string",
+              "expression": "Patient.name.family"
+            }
+            """;
+
+        return ResourceJsonNode.Parse(json).ToElement(_schema);
+    }
+}

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
@@ -5,6 +5,7 @@
 
 using Ignixa.Abstractions;
 using Ignixa.Search.Definition;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.Generated;
@@ -39,9 +40,8 @@ public class SearchParameterDefinitionManagerAddTests
     [Fact]
     public void GivenASearchParameterAddedAtRuntime_WhenAnotherIsAddedLater_ThenTheResourceTypeParameterKeepsItsIdentity()
     {
-        // _type is injected by the builder rather than read from the definition bundle. Re-running the
-        // build must reuse the instance already published: callers hold references to it, and status
-        // changes are applied by mutating that instance.
+        // Re-running the build must republish the _type instance already in the dictionary: callers hold
+        // references to it, and status changes are applied by mutating that instance.
         _manager.TryGetSearchParameter("Patient", "_type", out SearchParameterInfo before).ShouldBeTrue();
 
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("third", "third-code") });
@@ -51,15 +51,19 @@ public class SearchParameterDefinitionManagerAddTests
     }
 
     [Fact]
-    public void GivenASearchParameterAddedAtRuntime_WhenTheDefinitionsAreRebuilt_ThenResourceTypeIsRegisteredExactlyOnce()
+    public void GivenASearchParameterAddedAtRuntime_WhenTheDefinitionsAreRebuilt_ThenResourceTypeResolvesToOneInstanceEverywhere()
     {
-        // A second _type instance sharing the canonical Url compares equal but hashes differently, so a
-        // HashSet keeps both and the per-resource rebuild throws on the duplicate code. Assert the count
-        // directly so a duplicate that happens not to throw is still caught.
+        // Counting _type per accessor proves nothing: both are dictionary values keyed on the field being
+        // counted (per-type by Code, AllSearchParameters by Url), so a second instance is unrepresentable
+        // there. Reference identity across the URL lookup, the base type and two concrete types is the
+        // observable evidence that the rebuild published one instance rather than a fresh one per pass.
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("fourth", "fourth-code") });
 
-        _manager.GetSearchParameters("Patient").Count(p => p.Code == "_type").ShouldBe(1);
-        _manager.AllSearchParameters.Count(p => p.Code == "_type").ShouldBe(1);
+        _manager.TryGetSearchParameter(SearchParameterNames.ResourceTypeUri, out SearchParameterInfo byUrl).ShouldBeTrue();
+
+        _manager.GetSearchParameter(KnownResourceTypes.Resource, "_type").ShouldBeSameAs(byUrl);
+        _manager.GetSearchParameter("Patient", "_type").ShouldBeSameAs(byUrl);
+        _manager.GetSearchParameter("Observation", "_type").ShouldBeSameAs(byUrl);
     }
 
     private IElement CustomPatientParameter(string id, string code)

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchParameterDefinitionManagerAddTests.cs
@@ -15,6 +15,12 @@ using Xunit;
 
 namespace Ignixa.Application.Tests.Search.Definition;
 
+/// <summary>Regression coverage for the <see cref="SearchParameterInfo.GetHashCode"/> / Equals consistency fix.
+/// Every rebuild injects a fresh <c>_type</c> definition carrying an expression, while the generated bundle
+/// already published one under the same canonical URL with a null expression. Equals calls them the same
+/// parameter on the URL alone; the old hash combined the expression too, so the two landed in different buckets,
+/// both survived the builder's HashSet union, and the following <c>ToDictionary</c> on Code threw on the
+/// duplicate key. Hashing on Url alone collapses them onto the entry already in the dictionary.</summary>
 public class SearchParameterDefinitionManagerAddTests
 {
     private readonly R4CoreSchemaProvider _schema = new();
@@ -28,8 +34,9 @@ public class SearchParameterDefinitionManagerAddTests
     [Fact]
     public void GivenASearchParameterAddedAtRuntime_WhenAnotherIsAddedLater_ThenBothAreRegistered()
     {
-        // A host that registers SearchParameters as they are created calls this once per definition.
-        // The second call must not disturb the definitions the first one produced.
+        // A host that registers SearchParameters as they are created calls this once per definition, and every
+        // call rebuilds. Each rebuild re-injects _type, so the duplicate-key throw fires on the first call
+        // already; asserting on two proves the second rebuild does not disturb what the first produced either.
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("first", "first-code") });
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("second", "second-code") });
 
@@ -40,8 +47,9 @@ public class SearchParameterDefinitionManagerAddTests
     [Fact]
     public void GivenASearchParameterAddedAtRuntime_WhenAnotherIsAddedLater_ThenTheResourceTypeParameterKeepsItsIdentity()
     {
-        // Re-running the build must republish the _type instance already in the dictionary: callers hold
-        // references to it, and status changes are applied by mutating that instance.
+        // Deduplicating on Url keeps the incumbent and drops the newly injected _type, so a caller that took a
+        // reference before the rebuild still holds the live instance. That matters because status flags
+        // (IsSearchable, IsSupported) are applied by mutating the instance, not by replacing the entry.
         _manager.TryGetSearchParameter("Patient", "_type", out SearchParameterInfo before).ShouldBeTrue();
 
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("third", "third-code") });
@@ -54,9 +62,11 @@ public class SearchParameterDefinitionManagerAddTests
     public void GivenASearchParameterAddedAtRuntime_WhenTheDefinitionsAreRebuilt_ThenResourceTypeResolvesToOneInstanceEverywhere()
     {
         // Counting _type per accessor proves nothing: both are dictionary values keyed on the field being
-        // counted (per-type by Code, AllSearchParameters by Url), so a second instance is unrepresentable
-        // there. Reference identity across the URL lookup, the base type and two concrete types is the
-        // observable evidence that the rebuild published one instance rather than a fresh one per pass.
+        // counted (per-type by Code, AllSearchParameters by Url), so a second entry is unrepresentable there.
+        // Reference identity across the URL lookup, the base type and two concrete types is the observable
+        // evidence that the two colliding definitions collapsed onto one object rather than being split
+        // across the two lookups, which would let a status mutation applied through one path go unseen by
+        // the other.
         _manager.AddNewSearchParameters(new[] { CustomPatientParameter("fourth", "fourth-code") });
 
         _manager.TryGetSearchParameter(SearchParameterNames.ResourceTypeUri, out SearchParameterInfo byUrl).ShouldBeTrue();

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
@@ -58,6 +58,8 @@ public class SearchableSearchParameterDefinitionManagerTests
 
         searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeTrue();
         searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeTrue();
+        searchable.GetSearchParameter("Patient", CustomCode).Code.ShouldBe(CustomCode);
+        searchable.GetSearchParameter(new Uri(CustomUrl)).Code.ShouldBe(CustomCode);
         searchable.GetSearchParameters("Patient").ShouldContain(p => p.Code == CustomCode);
         searchable.AllSearchParameters.ShouldContain(p => p.Code == CustomCode);
 
@@ -74,11 +76,50 @@ public class SearchableSearchParameterDefinitionManagerTests
 
         searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeTrue();
         searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeTrue();
+        searchable.GetSearchParameter("Patient", CustomCode).Code.ShouldBe(CustomCode);
         searchable.GetSearchParameters("Patient").ShouldContain(p => p.Code == CustomCode);
         searchable.AllSearchParameters.ShouldContain(p => p.Code == CustomCode);
 
         searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
         byResourceType.ShouldContain(p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenASearchableParameterThatIsNotSupported_WhenPartialIndexingIsRequested_ThenEveryAccessorAgrees()
+    {
+        // IsSearchable and IsSupported are independent flags, so this combination is reachable. The
+        // collection accessors and the singular lookups must return the same answer about the same object.
+        SetStatus(isSearchable: true, isSupported: false);
+
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner, () => true);
+
+        searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeTrue();
+        searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeTrue();
+        searchable.GetSearchParameter("Patient", CustomCode).Code.ShouldBe(CustomCode);
+        searchable.GetSearchParameter(new Uri(CustomUrl)).Code.ShouldBe(CustomCode);
+        searchable.GetSearchParameters("Patient").ShouldContain(p => p.Code == CustomCode);
+        searchable.AllSearchParameters.ShouldContain(p => p.Code == CustomCode);
+
+        searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
+        byResourceType.ShouldContain(p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenAParameterThatIsNeitherSearchableNorSupported_WhenPartialIndexingIsRequested_ThenEveryAccessorRefusesIt()
+    {
+        SetStatus(isSearchable: false, isSupported: false);
+
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner, () => true);
+
+        searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeFalse();
+        searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeFalse();
+        Should.Throw<SearchParameterNotSupportedException>(() => searchable.GetSearchParameter("Patient", CustomCode));
+        Should.Throw<SearchParameterNotSupportedException>(() => searchable.GetSearchParameter(new Uri(CustomUrl)));
+        searchable.GetSearchParameters("Patient").ShouldNotContain(p => p.Code == CustomCode);
+        searchable.AllSearchParameters.ShouldNotContain(p => p.Code == CustomCode);
+
+        searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
+        byResourceType.ShouldNotContain(p => p.Code == CustomCode);
     }
 
     [Fact]

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
@@ -123,6 +123,39 @@ public class SearchableSearchParameterDefinitionManagerTests
     }
 
     [Fact]
+    public void GivenADelegateWhoseAnswerChanges_WhenTheSameSequenceIsEnumeratedTwice_ThenBothPassesAgree()
+    {
+        // The delegate is consulted once when the accessor is called, not once per element, so the sequence it
+        // hands back is a snapshot: re-enumerating it cannot pick up an answer the caller never asked for.
+        SetStatus(isSearchable: false, isSupported: true);
+
+        var calls = 0;
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner, () => calls++ == 0);
+
+        IEnumerable<SearchParameterInfo> parameters = searchable.GetSearchParameters("Patient");
+
+        parameters.ShouldContain(p => p.Code == CustomCode);
+        parameters.ShouldContain(p => p.Code == CustomCode);
+        calls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenADelegateThatThrows_WhenAnAccessorIsCalled_ThenItFaultsAtTheCallRatherThanAtEnumeration()
+    {
+        // AllSearchParameters is a property and GetSearchParameters returns a deferred sequence, so a
+        // per-element delegate would surface the host's failure at the consumer's first MoveNext with no
+        // frame naming this class. Snapshotting at entry keeps the fault on the caller's own stack.
+        var searchable = new SearchableSearchParameterDefinitionManager(
+            _inner,
+            () => throw new InvalidOperationException("host refused"));
+
+        Should.Throw<InvalidOperationException>(() => searchable.GetSearchParameters("Patient"));
+        Should.Throw<InvalidOperationException>(() => _ = searchable.AllSearchParameters);
+        Should.Throw<InvalidOperationException>(
+            () => searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> _));
+    }
+
+    [Fact]
     public void GivenAnUnknownResourceType_WhenSearchParametersAreRequested_ThenItReportsMissing()
     {
         var searchable = new SearchableSearchParameterDefinitionManager(_inner);

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
@@ -10,6 +10,7 @@ using Ignixa.Search.Models;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.Generated;
 using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
 using Xunit;
 
 namespace Ignixa.Application.Tests.Search.Definition;
@@ -38,10 +39,14 @@ public class SearchableSearchParameterDefinitionManagerTests
 
         var searchable = new SearchableSearchParameterDefinitionManager(_inner);
 
-        Assert.False(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
-        Assert.False(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
-        Assert.Throws<SearchParameterNotSupportedException>(() => searchable.GetSearchParameter("Patient", CustomCode));
-        Assert.DoesNotContain(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+        searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeFalse();
+        searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeFalse();
+        Should.Throw<SearchParameterNotSupportedException>(() => searchable.GetSearchParameter("Patient", CustomCode));
+        searchable.GetSearchParameters("Patient").ShouldNotContain(p => p.Code == CustomCode);
+        searchable.AllSearchParameters.ShouldNotContain(p => p.Code == CustomCode);
+
+        searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
+        byResourceType.ShouldNotContain(p => p.Code == CustomCode);
     }
 
     [Fact]
@@ -51,9 +56,13 @@ public class SearchableSearchParameterDefinitionManagerTests
 
         var searchable = new SearchableSearchParameterDefinitionManager(_inner, () => true);
 
-        Assert.True(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
-        Assert.True(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
-        Assert.Contains(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+        searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeTrue();
+        searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeTrue();
+        searchable.GetSearchParameters("Patient").ShouldContain(p => p.Code == CustomCode);
+        searchable.AllSearchParameters.ShouldContain(p => p.Code == CustomCode);
+
+        searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
+        byResourceType.ShouldContain(p => p.Code == CustomCode);
     }
 
     [Fact]
@@ -63,9 +72,22 @@ public class SearchableSearchParameterDefinitionManagerTests
 
         var searchable = new SearchableSearchParameterDefinitionManager(_inner);
 
-        Assert.True(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
-        Assert.True(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
-        Assert.Contains(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+        searchable.TryGetSearchParameter("Patient", CustomCode, out _).ShouldBeTrue();
+        searchable.TryGetSearchParameter(new Uri(CustomUrl), out _).ShouldBeTrue();
+        searchable.GetSearchParameters("Patient").ShouldContain(p => p.Code == CustomCode);
+        searchable.AllSearchParameters.ShouldContain(p => p.Code == CustomCode);
+
+        searchable.TryGetSearchParameters("Patient", out IEnumerable<SearchParameterInfo> byResourceType).ShouldBeTrue();
+        byResourceType.ShouldContain(p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenAnUnknownResourceType_WhenSearchParametersAreRequested_ThenItReportsMissing()
+    {
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner);
+
+        searchable.TryGetSearchParameters("NotAResourceType", out IEnumerable<SearchParameterInfo> parameters).ShouldBeFalse();
+        parameters.ShouldBeNull();
     }
 
     [Fact]
@@ -73,13 +95,13 @@ public class SearchableSearchParameterDefinitionManagerTests
     {
         var searchable = new SearchableSearchParameterDefinitionManager(_inner);
 
-        Assert.False(searchable.TryGetSearchParameter(new Uri("http://example.org/fhir/SearchParameter/absent"), out SearchParameterInfo value));
-        Assert.Null(value);
+        searchable.TryGetSearchParameter(new Uri("http://example.org/fhir/SearchParameter/absent"), out SearchParameterInfo value).ShouldBeFalse();
+        value.ShouldBeNull();
     }
 
     private void SetStatus(bool isSearchable, bool isSupported)
     {
-        Assert.True(_inner.TryGetSearchParameter(new Uri(CustomUrl), out SearchParameterInfo parameter));
+        _inner.TryGetSearchParameter(new Uri(CustomUrl), out SearchParameterInfo parameter).ShouldBeTrue();
 
         parameter.IsSearchable = isSearchable;
         parameter.IsSupported = isSupported;

--- a/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/SearchableSearchParameterDefinitionManagerTests.cs
@@ -1,0 +1,106 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa. All rights reserved.
+// Licensed under the MIT License (MIT).
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Models;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ignixa.Application.Tests.Search.Definition;
+
+public class SearchableSearchParameterDefinitionManagerTests
+{
+    private const string CustomCode = "custom-code";
+    private const string CustomUrl = "http://example.org/fhir/SearchParameter/custom";
+
+    private readonly R4CoreSchemaProvider _schema = new();
+    private readonly SearchParameterDefinitionManager _inner;
+
+    public SearchableSearchParameterDefinitionManagerTests()
+    {
+        _inner = new SearchParameterDefinitionManager(_schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+        _inner.AddNewSearchParameters(new[] { CustomPatientParameter() });
+    }
+
+    [Fact]
+    public void GivenAParameterThatIsSupportedButNotSearchable_WhenLookedUpByDefault_ThenItIsNotReturned()
+    {
+        // A parameter that has been registered but not yet reindexed is "supported" without being
+        // searchable: its index rows do not exist yet, so applying it as a filter would silently
+        // return too few resources. It must stay hidden unless the caller has opted in.
+        SetStatus(isSearchable: false, isSupported: true);
+
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner);
+
+        Assert.False(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
+        Assert.False(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
+        Assert.Throws<SearchParameterNotSupportedException>(() => searchable.GetSearchParameter("Patient", CustomCode));
+        Assert.DoesNotContain(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenAParameterThatIsSupportedButNotSearchable_WhenPartialIndexingIsRequested_ThenItIsReturned()
+    {
+        SetStatus(isSearchable: false, isSupported: true);
+
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner, () => true);
+
+        Assert.True(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
+        Assert.True(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
+        Assert.Contains(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenASearchableParameter_WhenLookedUpByDefault_ThenItIsReturned()
+    {
+        SetStatus(isSearchable: true, isSupported: true);
+
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner);
+
+        Assert.True(searchable.TryGetSearchParameter("Patient", CustomCode, out _));
+        Assert.True(searchable.TryGetSearchParameter(new Uri(CustomUrl), out _));
+        Assert.Contains(searchable.GetSearchParameters("Patient"), p => p.Code == CustomCode);
+    }
+
+    [Fact]
+    public void GivenAnUnknownDefinitionUri_WhenLookedUp_ThenItReportsMissingRatherThanFaulting()
+    {
+        var searchable = new SearchableSearchParameterDefinitionManager(_inner);
+
+        Assert.False(searchable.TryGetSearchParameter(new Uri("http://example.org/fhir/SearchParameter/absent"), out SearchParameterInfo value));
+        Assert.Null(value);
+    }
+
+    private void SetStatus(bool isSearchable, bool isSupported)
+    {
+        Assert.True(_inner.TryGetSearchParameter(new Uri(CustomUrl), out SearchParameterInfo parameter));
+
+        parameter.IsSearchable = isSearchable;
+        parameter.IsSupported = isSupported;
+    }
+
+    private IElement CustomPatientParameter()
+    {
+        string json = $$"""
+            {
+              "resourceType": "SearchParameter",
+              "id": "custom",
+              "url": "{{CustomUrl}}",
+              "name": "custom",
+              "status": "active",
+              "code": "{{CustomCode}}",
+              "base": [ "Patient" ],
+              "type": "string",
+              "expression": "Patient.name.family"
+            }
+            """;
+
+        return ResourceJsonNode.Parse(json).ToElement(_schema);
+    }
+}

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
@@ -31,6 +31,35 @@ public class SearchKeySyntaxParserTests
     }
 
     [Theory]
+    [InlineData("07d5d21479ee52Code", "07d5d21479ee52Code", null)]
+    [InlineData("2ndline:exact", "2ndline", "exact")]
+    [InlineData("0", "0", null)]
+    public void GivenAParameterCodeStartingWithADigit_WhenParsing_ThenItIsAcceptedAsAnIdentifier(
+        string key,
+        string expectedName,
+        string? expectedModifier)
+    {
+        // FHIR types SearchParameter.code as `code`, whose regex is [^\s]+, so a custom search
+        // parameter is free to start with a digit. Rejecting it as a syntax error turns a valid
+        // registered parameter into an unparseable key.
+        var syntax = SearchKeySyntaxParser.ParseParameter(key);
+
+        var parameter = syntax.ShouldBeOfType<ParameterKeySyntax>();
+        parameter.Name.ShouldBe(expectedName);
+        parameter.Modifier.ShouldBe(expectedModifier);
+    }
+
+    [Fact]
+    public void GivenADigitLeadingParameterInAChain_WhenParsing_ThenBothSegmentsAreAccepted()
+    {
+        var syntax = SearchKeySyntaxParser.ParseParameter("subject.07code");
+
+        var chain = syntax.ShouldBeOfType<ForwardChainKeySyntax>();
+        chain.ReferenceName.ShouldBe("subject");
+        chain.Next.ShouldBeOfType<ParameterKeySyntax>().Name.ShouldBe("07code");
+    }
+
+    [Theory]
     [InlineData("subject.name", "subject", null, "name")]
     [InlineData("subject:Patient.name", "subject", "Patient", "name")]
     public void GivenForwardKey_WhenParsing_ThenReturnsForwardChainKeySyntax(

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
@@ -39,14 +39,36 @@ public class SearchKeySyntaxParserTests
         string expectedName,
         string? expectedModifier)
     {
-        // FHIR types SearchParameter.code as `code`, whose regex is [^\s]+, so a custom search
-        // parameter is free to start with a digit. Rejecting it as a syntax error turns a valid
-        // registered parameter into an unparseable key.
+        // FHIR types SearchParameter.code as `code`, whose regex ([^\s]+([\s]?[^\s]+)*) admits any
+        // non-whitespace first character, so a custom search parameter is free to start with a digit.
+        // Rejecting it as a syntax error turns a valid registered parameter into an unparseable key.
         var syntax = SearchKeySyntaxParser.ParseParameter(key);
 
         var parameter = syntax.ShouldBeOfType<ParameterKeySyntax>();
         parameter.Name.ShouldBe(expectedName);
         parameter.Modifier.ShouldBe(expectedModifier);
+    }
+
+    [Fact]
+    public void GivenADigitLeadingResourceTypeInAChain_WhenParsing_ThenItIsDeferredToTheBinder()
+    {
+        // A digit-leading token in a resource-type position is a name error, not a syntax error --
+        // the parser accepts it and the binder rejects it, which is what produces a usable diagnostic.
+        var syntax = SearchKeySyntaxParser.ParseParameter("subject:2Foo.name");
+
+        var chain = syntax.ShouldBeOfType<ForwardChainKeySyntax>();
+        chain.ReferenceName.ShouldBe("subject");
+        chain.TargetResourceType.ShouldBe("2Foo");
+    }
+
+    [Fact]
+    public void GivenADigitLeadingModifier_WhenParsing_ThenItIsAcceptedAsAnIdentifier()
+    {
+        var syntax = SearchKeySyntaxParser.ParseParameter("name:0exact");
+
+        var parameter = syntax.ShouldBeOfType<ParameterKeySyntax>();
+        parameter.Name.ShouldBe("name");
+        parameter.Modifier.ShouldBe("0exact");
     }
 
     [Fact]
@@ -91,6 +113,19 @@ public class SearchKeySyntaxParserTests
         var next = chain.Next.ShouldBeOfType<ParameterKeySyntax>();
         next.Name.ShouldBe("code");
         next.Modifier.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenADigitLeadingSegmentInAReverseChain_WhenParsing_ThenBothSegmentsAreAccepted()
+    {
+        // The _has: path parses its source type and reference name through the same identifier rules,
+        // so the loosened start character must apply there too rather than only to a terminal name.
+        var syntax = SearchKeySyntaxParser.ParseParameter("_has:2Observation:0subject:code");
+
+        var chain = syntax.ShouldBeOfType<ReverseChainKeySyntax>();
+        chain.SourceResourceType.ShouldBe("2Observation");
+        chain.ReferenceName.ShouldBe("0subject");
+        chain.Next.ShouldBeOfType<ParameterKeySyntax>().Name.ShouldBe("code");
     }
 
     [Fact]

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
@@ -81,6 +81,37 @@ public class SearchKeySyntaxParserTests
         chain.Next.ShouldBeOfType<ParameterKeySyntax>().Name.ShouldBe("07code");
     }
 
+    [Fact]
+    public void GivenADigitLeadingReferencePathInNotReferenced_WhenParsing_ThenItIsAcceptedAsAnIdentifier()
+    {
+        // The reference path is an identifier position like any other; gating it on a leading letter made
+        // it the one place a digit-leading custom parameter was a syntax error rather than a name error.
+        var syntax = SearchKeySyntaxParser.ParseNotReferenced("Observation:0subject");
+
+        syntax.SourceResourceType.ShouldBe("Observation");
+        syntax.ReferencePath.ShouldBe("0subject");
+    }
+
+    [Fact]
+    public void GivenADigitLeadingSourceTypeInNotReferenced_WhenParsing_ThenItIsDeferredToTheBinder()
+    {
+        var syntax = SearchKeySyntaxParser.ParseNotReferenced("2Observation:subject");
+
+        syntax.SourceResourceType.ShouldBe("2Observation");
+        syntax.ReferencePath.ShouldBe("subject");
+    }
+
+    [Fact]
+    public void GivenADigitLeadingSourceTypeInAnInclude_WhenParsing_ThenItIsDeferredToTheBinder()
+    {
+        var syntax = SearchKeySyntaxParser.ParseInclude("2Observation:0subject:3Patient");
+
+        syntax.SourceResourceType.ShouldBe("2Observation");
+        syntax.SearchParameterName.ShouldBe("0subject");
+        syntax.TargetResourceType.ShouldBe("3Patient");
+        syntax.Wildcard.ShouldBeFalse();
+    }
+
     [Theory]
     [InlineData("subject.name", "subject", null, "name")]
     [InlineData("subject:Patient.name", "subject", "Patient", "name")]

--- a/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Expressions/Parsers/SearchKeySyntaxParserTests.cs
@@ -213,6 +213,47 @@ public class SearchKeySyntaxParserTests
         terminal.Modifier.ShouldBeNull();
     }
 
+    [Fact]
+    public void GivenAWildcardReferencePathInNotReferenced_WhenParsing_ThenTheReferencePathIsNull()
+    {
+        var syntax = SearchKeySyntaxParser.ParseNotReferenced("Observation:*");
+
+        syntax.SourceResourceType.ShouldBe("Observation");
+        syntax.ReferencePath.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("Observation:")]
+    [InlineData("Observation")]
+    [InlineData(":subject")]
+    [InlineData("Observation:subject:extra")]
+    public void GivenMalformedNotReferencedValue_WhenParsing_ThenThrowsPositionedSyntaxError(string value)
+    {
+        // "Observation:" is the at-end case: the reference path delegates to ParseIdentifier, which is what
+        // reports the missing identifier now that ParseNotReferencedPath does not test for the end itself.
+        var exception = Should.Throw<InvalidSearchOperationException>(
+            () => SearchKeySyntaxParser.ParseNotReferenced(value));
+
+        exception.Message.ShouldContain("_not-referenced value");
+        exception.Message.ShouldContain("line 1");
+        exception.Message.ShouldContain("column");
+    }
+
+    [Theory]
+    [InlineData("Observation")]
+    [InlineData("Observation:")]
+    [InlineData("Observation:subject:")]
+    [InlineData(":subject")]
+    public void GivenMalformedIncludeKey_WhenParsing_ThenThrowsPositionedSyntaxError(string key)
+    {
+        var exception = Should.Throw<InvalidSearchOperationException>(
+            () => SearchKeySyntaxParser.ParseInclude(key));
+
+        exception.Message.ShouldContain("include key");
+        exception.Message.ShouldContain("line 1");
+        exception.Message.ShouldContain("column");
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(".name")]

--- a/test/Ignixa.Application.Tests/Search/Models/SearchParameterInfoEqualityTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Models/SearchParameterInfoEqualityTests.cs
@@ -28,6 +28,37 @@ public class SearchParameterInfoEqualityTests
     }
 
     [Fact]
+    public void GivenTwoParametersSharingAUrlButDifferingByCode_WhenCompared_ThenTheCodeIsNotConsulted()
+    {
+        // Intended semantics, not an accident: the canonical URL wins outright, so a set built from both
+        // keeps whichever arrived first and the other Code disappears without a diagnostic. Two definitions
+        // carrying the same canonical URL under different codes are a definition-authoring error, and this
+        // is where the collapse happens.
+        var first = new SearchParameterInfo("_type", "_type", SearchParamType.Token, CanonicalUrl);
+        var second = new SearchParameterInfo("resource-type", "resource-type", SearchParamType.Token, CanonicalUrl);
+
+        first.Equals(second).ShouldBeTrue();
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+
+        var set = new HashSet<SearchParameterInfo> { first, second };
+        set.Count.ShouldBe(1);
+        set.Single().Code.ShouldBe("_type");
+    }
+
+    [Fact]
+    public void GivenOneParameterWithAUrlAndOneWithout_WhenCompared_ThenTheyAreNotEqual()
+    {
+        // The boundary between the two GetHashCode branches: one side hashes on Url, the other on
+        // Code/Type/Expression. Equals must reject the pair in both directions or the branches disagree.
+        var withUrl = new SearchParameterInfo("_type", "_type", SearchParamType.Token, CanonicalUrl, expression: "Patient.name");
+        var withoutUrl = new SearchParameterInfo("_type", "_type", SearchParamType.Token, url: null, expression: "Patient.name");
+
+        withUrl.Equals(withoutUrl).ShouldBeFalse();
+        withoutUrl.Equals(withUrl).ShouldBeFalse();
+        new HashSet<SearchParameterInfo> { withUrl, withoutUrl }.Count.ShouldBe(2);
+    }
+
+    [Fact]
     public void GivenTwoParametersWithDifferentUrls_WhenCompared_ThenTheyAreNotEqual()
     {
         var baseParameter = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));

--- a/test/Ignixa.Application.Tests/Search/Models/SearchParameterInfoEqualityTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Models/SearchParameterInfoEqualityTests.cs
@@ -1,0 +1,62 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa. All rights reserved.
+// Licensed under the MIT License (MIT).
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Search.Models;
+using Ignixa.Specification.ValueSets.Normative;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Application.Tests.Search.Models;
+
+public class SearchParameterInfoEqualityTests
+{
+    private static readonly Uri CanonicalUrl = new("http://hl7.org/fhir/SearchParameter/Resource-type");
+
+    [Fact]
+    public void GivenTwoParametersSharingAUrlButDifferingElsewhere_WhenCompared_ThenTheyAreEqualAndHashAlike()
+    {
+        // Equals decides on Url alone, so the hash must too. When it did not, a HashSet kept both entries and
+        // the per-resource rebuild in SearchParameterDefinitionBuilder threw on the resulting duplicate code.
+        var first = new SearchParameterInfo("_type", "_type", SearchParamType.Token, CanonicalUrl);
+        var second = new SearchParameterInfo("_type", "_type", SearchParamType.Token, CanonicalUrl, expression: "Resource.type().name");
+
+        first.Equals(second).ShouldBeTrue();
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+        new HashSet<SearchParameterInfo> { first, second }.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenTwoParametersWithDifferentUrls_WhenCompared_ThenTheyAreNotEqual()
+    {
+        var baseParameter = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));
+        var custom = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://example.org/fhir/SearchParameter/custom-name"));
+
+        baseParameter.Equals(custom).ShouldBeFalse();
+        new HashSet<SearchParameterInfo> { baseParameter, custom }.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GivenTwoUrllessParametersMatchingOnCodeTypeAndExpression_WhenCompared_ThenTheyAreEqualAndHashAlike()
+    {
+        // The fallback branch: with no canonical URL there is nothing else to identify the parameter by, so
+        // Equals compares the three descriptive fields and GetHashCode must combine the same three.
+        var first = new SearchParameterInfo("adhoc", "adhoc", SearchParamType.String, url: null, expression: "Patient.name");
+        var second = new SearchParameterInfo("adhoc", "adhoc", SearchParamType.String, url: null, expression: "Patient.name");
+
+        first.Equals(second).ShouldBeTrue();
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+        new HashSet<SearchParameterInfo> { first, second }.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenTwoUrllessParametersDifferingByExpression_WhenCompared_ThenTheyAreNotEqual()
+    {
+        var first = new SearchParameterInfo("adhoc", "adhoc", SearchParamType.String, url: null, expression: "Patient.name");
+        var second = new SearchParameterInfo("adhoc", "adhoc", SearchParamType.String, url: null, expression: "Patient.birthDate");
+
+        first.Equals(second).ShouldBeFalse();
+        new HashSet<SearchParameterInfo> { first, second }.Count.ShouldBe(2);
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -3441,6 +3441,30 @@ public class EmitTests
         Should.Throw<NotSupportedException>(() => SqlBuilder.Run(plan));
     }
 
+    public static TheoryData<string, CteDefinition> EmptyResourceTypeListNodes() => new()
+    {
+        { "ChainJoin/Forward", new CteDefinition.ChainJoin(new CteRef(0), ReferenceSearchParamId: 55, InnerResourceTypeId: 105, OutputResourceTypeIds: [], ChainDirection.Forward) },
+        { "ChainJoin/Reverse", new CteDefinition.ChainJoin(new CteRef(0), ReferenceSearchParamId: 55, InnerResourceTypeId: 105, OutputResourceTypeIds: [], ChainDirection.Reverse) },
+        { "ReferencedTypeExpansion", new CteDefinition.ReferencedTypeExpansion(new CteRef(0), OutputResourceTypeIds: []) },
+        { "CompartmentSource", new CteDefinition.CompartmentSource([], 77, new Predicate.Equal(new SqlColumnRef("ReferenceSearchParam", "ReferenceResourceId"), new SqlParameterRef("123"))) },
+    };
+
+    [Theory]
+    [MemberData(nameof(EmptyResourceTypeListNodes))]
+    public void GivenACteWhoseResourceTypeListIsEmpty_WhenEmitted_ThenItIsRefusedRatherThanEmittingAnEmptyFilter(
+        string scenario, CteDefinition node)
+    {
+        // Each of these renders its type list as an OR of equalities and interpolates the joined string
+        // straight into its WHERE clause, so an empty list emits nothing where a filter belongs and the
+        // statement does not parse. Lower refuses the chain shape at LowerChain, but QueryPlan is a public
+        // construction surface and `plan with { Query = … }` is a documented rewrite, so the emitter mirrors
+        // it -- otherwise the failure reaches SQL Server as a syntax error with no diagnosis.
+        var plan = new QueryPlan([new CteDefinition.ResourceSource(103), node], new CteRef(1));
+
+        Should.Throw<NotSupportedException>(() => SqlBuilder.Run(plan), $"{scenario} emitted SQL instead of refusing")
+            .Message.ShouldContain("names no resource type");
+    }
+
     [Fact]
     public void GivenAnIncludesOnlyPageWhoseStagesHaveDifferingLimits_WhenEmitted_ThenItIsRefusedRatherThanPagingOnAnArbitraryBudget()
     {

--- a/test/Ignixa.Search.Sql.Tests/Lowering/AccessConstraintTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/AccessConstraintTests.cs
@@ -244,6 +244,48 @@ public class AccessConstraintTests
     }
 
     [Fact]
+    public void GivenASystemLevelSearchWhoseMatchIsAChain_WhenTheChainOutputTypeIsConstrained_ThenTheConstraintStillNarrowsThatType()
+    {
+        // Arrange -- GET /?_type=Observation,Patient&subject:Patient.category=vital-signs. A chain under a
+        // null target type only became reachable when the dispatch guard was removed, which makes the
+        // ApplyToTypes arm for a ChainJoin-derived match a newly live authorization path. The chain emits
+        // Observation identities, so the Observation constraint must narrow them; it cannot ride on the
+        // single-type Apply arm, because there is no single match type to key it on.
+        var f = Arrange();
+        var chain = new ChainedExpression(
+            resourceTypes: ["Observation"],
+            referenceSearchParameter: f.SubjectParam,
+            targetResourceTypes: ["Patient"],
+            reversed: false,
+            expression: TokenPredicate(f.CategoryParam, "vital-signs"));
+
+        // Act
+        var plan = LowerHarness.Run(
+            chain, f.Symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, AccessConstraints = [f.ObservationConstraint], ResourceTypes = ["Observation", "Patient"] }).Plan;
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert -- the subtract-then-union shape ApplyToTypes builds, over the chain-derived match. Both
+        // arms share the same left side, and that side is the chain, so neutralising ApplyToTypes (leaving
+        // the root as the chain's own Intersect) fails here.
+        var ctes = plan.Ctes;
+        var root = ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Union>();
+        var subtract = root.Parts.Select(p => ctes[p.Index]).OfType<CteDefinition.Except>().ShouldHaveSingleItem();
+        var admitted = root.Parts.Select(p => ctes[p.Index]).OfType<CteDefinition.Intersect>().ShouldHaveSingleItem();
+        ctes[subtract.Right.Index].ShouldBeOfType<CteDefinition.ResourceSource>().ResourceTypeId.ShouldBe(ObservationTypeId);
+        ctes[admitted.Right.Index].ShouldBeOfType<CteDefinition.ParamSource>().SearchParamId.ShouldBe(StatusParamId);
+        subtract.Left.ShouldBe(admitted.Left);
+
+        var narrowedMatch = ctes[subtract.Left.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        ctes[narrowedMatch.Left.Index].ShouldBeOfType<CteDefinition.ChainJoin>()
+            .OutputResourceTypeIds.ShouldBe(new[] { ObservationTypeId });
+
+        sql.ShouldContain("SearchParamId = 220");
+        SqlGrammar.AssertValid(sql);
+    }
+
+    [Fact]
     public void GivenNoConstraints_WhenLowered_ThenThePlanIsIdenticalToOneLoweredWithoutTheParameter()
     {
         // Arrange

--- a/test/Ignixa.Search.Sql.Tests/Lowering/AllowedResourceTypesTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/AllowedResourceTypesTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing.SearchValues;
 using Ignixa.Search.Models;
 using Ignixa.Search.Sql.Ast;
 using Ignixa.Search.Sql.Builders;
@@ -221,6 +222,40 @@ public class AllowedResourceTypesTests
         plan.Includes![0].OutputTypeIds!.ShouldNotBeEmpty();
         plan.Includes![0].OutputTypeIds.ShouldBe(new short[] { SymbolTable.UnmatchableResourceTypeId });
         sql.ShouldContain("r.ResourceTypeId = -1");
+        SqlGrammar.AssertValid(sql);
+    }
+
+    [Fact]
+    public void GivenASystemLevelSearchWhoseMatchIsAChain_WhenTheChainOutputTypeIsNotAllowed_ThenTheMatchIsStillRestricted()
+    {
+        // Arrange -- GET /?subject:Patient.status=final under an allow-list of Patient only. A chain under a
+        // null target type only became reachable when the leaf-dispatch guard was removed, so RestrictMatch
+        // over a ChainJoin-derived match is a newly live authorization path with no coverage. The chain emits
+        // Observation, which the caller may not see.
+        var f = Arrange();
+        var chain = new ChainedExpression(
+            resourceTypes: ["Observation"],
+            referenceSearchParameter: f.SubjectParam,
+            targetResourceTypes: ["Patient"],
+            reversed: false,
+            expression: new SearchParameterExpression(
+                f.StatusParam,
+                new SearchParameterPredicateExpression(f.StatusParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "final", text: null))));
+
+        // Act
+        var plan = LowerHarness.Run(
+            chain, f.Symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, AllowedResourceTypes = ["Patient"] }).Plan;
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert -- the match root is the chain intersected with the allowed base set, so the Observation
+        // rows the chain produces cannot survive. Neutralising RestrictMatch would leave the root as the
+        // bare ChainJoin and fail here.
+        var ctes = plan.Ctes;
+        var root = ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        ctes[root.Left.Index].ShouldBeOfType<CteDefinition.ChainJoin>().OutputResourceTypeIds.ShouldBe(new[] { ObservationTypeId });
+        ctes[root.Right.Index].ShouldBeOfType<CteDefinition.MultiTypeResourceSource>().ResourceTypeIds.ShouldBe(new[] { PatientTypeId });
         SqlGrammar.AssertValid(sql);
     }
 

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -6,6 +6,7 @@ using Ignixa.Search.Sql.Ast;
 using Ignixa.Search.Sql.Builders;
 using Ignixa.Search.Sql.Lowering;
 using Ignixa.Search.Sql.Symbols;
+using Ignixa.Search.Sql.Tests.Ast;
 using Ignixa.Search.Sql.Tests.TestSupport;
 using Ignixa.Specification.ValueSets.Normative;
 using Shouldly;
@@ -1274,18 +1275,8 @@ public class LowerTests
         // join emits), so the ambient scope it would otherwise inherit is unused. LowerChain reads neither.
         // The identities a ChainJoin yields are (ResourceTypeId, SurrogateId) pairs over concrete target
         // types, so the enclosing cross-type intersection stays well-typed.
-        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
-        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
-        var chain = new ChainedExpression(
-            ["Device"],
-            subjectParam,
-            ["Patient"],
-            reversed: true,
-            new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
-                codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, "4548-4", text: null))));
-        var symbols = new SymbolTable(
-            new Dictionary<string, short> { [codeParam.Url!.ToString()] = 202, [subjectParam.Url!.ToString()] = 203 },
-            new Dictionary<string, short> { ["Patient"] = 103, ["Device"] = 104 });
+        var chain = ReverseChain(["Device"], ["Patient"]);
+        var symbols = ChainSymbols();
 
         // Act
         var plan = LowerHarness.Run(
@@ -1384,21 +1375,165 @@ public class LowerTests
     [Fact]
     public void GivenAReverseChainWithMoreThanOneReferencingTypeUnderSystemLevel_WhenLowered_ThenItThrows()
     {
-        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
-        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
-        var chain = new ChainedExpression(
-            ["Device", "Observation"],
-            subjectParam,
-            ["Patient"],
-            reversed: true,
-            new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
-                codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, "4548-4", text: null))));
+        var chain = ReverseChain(["Device", "Observation"], ["Patient"]);
 
         Should.Throw<NotSupportedException>(() => LowerHarness.Run(
             chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
             sort: [], sortPhase: SortPhase.Valued, page: null,
             new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Patient", "Device"] }))
             .Message.ShouldContain("Reverse chain's referencing side resolved to 2 types");
+    }
+
+    [Fact]
+    public void GivenAReverseChainWithNoTargetTypes_WhenLowered_ThenItThrowsRatherThanEmittingAnEmptyOutputFilter()
+    {
+        // The output side has no ambiguity to resolve, so it has no single-type guard -- but an empty list is
+        // worse than an ambiguous one: EmitChainJoin string.Joins the output equalities, and joining none of
+        // them interpolates an empty string straight into the WHERE clause. Without this guard the failure
+        // surfaces as a SQL Server syntax error at query time instead of a diagnosis at compile time.
+        var chain = ReverseChain(["Device"], []);
+
+        Should.Throw<NotSupportedException>(() => LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Patient", "Device"] }))
+            .Message.ShouldContain("Reverse chain's target side resolved to 0 resource types");
+    }
+
+    [Fact]
+    public void GivenAForwardChainWithNoReferencingTypes_WhenLowered_ThenItThrowsRatherThanEmittingAnEmptyOutputFilter()
+    {
+        // Mirror of the reverse case: forward chains emit their referencing types, so that is the side that
+        // must be non-empty.
+        var chain = ForwardChain([], ["Patient"]);
+
+        Should.Throw<NotSupportedException>(() => LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation", "Device"] }))
+            .Message.ShouldContain("Forward chain's referencing side resolved to 0 resource types");
+    }
+
+    [Fact]
+    public void GivenAReverseChainWithSeveralTargetTypes_WhenLoweredUnderSystemLevel_ThenEveryTargetTypeIsEmitted()
+    {
+        // Arrange -- GET /?_type=Patient,Device&_has:Observation:subject:code=4548-4, the production shape:
+        // SearchKeyBinder.BindReverse computes the targets as the reference parameter's own targets INTERSECT
+        // the requested types, which is routinely more than one. Only the referencing side is constrained to
+        // a single type, so a multi-target output is legal -- and it is the only path that reaches
+        // EmitChainJoin's parenthesisation branch, where an unparenthesised OR would bind loosely against the
+        // sibling AND terms and silently widen the join.
+        var chain = ReverseChain(["Observation"], ["Patient", "Device"]);
+
+        // Act
+        var lowered = LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Patient", "Device"] });
+        var sql = SqlBuilder.Run(lowered.Plan).Sql;
+
+        // Assert
+        var join = lowered.Plan.Ctes.OfType<CteDefinition.ChainJoin>().ShouldHaveSingleItem();
+        join.InnerResourceTypeId.ShouldBe((short)105);
+        join.OutputResourceTypeIds.ShouldBe([(short)103, (short)104]);
+        sql.ShouldContain("(rsp.ReferenceResourceTypeId = 103 OR rsp.ReferenceResourceTypeId = 104)");
+        SqlGrammar.AssertValid(sql);
+    }
+
+    [Fact]
+    public void GivenAForwardChainWithSeveralReferencingTypes_WhenLoweredUnderSystemLevel_ThenEveryReferencingTypeIsEmitted()
+    {
+        // Arrange -- GET /?_type=Observation,Device&subject:Patient.name=smith exactly as the binder produces
+        // it: SearchKeyBinder.BindForward binds the referencing side to the FULL requested type list, so the
+        // real shape is ForwardChain(["Observation", "Device"], ["Patient"]) -- not the single-output shape the
+        // sibling tests build. Only the target side is narrowed to one type.
+        var chain = ForwardChain(["Observation", "Device"], ["Patient"]);
+
+        // Act
+        var lowered = LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation", "Device"] });
+        var sql = SqlBuilder.Run(lowered.Plan).Sql;
+
+        // Assert
+        var join = lowered.Plan.Ctes.OfType<CteDefinition.ChainJoin>().ShouldHaveSingleItem();
+        join.InnerResourceTypeId.ShouldBe((short)103);
+        join.OutputResourceTypeIds.ShouldBe([(short)105, (short)104]);
+        sql.ShouldContain("(rsp.ResourceTypeId = 105 OR rsp.ResourceTypeId = 104)");
+        SqlGrammar.AssertValid(sql);
+    }
+
+    [Fact]
+    public void GivenAChainWhoseOutputTypeIsOutsideTheRequestedTypes_WhenLowered_ThenTheRequestedTypesStillNarrowIt()
+    {
+        // Arrange -- GET /?_type=Device&_has:Device:subject:code=4548-4. The chain emits Patient identities
+        // while the caller asked only for Device, so the requested-type narrowing is the only thing that keeps
+        // the answer empty. The sibling chain tests all pick chain types inside ResourceTypes and never assert
+        // the narrowing set, so an implementation that skipped NarrowToRequestedTypes would still pass them.
+        var chain = ReverseChain(["Device"], ["Patient"]);
+
+        // Act
+        var plan = LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Device"] }).Plan;
+
+        // Assert -- the match root intersects the chain's Patient output against a Device-only base set.
+        var intersect = plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        plan.Ctes[intersect.Left.Index].ShouldBeOfType<CteDefinition.ChainJoin>()
+            .OutputResourceTypeIds.ShouldBe([(short)103]);
+        plan.Ctes[intersect.Right.Index].ShouldBeOfType<CteDefinition.MultiTypeResourceSource>()
+            .ResourceTypeIds.ShouldBe([(short)104]);
+    }
+
+    [Fact]
+    public void GivenAChainUnderAWildcardCompartmentSearch_WhenLowered_ThenItStillThrows()
+    {
+        // Arrange -- the other null-target case the deleted dispatch guard used to cover. A wildcard
+        // compartment search has no single type to scope anything against and is NOT system-level, so it must
+        // still be refused. The refusal now comes from Lower.Run's residue arm rather than from leaf dispatch,
+        // which is correct but incidental: this pins it so a refactor that peels the compartment leaf
+        // differently cannot fail open into LowerChain with a null scope.
+        var compartment = new CompartmentSearchExpression("Patient", "123");
+        var tree = Expression.And(compartment, ForwardChain(["Observation"], ["Patient"]));
+
+        // Act & Assert -- no SystemLevelSearch option, so this stays a genuine wildcard compartment search.
+        Should.Throw<NotSupportedException>(() => LowerHarness.Run(
+            tree, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null))
+            .Message.ShouldContain("wildcard compartment search");
+    }
+
+    [Fact]
+    public void GivenAChainNestedInAnotherChainUnderASystemLevelSearch_WhenLowered_ThenTheInnerChainSeesAConcreteScope()
+    {
+        // Arrange -- depth 2 under a null ambient scope. LowerChain passes a concrete type into lowerNode for
+        // its inner expression in both directions, so a chain reached inside another chain's scope never sees
+        // the null. The invariant is real but nothing asserted it, and it is what lets the outer chain tolerate
+        // a null ambient scope without the tolerance leaking further down.
+        var inner = ReverseChain(["Device"], ["Patient"]);
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
+        var outer = new ChainedExpression(["Observation"], subjectParam, ["Patient"], reversed: false, inner);
+
+        // Act
+        var plan = LowerHarness.Run(
+            outer, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation"] }).Plan;
+
+        // Assert -- both joins lowered, and the inner one scoped against Device rather than nothing.
+        var joins = plan.Ctes.OfType<CteDefinition.ChainJoin>().ToList();
+        joins.Count.ShouldBe(2);
+
+        var innerJoin = joins.Single(j => j.Direction == ChainDirection.Reverse);
+        innerJoin.InnerResourceTypeId.ShouldBe((short)104);
+        innerJoin.OutputResourceTypeIds.ShouldBe([(short)103]);
+        plan.Ctes[innerJoin.InnerMatch.Index].ShouldBeOfType<CteDefinition.ParamSource>().ResourceTypeId.ShouldBe((short)104);
+
+        var outerJoin = joins.Single(j => j.Direction == ChainDirection.Forward);
+        outerJoin.InnerResourceTypeId.ShouldBe((short)103);
+        outerJoin.OutputResourceTypeIds.ShouldBe([(short)105]);
     }
 
     /// <summary>A forward chain on <c>subject</c> whose inner expression is a name filter on the target type.</summary>
@@ -1413,6 +1548,20 @@ public class LowerTests
             reversed: false,
             new SearchParameterExpression(nameParam, new SearchParameterPredicateExpression(
                 nameParam, SearchComparator.Eq, modifier: null, new StringSearchValue("smith"))));
+    }
+
+    /// <summary>A reverse chain on <c>subject</c> whose inner expression is a code filter on the referencing type.</summary>
+    private static ChainedExpression ReverseChain(string[] referencingTypes, string[] targetTypes)
+    {
+        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
+        return new ChainedExpression(
+            referencingTypes,
+            subjectParam,
+            targetTypes,
+            reversed: true,
+            new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
+                codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, "4548-4", text: null))));
     }
 
     /// <summary>Symbols covering both chain shapes: the code/name/subject parameters and the types they span.</summary>

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -1389,8 +1389,9 @@ public class LowerTests
     {
         // The output side has no ambiguity to resolve, so it has no single-type guard -- but an empty list is
         // worse than an ambiguous one: EmitChainJoin string.Joins the output equalities, and joining none of
-        // them interpolates an empty string straight into the WHERE clause. Without this guard the failure
-        // surfaces as a SQL Server syntax error at query time instead of a diagnosis at compile time.
+        // them interpolates an empty string straight into the WHERE clause, which does not parse. Refusing at
+        // lowering names the chain that produced it; SqlBuilder.RejectUnsupportedCombinations carries the same
+        // check as a backstop for a QueryPlan built without going through Lower.
         var chain = ReverseChain(["Device"], []);
 
         Should.Throw<NotSupportedException>(() => LowerHarness.Run(
@@ -1419,10 +1420,10 @@ public class LowerTests
     {
         // Arrange -- GET /?_type=Patient,Device&_has:Observation:subject:code=4548-4, the production shape:
         // SearchKeyBinder.BindReverse computes the targets as the reference parameter's own targets INTERSECT
-        // the requested types, which is routinely more than one. Only the referencing side is constrained to
-        // a single type, so a multi-target output is legal -- and it is the only path that reaches
-        // EmitChainJoin's parenthesisation branch, where an unparenthesised OR would bind loosely against the
-        // sibling AND terms and silently widen the join.
+        // the requested types, which is routinely more than one. Only the referencing side is constrained to a
+        // single type, so a multi-target output is legal, and it reaches EmitChainJoin's parenthesisation
+        // branch, where an unparenthesised OR would bind loosely against the sibling AND terms and silently
+        // widen the join. The forward sibling below covers the same branch from the other direction.
         var chain = ReverseChain(["Observation"], ["Patient", "Device"]);
 
         // Act
@@ -1469,8 +1470,8 @@ public class LowerTests
     {
         // Arrange -- GET /?_type=Device&_has:Device:subject:code=4548-4. The chain emits Patient identities
         // while the caller asked only for Device, so the requested-type narrowing is the only thing that keeps
-        // the answer empty. The sibling chain tests all pick chain types inside ResourceTypes and never assert
-        // the narrowing set, so an implementation that skipped NarrowToRequestedTypes would still pass them.
+        // the answer empty. The sibling chain tests all pick chain types inside ResourceTypes and assert only
+        // that an Intersect is there, never which types it narrows to; this one pins the narrowing set itself.
         var chain = ReverseChain(["Device"], ["Patient"]);
 
         // Act
@@ -1510,8 +1511,9 @@ public class LowerTests
     {
         // Arrange -- depth 2 under a null ambient scope. LowerChain passes a concrete type into lowerNode for
         // its inner expression in both directions, so a chain reached inside another chain's scope never sees
-        // the null. The invariant is real but nothing asserted it, and it is what lets the outer chain tolerate
-        // a null ambient scope without the tolerance leaking further down.
+        // the null. EndToEndCompilationTests' GivenANestedChainTwoLevelsDeep covers depth 2 only under a typed
+        // target, where there is no null to leak; this is what lets the outer chain tolerate a null ambient
+        // scope without the tolerance leaking further down.
         var inner = ReverseChain(["Device"], ["Patient"]);
         var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
         var outer = new ChainedExpression(["Observation"], subjectParam, ["Patient"], reversed: false, inner);

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -1302,6 +1302,132 @@ public class LowerTests
         plan.Ctes[join.InnerMatch.Index].ShouldBeOfType<CteDefinition.ParamSource>().ResourceTypeId.ShouldBe((short)104);
     }
 
+    [Fact]
+    public void GivenAForwardChainUnderASystemLevelSearch_WhenLowered_ThenItLowersAgainstItsOwnTargetType()
+    {
+        // Arrange -- GET /?_type=Observation,Device&subject:Patient.name=smith. The mirror of the reverse
+        // case: a forward chain scopes its inner expression against its single target type (Patient) and
+        // emits its referencing types (Observation), so the null ambient scope is again unused.
+        var chain = ForwardChain(["Observation"], ["Patient"]);
+        var symbols = ChainSymbols();
+
+        // Act
+        var plan = LowerHarness.Run(
+            chain, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation", "Device"] }).Plan;
+
+        // Assert -- the join reads Patient rows and emits Observation identities, both taken from the chain.
+        var intersect = plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        var join = plan.Ctes[intersect.Left.Index].ShouldBeOfType<CteDefinition.ChainJoin>();
+        join.Direction.ShouldBe(ChainDirection.Forward);
+        join.InnerResourceTypeId.ShouldBe((short)103);
+        join.OutputResourceTypeIds.ShouldBe([(short)105]);
+        plan.Ctes[join.InnerMatch.Index].ShouldBeOfType<CteDefinition.ParamSource>().ResourceTypeId.ShouldBe((short)103);
+    }
+
+    [Fact]
+    public void GivenAChainNestedInAnAndUnderASystemLevelSearch_WhenLowered_ThenTheChainStillLowers()
+    {
+        // Arrange -- the shape the deleted dispatch guard claimed to cover "equally": the chain is not at
+        // the top level, so the null ambient scope reaches it through LowerAnd's recursion rather than
+        // directly. The sibling must be an ordinary search parameter, not _type: a resource-column leaf is
+        // peeled into the outer WHERE by ExtractResourceColumnPredicates, which would collapse the And back
+        // to a bare chain and never reach LowerAnd at all.
+        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
+        var codeLeaf = new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
+            codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "1234", text: null)));
+        var chain = ForwardChain(["Observation"], ["Patient"]);
+        var and = Expression.And(chain, codeLeaf);
+        var symbols = ChainSymbols();
+
+        // Act
+        var plan = LowerHarness.Run(
+            and, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation", "Device"] }).Plan;
+
+        // Assert -- the chain still self-typed under the null ambient scope.
+        var join = plan.Ctes.OfType<CteDefinition.ChainJoin>().ShouldHaveSingleItem();
+        join.Direction.ShouldBe(ChainDirection.Forward);
+        join.InnerResourceTypeId.ShouldBe((short)103);
+        join.OutputResourceTypeIds.ShouldBe([(short)105]);
+
+        // ...and it got there through LowerAnd: the sibling leg lowered cross-type into its own CTE and the
+        // two legs are joined by an Intersect. Neither exists if the And was peeled away before dispatch.
+        var indexed = plan.Ctes.Select((cte, index) => (cte, index)).ToList();
+        var siblingIndex = indexed.Single(x => x.cte is CteDefinition.ParamSource { SearchParamId: 202 }).index;
+        var joinIndex = indexed.Single(x => ReferenceEquals(x.cte, join)).index;
+        plan.Ctes.OfType<CteDefinition.Intersect>().ShouldContain(
+            intersect => (intersect.Left.Index == joinIndex && intersect.Right.Index == siblingIndex)
+                || (intersect.Left.Index == siblingIndex && intersect.Right.Index == joinIndex));
+    }
+
+    [Fact]
+    public void GivenAForwardChainWithMoreThanOneTargetTypeUnderSystemLevel_WhenLowered_ThenItThrows()
+    {
+        // The side that must be single is now reachable under a null ambient scope, where the deleted
+        // dispatch guard used to short-circuit first. LowerChain must still refuse the ambiguity rather
+        // than silently picking a type.
+        var chain = ForwardChain(["Observation"], ["Patient", "Device"]);
+
+        var exception = Should.Throw<NotSupportedException>(() => LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Observation", "Device"] }));
+
+        // Assert on the ambiguity guard specifically -- the deleted dispatch guard also threw
+        // NotSupportedException, so only the message distinguishes the two.
+        exception.Message.ShouldContain("Forward chain resolved to 2 candidate target types");
+    }
+
+    [Fact]
+    public void GivenAReverseChainWithMoreThanOneReferencingTypeUnderSystemLevel_WhenLowered_ThenItThrows()
+    {
+        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
+        var chain = new ChainedExpression(
+            ["Device", "Observation"],
+            subjectParam,
+            ["Patient"],
+            reversed: true,
+            new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
+                codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, "4548-4", text: null))));
+
+        Should.Throw<NotSupportedException>(() => LowerHarness.Run(
+            chain, ChainSymbols(), targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Patient", "Device"] }))
+            .Message.ShouldContain("Reverse chain's referencing side resolved to 2 types");
+    }
+
+    /// <summary>A forward chain on <c>subject</c> whose inner expression is a name filter on the target type.</summary>
+    private static ChainedExpression ForwardChain(string[] referencingTypes, string[] targetTypes)
+    {
+        var nameParam = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
+        return new ChainedExpression(
+            referencingTypes,
+            subjectParam,
+            targetTypes,
+            reversed: false,
+            new SearchParameterExpression(nameParam, new SearchParameterPredicateExpression(
+                nameParam, SearchComparator.Eq, modifier: null, new StringSearchValue("smith"))));
+    }
+
+    /// <summary>Symbols covering both chain shapes: the code/name/subject parameters and the types they span.</summary>
+    private static SymbolTable ChainSymbols()
+    {
+        return new SymbolTable(
+            new Dictionary<string, short>
+            {
+                ["http://hl7.org/fhir/SearchParameter/clinical-code"] = 202,
+                ["http://hl7.org/fhir/SearchParameter/Device-subject"] = 203,
+                ["http://hl7.org/fhir/SearchParameter/Patient-name"] = 204,
+            },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Device"] = 104, ["Observation"] = 105 });
+    }
+
     /// <summary>The shape a bound <c>_type=a,b</c> takes: an Or of bare _type equalities under one wrapper.</summary>
     private static SearchParameterExpression TypeList(params string[] resourceTypes)
     {

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -1265,6 +1265,43 @@ public class LowerTests
         or.Right.ShouldBeOfType<Predicate.False>().Reason.ShouldNotBeNull();
     }
 
+    [Fact]
+    public void GivenAReverseChainUnderASystemLevelSearch_WhenLowered_ThenItLowersAgainstItsOwnReferencingType()
+    {
+        // Arrange -- GET /?_type=Patient,Device&_has:Device:subject:code=4548-4. The chain sits under no
+        // ambient resource type, but it does not need one: a reverse chain names its own referencing type
+        // (Device, which its inner expression scopes against) and its own target types (Patient, which the
+        // join emits), so the ambient scope it would otherwise inherit is unused. LowerChain reads neither.
+        // The identities a ChainJoin yields are (ResourceTypeId, SurrogateId) pairs over concrete target
+        // types, so the enclosing cross-type intersection stays well-typed.
+        var codeParam = new SearchParameterInfo("code", "code", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/clinical-code"));
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-subject"));
+        var chain = new ChainedExpression(
+            ["Device"],
+            subjectParam,
+            ["Patient"],
+            reversed: true,
+            new SearchParameterExpression(codeParam, new SearchParameterPredicateExpression(
+                codeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, "4548-4", text: null))));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [codeParam.Url!.ToString()] = 202, [subjectParam.Url!.ToString()] = 203 },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Device"] = 104 });
+
+        // Act
+        var plan = LowerHarness.Run(
+            chain, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            new LowerOptions { SystemLevelSearch = true, ResourceTypes = ["Patient", "Device"] }).Plan;
+
+        // Assert -- the join reads Device rows and emits Patient identities, both taken from the chain.
+        var intersect = plan.Ctes[plan.Match.Index].ShouldBeOfType<CteDefinition.Intersect>();
+        var join = plan.Ctes[intersect.Left.Index].ShouldBeOfType<CteDefinition.ChainJoin>();
+        join.Direction.ShouldBe(ChainDirection.Reverse);
+        join.InnerResourceTypeId.ShouldBe((short)104);
+        join.OutputResourceTypeIds.ShouldBe([(short)103]);
+        plan.Ctes[join.InnerMatch.Index].ShouldBeOfType<CteDefinition.ParamSource>().ResourceTypeId.ShouldBe((short)104);
+    }
+
     /// <summary>The shape a bound <c>_type=a,b</c> takes: an Or of bare _type equalities under one wrapper.</summary>
     private static SearchParameterExpression TypeList(params string[] resourceTypes)
     {


### PR DESCRIPTION
Four compiler fixes found while cutting the Microsoft FHIR Server SQL data layer over to `Ignixa.Search` / `Ignixa.Search.Sql`, plus two review passes. Each fix is independent and ships with tests. Rebased onto `main` (`3fe17eb0`).

### `f0befda4` — Gate partially indexed search parameters behind an explicit opt-in

`SearchableSearchParameterDefinitionManager` surfaced partially indexed parameters alongside fully indexed ones. Searching a partial index does not return *fewer* results, it returns *wrong* ones, in both directions: a positive filter misses resources whose index rows do not exist yet, while a negated one comes back through `Except(anchor, inner)` and returns those not-yet-reindexed resources as matches. Nothing in the response distinguishes such a bundle from a complete one. Now opt-in, so a host that knows its reindex has completed can enable it deliberately.

No production code constructs this class — the resolver registrations in `SearchServicesRegistration` and `SearchOptionsBuilderFactory` hand back the raw `SearchParameterDefinitionManager`, which applies no visibility filter at all. So this switch currently reaches only tests and direct callers such as the FHIR Server host.

### `33ac5459` — Accept a leading digit in a search parameter key

`SearchKeySyntaxParser` rejected keys beginning with a digit. FHIR permits them, and real servers define them (`2fa-status`). The parser now accepts a leading digit in every identifier position, `_not-referenced` included.

### `f179397b` — Lower a chain under a system-level search instead of refusing it

`Lower` threw `NotSupportedException` for a `ChainedExpression` when `resourceType` was null. That refused every chained search issued at the system level with `_type` supplying the base, e.g.

```
GET /?_type=Observation&subject:Patient.name=smith
```

The chain has a well-defined base there — `_type` names it — so the guard was rejecting a shape the rest of the pipeline could already handle. Removed the guard; the existing `LowerChain` path handles it. A chain under a *wildcard compartment* search still throws, which is a different null-target case.

### `681e642f` — Make `SearchParameterInfo.GetHashCode` consistent with `Equals`

⚠️ **Public equality-contract change — worth a release note.** `Equals` decides on `Url` alone when one is present, but `GetHashCode` combined all four fields. Two definitions sharing a canonical URL but differing in `Expression` therefore compared equal yet hashed differently, so a `HashSet` kept both and a later `ToDictionary` on `Code` threw.

That is a hard crash on IG load. The generated bundle publishes `_type` with `expression: null`; `SearchParameterDefinitionBuilder` injects a fresh `_type` on every rebuild with `expression: "Resource.type().name"`. Same URL, same code — equal, but different buckets, so both survived the union and the duplicate-key throw took down every tenant package preload. `GetHashCode` now mirrors the `Url`-alone / three-field split exactly.

Note the visible consequence: two parameters sharing a canonical URL under *different* codes now collapse to one entry where both previously survived. Reachable only from a definition-authoring error, and pinned by a test as intended semantics.

### `ab0e8d08` — First review pass

A review found no correctness bugs in the four fixes, but three of the doc blocks they shipped asserted things the code did not do, and one fix swapped a predicate where it meant to widen it.

**Predicate unified.** Under the opt-in, the three collection accessors filtered on `IsSupported` *instead of* `IsSearchable`, while the four singular lookups used the union. Those flags are independent, so a parameter could be returned by `GetSearchParameter` and omitted from `GetSearchParameters`. All seven accessors now share one predicate.

**Missing guard.** `LowerChain` guarded the must-be-single side of a chain but not the output side, where an empty type list emits no filter at all rather than matching nothing.

**Parser consistency.** `_not-referenced` was the one identifier position still gated on `IsAsciiLetter`.

**Coverage** for the shapes the cutover actually hits: multi-type output on both chain directions, chain output narrowed against a disjoint `_type` set, chain under access constraints and under `AllowedResourceTypeFilter` at system level, a chain nested in another chain under a null scope, and a chain under a wildcard compartment search still throwing.

### `3bd59823` — Second review pass

A review of the commit above found it had introduced or left seven false statements while correcting three, and shipped two real defects.

**The visibility predicate was passed as a method group to `Where()`**, moving the host `Func<bool>` from one invocation per accessor call to one per element at enumeration time — contradicting the doc directly above it. `TryGetSearchParameters` returned `true` and then faulted mid-enumeration if the delegate threw; `AllSearchParameters`, a property, deferred its failure to the consumer's first `MoveNext`. The decision is now snapshotted at accessor entry.

**The empty-output guard sat at a layer its own threat model bypasses.** It was justified by the compiler being a public API since #371 — but `QueryPlan` and `CteDefinition.ChainJoin` are public with public constructors, so a caller reaches the emitter without passing through `Lower`. `SqlBuilder` already mirrors five Lower-stage invariants for exactly this reason; this is the sixth. It also covers `ReferencedTypeExpansion` and `CompartmentSource` — `EmitTypeInFilter` was assumed safe on an empty list and is not.

**Comment corrections**, this time each verified against the code: `_sort` was listed as throwing on a null target type when its guard deliberately excludes system-level search; `UnionExpression` claimed instances are created only through `Expression.Union`, which has no call sites in `src/` at all while `ExpressionRewriter` constructs one directly; `:not` was described as negating the presence set when only `:missing=true` does; the class summary contradicted the parameter doc added below it; and two test comments claimed coverage their siblings already had.

Per the reviewer's point that these defects survive because the blocks are long enough that nobody re-derives them, the doc blocks were cut rather than patched.

Also: `_not-referenced` had no negative coverage at all, and the hand-rolled ASCII helpers are now `char.IsAsciiLetterOrDigit`.

A fifth commit, `5d0fc29c "Reuse the injected _type parameter when definitions are rebuilt"`, was dropped. Its tests passed identically with and without it once the `GetHashCode` fix was in place, and its stated rationale — that callers hold references and mutate status flags — is exercised by nothing in `src/`.

## Verification

- `Ignixa.Search.Sql.Tests` — 1072/1072 on net9.0 and net10.0
- `Ignixa.Application.Tests` — 1089 passed, 1 skipped (pre-existing)
- `dotnet build All.sln` — clean, 0 warnings
- Both new guards proven load-bearing by deletion

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 38b039e8-340f-4ecf-a134-ac35e7049848
