### PR TITLE
Exclude the specification's example SearchParameters from the definition set

### DIFF
--- a/codegen/Ignixa.Specification.Generators/CSharpSearchParameterLanguage.cs
+++ b/codegen/Ignixa.Specification.Generators/CSharpSearchParameterLanguage.cs
@@ -21,6 +21,35 @@ public sealed class CSharpSearchParameterLanguage : ILanguage
 {
     private const string LanguageName = "CSharpSearchParameter";
 
+    /// <summary>
+    /// Canonical URLs of the SearchParameter instances the FHIR specification publishes purely as
+    /// *examples* on the SearchParameter resource page. They are illustrations, not conformance
+    /// resources, and they must never reach the definition set.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// They matter because they collide with real parameters on (base resource type, code), and the
+    /// consumer indexes by that pair with a first-writer-wins <c>TryAdd</c>. Emission order therefore
+    /// decides the winner, and for <c>_id</c> the example wins in every FHIR version: the definition
+    /// published under <c>SearchParameter/example</c> ("ID-SEARCH-PARAMETER", expression <c>id</c>)
+    /// shadows the normative <c>SearchParameter/Resource-id</c> (expression <c>Resource.id</c>).
+    /// Anything joining the two definition sets by canonical URL therefore fails to resolve <c>_id</c>.
+    /// </para>
+    /// <para>
+    /// <c>example-reference</c> loses its race today only by luck of ordering — it declares code
+    /// <c>subject</c> on Condition, targeting Organization instead of Group|Patient — and
+    /// <c>example-extension</c> contributes a <c>part-agree</c> parameter based on Patient whose
+    /// expression navigates a DocumentReference extension. Excluding all three removes the class of
+    /// defect rather than the one instance of it.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> SpecificationExampleSearchParameterUrls = new(StringComparer.Ordinal)
+    {
+        "http://hl7.org/fhir/SearchParameter/example",
+        "http://hl7.org/fhir/SearchParameter/example-extension",
+        "http://hl7.org/fhir/SearchParameter/example-reference",
+    };
+
     /// <summary>Gets the language name.</summary>
     public string Name => LanguageName;
 
@@ -138,6 +167,11 @@ public sealed class CSharpSearchParameterLanguage : ILanguage
         int count = 0;
         foreach (var searchParam in searchParameters.Values)
         {
+            if (searchParam.Url != null && SpecificationExampleSearchParameterUrls.Contains(searchParam.Url))
+            {
+                continue;
+            }
+
             GenerateSearchParameterInfoFromObject(sb, searchParam, count == 0);
             count++;
         }

--- a/codegen/generate-search-parameters.ps1
+++ b/codegen/generate-search-parameters.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 # Paths
 $scriptDir = $PSScriptRoot
-$outputDir = Join-Path $scriptDir ".." "src" "Ignixa.Search" "Generated"
+$outputDir = Join-Path $scriptDir ".." "src" "Core" "Ignixa.Search" "Generated"
 $codegenExe = Join-Path $scriptDir "fhir-codegen" "src" "fhir-codegen" "bin" "Release" "net8.0" "fhir-codegen.exe"
 
 # Create output directory

--- a/src/Core/Ignixa.Search/Generated/R4BSearchParameterDefinitions.g.cs
+++ b/src/Core/Ignixa.Search/Generated/R4BSearchParameterDefinitions.g.cs
@@ -6514,39 +6514,6 @@ public static class R4BSearchParameterDefinitions
                 description: "The business version of the evidence variable")
 ,
             new SearchParameterInfo(
-                name: "Example Search Parameter on an extension",
-                code: "part-agree",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-extension"),
-                components: null,
-                expression: "DocumentReference.extension('http://example.org/fhir/StructureDefinition/participation-agreement')",
-                targetResourceTypes: new[] { "DocumentReference" },
-                baseResourceTypes: new[] { "Patient" },
-                description: "Search by url for a participation agreement, which is stored in a DocumentReference")
-,
-            new SearchParameterInfo(
-                name: "Example Search Parameter",
-                code: "subject",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-reference"),
-                components: null,
-                expression: "Condition.subject",
-                targetResourceTypes: new[] { "Organization" },
-                baseResourceTypes: new[] { "Condition" },
-                description: "Search by condition subject")
-,
-            new SearchParameterInfo(
-                name: "ID-SEARCH-PARAMETER",
-                code: "_id",
-                searchParamType: SearchParamType.Token,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example"),
-                components: null,
-                expression: "id",
-                targetResourceTypes: null,
-                baseResourceTypes: new[] { "Resource" },
-                description: "Search by resource identifier - e.g. same as the read interaction, but can return included resources")
-,
-            new SearchParameterInfo(
                 name: "context-quantity",
                 code: "context-quantity",
                 searchParamType: SearchParamType.Quantity,

--- a/src/Core/Ignixa.Search/Generated/R4SearchParameterDefinitions.g.cs
+++ b/src/Core/Ignixa.Search/Generated/R4SearchParameterDefinitions.g.cs
@@ -6393,39 +6393,6 @@ public static class R4SearchParameterDefinitions
                 description: "The business version of the evidence variable")
 ,
             new SearchParameterInfo(
-                name: "Example Search Parameter on an extension",
-                code: "part-agree",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-extension"),
-                components: null,
-                expression: "DocumentReference.extension('http://example.org/fhir/StructureDefinition/participation-agreement')",
-                targetResourceTypes: new[] { "DocumentReference" },
-                baseResourceTypes: new[] { "Patient" },
-                description: "Search by url for a participation agreement, which is stored in a DocumentReference")
-,
-            new SearchParameterInfo(
-                name: "Example Search Parameter",
-                code: "subject",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-reference"),
-                components: null,
-                expression: "Condition.subject",
-                targetResourceTypes: new[] { "Organization" },
-                baseResourceTypes: new[] { "Condition" },
-                description: "Search by condition subject")
-,
-            new SearchParameterInfo(
-                name: "ID-SEARCH-PARAMETER",
-                code: "_id",
-                searchParamType: SearchParamType.Token,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example"),
-                components: null,
-                expression: "id",
-                targetResourceTypes: null,
-                baseResourceTypes: new[] { "Resource" },
-                description: "Search by resource identifier - e.g. same as the read interaction, but can return included resources")
-,
-            new SearchParameterInfo(
                 name: "context-quantity",
                 code: "context-quantity",
                 searchParamType: SearchParamType.Quantity,

--- a/src/Core/Ignixa.Search/Generated/R5SearchParameterDefinitions.g.cs
+++ b/src/Core/Ignixa.Search/Generated/R5SearchParameterDefinitions.g.cs
@@ -5480,39 +5480,6 @@ public static class R5SearchParameterDefinitions
                 description: "Search Composition Bundle")
 ,
             new SearchParameterInfo(
-                name: "ExampleSearchParameterOnAnExtension",
-                code: "part-agree",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-extension"),
-                components: null,
-                expression: "Patient.extension('http://example.org/fhir/StructureDefinition/participation-agreement').value",
-                targetResourceTypes: new[] { "DocumentReference" },
-                baseResourceTypes: new[] { "Patient" },
-                description: "Search by url for a participation agreement, which is stored as an extension referencing a DocumentReference")
-,
-            new SearchParameterInfo(
-                name: "ExampleSearchParameter",
-                code: "subject",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-reference"),
-                components: null,
-                expression: "Condition.subject",
-                targetResourceTypes: new[] { "Organization" },
-                baseResourceTypes: new[] { "Condition" },
-                description: "Search by condition subject")
-,
-            new SearchParameterInfo(
-                name: "IDSEARCHPARAMETER",
-                code: "_id",
-                searchParamType: SearchParamType.Token,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example"),
-                components: null,
-                expression: "id",
-                targetResourceTypes: null,
-                baseResourceTypes: new[] { "Resource" },
-                description: "Search by resource identifier - e.g. same as the read interaction, but can return included resources")
-,
-            new SearchParameterInfo(
                 name: "care-team",
                 code: "care-team",
                 searchParamType: SearchParamType.Reference,

--- a/src/Core/Ignixa.Search/Generated/R6SearchParameterDefinitions.g.cs
+++ b/src/Core/Ignixa.Search/Generated/R6SearchParameterDefinitions.g.cs
@@ -5810,39 +5810,6 @@ public static class R6SearchParameterDefinitions
                 description: "Search Composition Bundle")
 ,
             new SearchParameterInfo(
-                name: "ExampleSearchParameterOnAnExtension",
-                code: "part-agree",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-extension"),
-                components: null,
-                expression: "Patient.extension('http://example.org/fhir/StructureDefinition/participation-agreement').value",
-                targetResourceTypes: new[] { "DocumentReference" },
-                baseResourceTypes: new[] { "Patient" },
-                description: "Search by url for a participation agreement, which is stored as an extension referencing a DocumentReference")
-,
-            new SearchParameterInfo(
-                name: "ExampleSearchParameter",
-                code: "subject",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-reference"),
-                components: null,
-                expression: "Condition.subject",
-                targetResourceTypes: new[] { "Organization" },
-                baseResourceTypes: new[] { "Condition" },
-                description: "Search by condition subject")
-,
-            new SearchParameterInfo(
-                name: "IDSEARCHPARAMETER",
-                code: "_id",
-                searchParamType: SearchParamType.Token,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example"),
-                components: null,
-                expression: "id",
-                targetResourceTypes: null,
-                baseResourceTypes: new[] { "Resource" },
-                description: "Search by resource identifier - e.g. same as the read interaction, but can return included resources")
-,
-            new SearchParameterInfo(
                 name: "care-team",
                 code: "care-team",
                 searchParamType: SearchParamType.Reference,

--- a/src/Core/Ignixa.Search/Generated/STU3SearchParameterDefinitions.g.cs
+++ b/src/Core/Ignixa.Search/Generated/STU3SearchParameterDefinitions.g.cs
@@ -5557,28 +5557,6 @@ public static class STU3SearchParameterDefinitions
                 description: "The current status of the Episode of Care as provided (does not check the status history collection)")
 ,
             new SearchParameterInfo(
-                name: "Example Search Parameter on an extension",
-                code: "part-agree",
-                searchParamType: SearchParamType.Reference,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example-extension"),
-                components: null,
-                expression: "DocumentReference.extension('http://example.org/fhir/StructureDefinition/participation-agreement')",
-                targetResourceTypes: new[] { "DocumentReference" },
-                baseResourceTypes: new[] { "Patient" },
-                description: "Search by url for a participation agreement, which is stored in a DocumentReference")
-,
-            new SearchParameterInfo(
-                name: "ID-SEARCH-PARAMETER",
-                code: "_id",
-                searchParamType: SearchParamType.Token,
-                url: new Uri("http://hl7.org/fhir/SearchParameter/example"),
-                components: null,
-                expression: "id",
-                targetResourceTypes: null,
-                baseResourceTypes: new[] { "Resource" },
-                description: "Search by resource identifier - e.g. same as the read interaction, but can return included resources")
-,
-            new SearchParameterInfo(
                 name: "date",
                 code: "date",
                 searchParamType: SearchParamType.Date,

--- a/test/Ignixa.Application.Tests/Search/Definition/GeneratedSearchParameterDefinitionsTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Definition/GeneratedSearchParameterDefinitionsTests.cs
@@ -1,0 +1,124 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa. All rights reserved.
+// Licensed under the MIT License (MIT).
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Application.Tests.Search.Definition;
+
+/// <summary>
+/// Guards the generated base search parameter sets against the FHIR specification's own *example*
+/// SearchParameter instances leaking into the conformance set.
+/// </summary>
+/// <remarks>
+/// The published search-parameters bundle ships three illustrative instances alongside the normative
+/// ones — <c>SearchParameter/example</c>, <c>SearchParameter/example-reference</c> and
+/// <c>SearchParameter/example-extension</c>. They are documentation, not conformance, but they declare
+/// real codes on real base resource types, so they collide with normative entries.
+/// <para>
+/// The collision is decided by emission order, silently:
+/// <see cref="SearchParameterDefinitionManager"/> populates both its URL and its type lookup with
+/// <c>TryAdd</c>, so the first parameter emitted for a given (base resource type, code) pair wins and
+/// every later one is discarded without a diagnostic. Before these entries were excluded from
+/// generation, <c>SearchParameter/example</c> was emitted ahead of <c>Resource-id</c> and therefore
+/// owned <c>_id</c> in every FHIR version — with expression <c>id</c> rather than <c>Resource.id</c>.
+/// </para>
+/// </remarks>
+public class GeneratedSearchParameterDefinitionsTests
+{
+    /// <summary>
+    /// Canonical URLs of the specification's example SearchParameter instances. None of these may
+    /// appear in a generated conformance set.
+    /// </summary>
+    private static readonly string[] ExampleUrls =
+    [
+        "http://hl7.org/fhir/SearchParameter/example",
+        "http://hl7.org/fhir/SearchParameter/example-reference",
+        "http://hl7.org/fhir/SearchParameter/example-extension",
+    ];
+
+    [Theory]
+    [InlineData(FhirVersion.Stu3)]
+    [InlineData(FhirVersion.R4)]
+    [InlineData(FhirVersion.R4B)]
+    [InlineData(FhirVersion.R5)]
+    [InlineData(FhirVersion.R6)]
+    public void GivenAGeneratedDefinitionSet_WhenLoaded_ThenIdResolvesToTheNormativeResourceIdParameter(FhirVersion version)
+    {
+        // Arrange
+        var manager = CreateManager(version);
+
+        // Act
+        var found = manager.TryGetSearchParameter("Patient", "_id", out var parameter);
+
+        // Assert: SearchParameter/example also declares code _id on Resource, with expression "id".
+        // If it wins the TryAdd race, every _id search compiles against the wrong expression.
+        found.ShouldBeTrue();
+        parameter.Url.ShouldBe(new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        parameter.Expression.ShouldBe("Resource.id");
+    }
+
+    [Theory]
+    [InlineData(FhirVersion.Stu3)]
+    [InlineData(FhirVersion.R4)]
+    [InlineData(FhirVersion.R4B)]
+    [InlineData(FhirVersion.R5)]
+    [InlineData(FhirVersion.R6)]
+    public void GivenAGeneratedDefinitionSet_WhenLoaded_ThenNoExampleSearchParameterIsPresent(FhirVersion version)
+    {
+        // Arrange
+        var manager = CreateManager(version);
+
+        // Act
+        var present = ExampleUrls
+            .Where(url => manager.UrlLookup.ContainsKey(new Uri(url)))
+            .ToList();
+
+        // Assert
+        present.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(FhirVersion.Stu3)]
+    [InlineData(FhirVersion.R4)]
+    [InlineData(FhirVersion.R4B)]
+    [InlineData(FhirVersion.R5)]
+    [InlineData(FhirVersion.R6)]
+    public void GivenAGeneratedDefinitionSet_WhenLoaded_ThenSubjectOnConditionResolvesToTheNormativeParameter(FhirVersion version)
+    {
+        // Arrange
+        var manager = CreateManager(version);
+
+        // Act
+        var found = manager.TryGetSearchParameter("Condition", "subject", out var parameter);
+
+        // Assert: SearchParameter/example-reference declares code "subject" on Condition targeting
+        // Organization, while the normative Condition-subject targets the patient/group types — so
+        // adopting the example silently changes which references a chain may traverse. Before the
+        // exclusion this resolved correctly only because Condition-subject happened to be emitted
+        // first; this assertion removes the reliance on emission order.
+        found.ShouldBeTrue();
+        parameter.Url.ShouldBe(new Uri("http://hl7.org/fhir/SearchParameter/Condition-subject"));
+    }
+
+    private static SearchParameterDefinitionManager CreateManager(FhirVersion version)
+    {
+        IFhirSchemaProvider schema = version switch
+        {
+            FhirVersion.Stu3 => new STU3CoreSchemaProvider(),
+            FhirVersion.R4 => new R4CoreSchemaProvider(),
+            FhirVersion.R4B => new R4BCoreSchemaProvider(),
+            FhirVersion.R5 => new R5CoreSchemaProvider(),
+            FhirVersion.R6 => new R6CoreSchemaProvider(),
+            _ => throw new NotSupportedException($"FHIR version {version} is not covered by this test."),
+        };
+
+        return new SearchParameterDefinitionManager(schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+    }
+}


### PR DESCRIPTION
## Problem

The published `search-parameters` bundle ships three illustrative SearchParameter instances alongside the normative ones — `SearchParameter/example`, `SearchParameter/example-reference` and `SearchParameter/example-extension`. They are documentation on the SearchParameter resource page, not conformance resources, but they declare real codes on real base resource types, so they collide with normative entries in the generated definition sets.

`SearchParameterDefinitionManager` populates both `UrlLookup` and `TypeLookup` with `TryAdd`, so the **first** parameter emitted for a given `(base resource type, code)` pair wins and every later one is discarded without a diagnostic. Emission order silently decides the winner.

**For `_id` the example wins in every FHIR version.** `ID-SEARCH-PARAMETER` (`SearchParameter/example`, expression `id`) shadows the normative `Resource-id` (expression `Resource.id`), so `TypeLookup["Patient"]["_id"]` resolves to the example. Any consumer joining its own definition set to Ignixa''s by canonical URL therefore cannot resolve `_id` at all — which is how this was found, integrating `Ignixa.Search` into Microsoft''s FHIR server.

Collision census over the generated sets:

```
R4/R4B/R5 : Resource|_id      -> example , Resource-id         ** EXAMPLE WINS **
            Condition|subject -> Condition-subject , example-reference
STU3      : Resource|_id      -> example , Resource-id         ** EXAMPLE WINS **
```

`example-reference` loses its race today **only by luck of ordering**: it declares code `subject` on Condition targeting `Organization`, where the normative `Condition-subject` targets `Group|Patient`. One reordering of the bundle and a chain through `Condition.subject` starts traversing the wrong references. `example-extension` contributes a `part-agree` parameter based on `Patient` whose expression navigates a `DocumentReference` extension. Excluding all three removes the class of defect rather than the one instance of it.

Nothing in the repository referenced any of the three.

## Change

- `CSharpSearchParameterLanguage` skips the three canonical example URLs when emitting entries.
- The five `*SearchParameterDefinitions.g.cs` artifacts are updated to match.
- `generate-search-parameters.ps1`''s `$outputDir` fixed — it still pointed at `src/Ignixa.Search/Generated` rather than `src/Core/Ignixa.Search/Generated`, so running it would have written the generated files to a directory nothing compiles.
- New `GeneratedSearchParameterDefinitionsTests` pins the invariant across all five versions.

### Why the generator and its artifacts changed together

The `codegen/fhir-codegen` submodule is not checked out in this working tree, so `generate-search-parameters.ps1` cannot be run to regenerate. The `.g.cs` files were edited to match exactly what the guarded generator emits: whole entries removed, separators left well-formed, pure deletions (`154 deletions, 0 insertions`). R4/R4B/R5/R6 drop three each; STU3 drops two, because it does not publish `example-reference`.

The `count == 0` "isFirst" separator logic is unaffected — `count` is only incremented for entries that are actually emitted. **Happy to drop the artifact changes and regenerate instead if you''d prefer** — the generator change alone is the fix.

## Test plan

- [x] `GeneratedSearchParameterDefinitionsTests` — 15 cases across STU3/R4/R4B/R5/R6, asserting `_id` resolves to `Resource-id` with expression `Resource.id`, that no example URL is present, and that `Condition.subject` resolves normatively.
- [x] **Proven load-bearing**: against the unfixed generated files 10 of the 15 fail. The five `Condition.subject` cases pass — which is exactly the point, that one is correct only by accident today.
- [x] `Ignixa.Application.Tests` — 1122/1123 (1 pre-existing skip).
- [x] `Ignixa.Search.Sql.Tests` — 1074/1074 on both `net9.0` and `net10.0`.

## Out of scope, noted while here

- `_type` is emitted twice — once from the bundle as `Resource-type`, once by the hardcoded append at `CSharpSearchParameterLanguage.cs:145-159` whose comment claims it is "not included in the standard FHIR search-parameters" (it is, in R4). Harmless today because `SearchParameterInfo`''s equality is URL-based and both carry the same URL.
- R6 additionally has genuine `Resource|identifier` / `status` / `type` collisions between `DeviceAlert-*`, `InsuranceProduct-*` and `MolecularDefinition-*`. That is an R6-ballot package artifact with a different cause, left alone.
- `SearchParameterDefinitionBuilder.BuildSearchParameterDefinition:270-274` does `results.ToDictionary(r => r.Code)`, which would **throw** on a duplicate code. The generated path avoids it only because it uses `TryAdd` instead.
