### PR TITLE
fix(search-sql): split token codes at the column width, as fhir-server does

### DIFF
--- a/docs/migrations/token-code-split-width.md
+++ b/docs/migrations/token-code-split-width.md
@@ -1,0 +1,79 @@
+# Migration: token code overflow split point moves from 128 to 256
+
+## Who this affects
+
+Only databases **this server already wrote token search rows into**, before the change described here.
+
+A database provisioned from `Resources/97.sql` and populated by `microsoft/fhir-server` is unaffected — that
+server always split at the column width, which is what this change adopts. A brand-new database is
+unaffected. There is nothing to run for either.
+
+## What changed
+
+`dbo.TokenSearchParam.Code` is `VARCHAR(256)`. A token code longer than the column is stored split: the
+leading characters in `Code`, the remainder in `CodeOverflow`.
+
+Ignixa's row generators used to divide that value at a hard-coded **128** rather than at the column's
+declared width. They now divide at the width, which is where `microsoft/fhir-server` divides it and where
+the search compiler has always expected to find it.
+
+The same correction applies to `TokenStringCompositeSearchParam.TextOverflow2`, which used to hold the
+*remainder* of an over-long string component and now holds the *whole* value, matching
+`StringSearchParam.TextOverflow`.
+
+## The consequence for existing rows
+
+Rows written under the old convention hold `Code` = the first 128 characters. The read path now assumes the
+first 256. The two disagree for one band of values:
+
+| Stored token code length | Findable after this change | Why |
+|---|---|---|
+| ≤ 128 | yes | stored whole in `Code` under both conventions |
+| **129 – 256** | **no** | search compares the whole value against `Code`, which holds only 128 characters |
+| > 256 | yes | search reassembles `Code + CodeOverflow`, which is split-point agnostic |
+
+The failure is silent: an affected search returns an empty result set, not an error.
+
+`TokenStringCompositeSearchParam` rows with a string component longer than 256 characters are affected the
+same way, because `TextOverflow2` holds a remainder that the read path now compares as a whole value.
+
+## What to do
+
+Reindex the affected resources. Any operation that re-runs search parameter extraction and rewrites the
+search parameter tables is sufficient — the row generators produce the new layout on the next write, and a
+row rewritten under the new convention needs nothing further.
+
+Scoping the work: token codes longer than 128 characters are uncommon in practice. Before reindexing
+wholesale, this identifies whether the affected band exists at all.
+
+```sql
+SELECT COUNT(*)
+FROM dbo.TokenSearchParam
+WHERE CodeOverflow IS NOT NULL
+  AND LEN(Code) = 128
+  AND LEN(Code) + LEN(CodeOverflow) <= 256;
+```
+
+A count of zero means no row falls in the affected band and no reindex is required. `LEN(Code) = 128` is
+what identifies a row written under the old convention: under the new one a row with a non-null overflow
+always has `LEN(Code) = 256`.
+
+The composite equivalent:
+
+```sql
+SELECT COUNT(*)
+FROM dbo.TokenStringCompositeSearchParam
+WHERE TextOverflow2 IS NOT NULL
+  AND LEN(Text2) = 128;
+```
+
+## Why the split moved up rather than the reader moving down
+
+The package README offers adoption of an existing `microsoft/fhir-server` database without data migration.
+That server splits at the column width. Holding Ignixa at 128 would have made every token code over 128
+characters in such a database unfindable — a permanently wrong answer against a far larger population of
+data than the one this note covers.
+
+A reader tolerant of both conventions (`Code = @code OR Code + CodeOverflow = @code`) was considered and
+rejected: it would carry an `OR` on the hottest search path in the server, permanently, to serve a
+transitional state.

--- a/docs/migrations/token-code-split-width.md
+++ b/docs/migrations/token-code-split-width.md
@@ -34,8 +34,12 @@ first 256. The two disagree for one band of values:
 
 The failure is silent: an affected search returns an empty result set, not an error.
 
-`TokenStringCompositeSearchParam` rows with a string component longer than 256 characters are affected the
-same way, because `TextOverflow2` holds a remainder that the read path now compares as a whole value.
+`TokenStringCompositeSearchParam` is affected more broadly: the old writer split at 128 unconditionally, so
+every row with a string component longer than 128 characters — not just past 256 — has `TextOverflow2`
+holding a remainder rather than the whole value. The read path now treats `TextOverflow2` as the whole
+value once the *search* value exceeds 256 characters, so any of those rows can miss a match at that point,
+not only ones whose stored value happens to exceed 256. The diagnostic query below already scopes to this
+full band — it has no upper bound for exactly this reason.
 
 ## What to do
 

--- a/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
+++ b/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
@@ -30,9 +30,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Ignixa.Search.Sql.Tests" />
-    <!-- Reads TokenColumnEquality.InlineCodeWidth to pin the compiler's split point against what the
-         token row generators actually write, which this assembly's own tests cannot observe. -->
-    <InternalsVisibleTo Include="Ignixa.DataLayer.SqlEntityFramework.IntegrationTests" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
+++ b/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
@@ -30,6 +30,9 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Ignixa.Search.Sql.Tests" />
+    <!-- Reads TokenColumnEquality.InlineCodeWidth to pin the compiler's split point against what the
+         token row generators actually write, which this assembly's own tests cannot observe. -->
+    <InternalsVisibleTo Include="Ignixa.DataLayer.SqlEntityFramework.IntegrationTests" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
@@ -12,6 +12,23 @@ namespace Ignixa.Search.Sql.Lowering;
 /// </summary>
 internal static class TokenColumnEquality
 {
+    /// <summary>
+    /// The character count at which the row generators split an overflowing token code: the leading
+    /// <see cref="InlineCodeWidth"/> characters go to the Code column and the remainder to CodeOverflow.
+    /// This is a storage convention, not a schema fact, and it must change in lockstep with the literal
+    /// 128 in every token row generator — the writers and this reader are deliberately two independent
+    /// sources of truth, so a divergence is caught rather than propagated.
+    /// <para>
+    /// It is deliberately NOT read from <c>SqlCatalog</c>, whose own summary says it "describes the
+    /// schema, not storage convention". The Code column is declared VARCHAR(256) while the generators
+    /// split at 128, so deriving the split point from the column width searches for a prefix no row ever
+    /// stores: every code longer than 128 characters silently matches nothing. Tests inside this assembly
+    /// cannot detect that, because the only width they can read is the same one the rule would read;
+    /// the guard lives in the row generators' test project instead.
+    /// </para>
+    /// </summary>
+    internal const int InlineCodeWidth = 128;
+
     public static Predicate Build(TableDescriptor table, string systemColumn, string codeColumn, string overflowColumn, TokenSearchValue value, LeafContext context)
     {
         int? systemId = value.System is { Length: > 0 } system ? context.SystemId(system) : null;
@@ -43,23 +60,16 @@ internal static class TokenColumnEquality
         var column = new SqlColumnRef(table.TableName, codeColumn);
         var overflow = new SqlColumnRef(table.TableName, overflowColumn);
 
-        // Split point is the Code column's declared width (what every row generator splits at). Reading it
-        // from the catalog, not a constant, keeps the compiler matching the DDL: a hard-coded width that
-        // disagreed would silently match nothing for every overflowing code.
-        int inlineCodeWidth = table.Column(codeColumn).MaxLength
-            ?? throw new NotSupportedException(
-                $"Column {table.TableName}.{codeColumn} declares no width, so the code overflow split point is unknown.");
-
         return code switch
         {
             null or "" => null,
-            { } shorter when shorter.Length < inlineCodeWidth => new Predicate.Equal(column, context.Parameter(code)),
-            { } exact when exact.Length == inlineCodeWidth => new Predicate.And(
+            { } shorter when shorter.Length < InlineCodeWidth => new Predicate.Equal(column, context.Parameter(code)),
+            { } exact when exact.Length == InlineCodeWidth => new Predicate.And(
                 new Predicate.IsNull(overflow),
                 new Predicate.Equal(column, context.Parameter(code))),
             _ => new Predicate.And(
-                new Predicate.Equal(column, context.Parameter(code[..inlineCodeWidth])),
-                new Predicate.Equal(overflow, context.Parameter(code[inlineCodeWidth..]))),
+                new Predicate.Equal(column, context.Parameter(code[..InlineCodeWidth])),
+                new Predicate.Equal(overflow, context.Parameter(code[InlineCodeWidth..]))),
         };
     }
 }

--- a/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
@@ -12,23 +12,6 @@ namespace Ignixa.Search.Sql.Lowering;
 /// </summary>
 internal static class TokenColumnEquality
 {
-    /// <summary>
-    /// The character count at which the row generators split an overflowing token code: the leading
-    /// <see cref="InlineCodeWidth"/> characters go to the Code column and the remainder to CodeOverflow.
-    /// This is a storage convention, not a schema fact, and it must change in lockstep with the literal
-    /// 128 in every token row generator — the writers and this reader are deliberately two independent
-    /// sources of truth, so a divergence is caught rather than propagated.
-    /// <para>
-    /// It is deliberately NOT read from <c>SqlCatalog</c>, whose own summary says it "describes the
-    /// schema, not storage convention". The Code column is declared VARCHAR(256) while the generators
-    /// split at 128, so deriving the split point from the column width searches for a prefix no row ever
-    /// stores: every code longer than 128 characters silently matches nothing. Tests inside this assembly
-    /// cannot detect that, because the only width they can read is the same one the rule would read;
-    /// the guard lives in the row generators' test project instead.
-    /// </para>
-    /// </summary>
-    internal const int InlineCodeWidth = 128;
-
     public static Predicate Build(TableDescriptor table, string systemColumn, string codeColumn, string overflowColumn, TokenSearchValue value, LeafContext context)
     {
         int? systemId = value.System is { Length: > 0 } system ? context.SystemId(system) : null;
@@ -60,16 +43,25 @@ internal static class TokenColumnEquality
         var column = new SqlColumnRef(table.TableName, codeColumn);
         var overflow = new SqlColumnRef(table.TableName, overflowColumn);
 
+        // The split point is the Code column's declared width. microsoft/fhir-server derives it the same
+        // way (VLatest.TokenSearchParam.Code.Metadata.MaxLength), and so do this repo's row generators via
+        // SearchParamColumnWidths, so a database either server populated splits here too. A literal that
+        // drifted from the DDL would search for a prefix no row stores — every overflowing code would
+        // silently match nothing.
+        int inlineCodeWidth = table.Column(codeColumn).MaxLength
+            ?? throw new NotSupportedException(
+                $"Column {table.TableName}.{codeColumn} declares no width, so the code overflow split point is unknown.");
+
         return code switch
         {
             null or "" => null,
-            { } shorter when shorter.Length < InlineCodeWidth => new Predicate.Equal(column, context.Parameter(code)),
-            { } exact when exact.Length == InlineCodeWidth => new Predicate.And(
+            { } shorter when shorter.Length < inlineCodeWidth => new Predicate.Equal(column, context.Parameter(code)),
+            { } exact when exact.Length == inlineCodeWidth => new Predicate.And(
                 new Predicate.IsNull(overflow),
                 new Predicate.Equal(column, context.Parameter(code))),
             _ => new Predicate.And(
-                new Predicate.Equal(column, context.Parameter(code[..InlineCodeWidth])),
-                new Predicate.Equal(overflow, context.Parameter(code[InlineCodeWidth..]))),
+                new Predicate.Equal(column, context.Parameter(code[..inlineCodeWidth])),
+                new Predicate.Equal(overflow, context.Parameter(code[inlineCodeWidth..]))),
         };
     }
 }

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Entities/ReferenceTokenCompositeSearchParamEntity.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Entities/ReferenceTokenCompositeSearchParamEntity.cs
@@ -60,4 +60,9 @@ public class ReferenceTokenCompositeSearchParamEntity
     [Required]
     [MaxLength(256)]
     public string Code2 { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets overflow code for the token component (when code exceeds 256 chars).
+    /// </summary>
+    public string? CodeOverflow2 { get; set; }
 }

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Entities/TokenNumberNumberCompositeSearchParamEntity.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Entities/TokenNumberNumberCompositeSearchParamEntity.cs
@@ -44,6 +44,11 @@ public class TokenNumberNumberCompositeSearchParamEntity
     public string Code1 { get; set; } = null!;
 
     /// <summary>
+    /// Gets or sets overflow code for the token component (when code exceeds 256 chars).
+    /// </summary>
+    public string? CodeOverflow1 { get; set; }
+
+    /// <summary>
     /// Gets or sets the single low value for the first number component.
     /// </summary>
     public decimal? SingleValue2 { get; set; }

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/RefTokenCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/RefTokenCompositeRowGenerator.cs
@@ -45,7 +45,7 @@ public class RefTokenCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ReferenceResourceId1", SqlDbType.VarChar, 64),
             new SqlMetaData("ReferenceResourceVersion1", SqlDbType.Int),
             new SqlMetaData("SystemId2", SqlDbType.Int),
-            new SqlMetaData("Code2", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code2", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow2", SqlDbType.VarChar, -1),
         };
 
@@ -128,10 +128,10 @@ public class RefTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > 128)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(8, tokenComponent.Code.Substring(0, 128));
-                            record.SetString(9, tokenComponent.Code.Substring(128));
+                            record.SetString(8, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(9, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/RefTokenCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/RefTokenCompositeRowGenerator.cs
@@ -18,6 +18,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class RefTokenCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code2Width = SearchParamColumnWidths.For("ReferenceTokenCompositeSearchParam", "Code2");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -45,7 +47,7 @@ public class RefTokenCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ReferenceResourceId1", SqlDbType.VarChar, 64),
             new SqlMetaData("ReferenceResourceVersion1", SqlDbType.Int),
             new SqlMetaData("SystemId2", SqlDbType.Int),
-            new SqlMetaData("Code2", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code2", SqlDbType.VarChar, Code2Width),
             new SqlMetaData("CodeOverflow2", SqlDbType.VarChar, -1),
         };
 
@@ -128,10 +130,10 @@ public class RefTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > Code2Width)
                         {
-                            record.SetString(8, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(9, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(8, tokenComponent.Code.Substring(0, Code2Width));
+                            record.SetString(9, tokenComponent.Code.Substring(Code2Width));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/SearchParamColumnWidths.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/SearchParamColumnWidths.cs
@@ -8,33 +8,25 @@ using Ignixa.Search.Sql.Catalog;
 namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 
 /// <summary>
-/// The widths at which the row generators split an overflowing value, sourced from the real DDL in
-/// Resources/97.sql via <see cref="SqlCatalog"/>.
+/// The width at which a row generator divides an overflowing value between an inline column and its
+/// overflow companion, sourced from the real DDL in Resources/97.sql via <see cref="SqlCatalog"/>.
 /// </summary>
 /// <remarks>
 /// microsoft/fhir-server derives the same split from its generated column metadata
 /// (<c>VLatest.TokenSearchParam.Code.Metadata.MaxLength</c>), so taking it from the catalog rather than a
 /// literal is what keeps rows written here byte-compatible with a database that server populated -- the
-/// zero-data-migration promise in this package's README. A literal that drifted from the DDL would make
-/// every overflowing value silently unmatchable, because the search compiler splits at the same width.
+/// zero-data-migration promise in this package's README.
 ///
-/// One width covers every token slot because fhir-server's composite generators delegate to its leaf
-/// token generator, and 97.sql declares every composite Code1/Code2 identically to TokenSearchParam.Code.
+/// Each caller names the column it is about to write, because that is the column the reader resolves the
+/// same width from: <c>TokenColumnEquality</c> and <c>TokenStringLoweringRule</c> look up the width on the
+/// table they are querying. Deriving both sides from the same catalog entry is what makes them agree.
+/// Sharing one leaf width across every slot would only agree while the DDL happened to stay uniform, which
+/// is the same class of coupling as the literal this replaced.
 /// </remarks>
 internal static class SearchParamColumnWidths
 {
-    /// <summary>
-    /// Split point for a token code: Code keeps the leading characters, CodeOverflow the remainder.
-    /// </summary>
-    internal static readonly int TokenCode = Width("TokenSearchParam", "Code");
-
-    /// <summary>
-    /// Split point for a searchable string: Text keeps a redundant leading prefix so the index can still
-    /// seek, and TextOverflow holds the WHOLE value -- not the remainder.
-    /// </summary>
-    internal static readonly int StringText = Width("StringSearchParam", "Text");
-
-    private static int Width(string table, string column) =>
+    internal static int For(string table, string column) =>
         SqlCatalog.Default.Table(table).Column(column).MaxLength
-        ?? throw new InvalidOperationException($"{table}.{column} has no MaxLength in SqlCatalog.");
+        ?? throw new InvalidOperationException(
+            $"{table}.{column} declares no width, so the overflow split point is unknown.");
 }

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/SearchParamColumnWidths.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/SearchParamColumnWidths.cs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Search.Sql.Catalog;
+
+namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
+
+/// <summary>
+/// The widths at which the row generators split an overflowing value, sourced from the real DDL in
+/// Resources/97.sql via <see cref="SqlCatalog"/>.
+/// </summary>
+/// <remarks>
+/// microsoft/fhir-server derives the same split from its generated column metadata
+/// (<c>VLatest.TokenSearchParam.Code.Metadata.MaxLength</c>), so taking it from the catalog rather than a
+/// literal is what keeps rows written here byte-compatible with a database that server populated -- the
+/// zero-data-migration promise in this package's README. A literal that drifted from the DDL would make
+/// every overflowing value silently unmatchable, because the search compiler splits at the same width.
+///
+/// One width covers every token slot because fhir-server's composite generators delegate to its leaf
+/// token generator, and 97.sql declares every composite Code1/Code2 identically to TokenSearchParam.Code.
+/// </remarks>
+internal static class SearchParamColumnWidths
+{
+    /// <summary>
+    /// Split point for a token code: Code keeps the leading characters, CodeOverflow the remainder.
+    /// </summary>
+    internal static readonly int TokenCode = Width("TokenSearchParam", "Code");
+
+    /// <summary>
+    /// Split point for a searchable string: Text keeps a redundant leading prefix so the index can still
+    /// seek, and TextOverflow holds the WHOLE value -- not the remainder.
+    /// </summary>
+    internal static readonly int StringText = Width("StringSearchParam", "Text");
+
+    private static int Width(string table, string column) =>
+        SqlCatalog.Default.Table(table).Column(column).MaxLength
+        ?? throw new InvalidOperationException($"{table}.{column} has no MaxLength in SqlCatalog.");
+}

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/StringSearchParameterRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/StringSearchParameterRowGenerator.cs
@@ -33,11 +33,7 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </remarks>
 public class StringSearchParameterRowGenerator : ISearchParameterRowGenerator
 {
-    // Inline width sourced from SqlCatalog (Phase 3) instead of a locally hardcoded constant --
-    // matches dbo.StringSearchParam.Text's real DDL width (Resources/97.sql).
-    private static readonly int InlineWidth =
-        SqlCatalog.Default.Table("StringSearchParam").Column("Text").MaxLength
-        ?? throw new InvalidOperationException("StringSearchParam.Text has no MaxLength in SqlCatalog.");
+    private static readonly int InlineWidth = SearchParamColumnWidths.StringText;
 
     public IEnumerable<SqlDataRecord> GenerateSqlDataRecords(
         IReadOnlyList<ResourceWrapper> resources,
@@ -50,7 +46,7 @@ public class StringSearchParameterRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceTypeId", SqlDbType.SmallInt),
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
-            new SqlMetaData("Text", SqlDbType.NVarChar, 256),
+            new SqlMetaData("Text", SqlDbType.NVarChar, SearchParamColumnWidths.StringText),
             new SqlMetaData("TextOverflow", SqlDbType.NVarChar, -1),
             new SqlMetaData("IsMin", SqlDbType.Bit),
             new SqlMetaData("IsMax", SqlDbType.Bit),

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/StringSearchParameterRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/StringSearchParameterRowGenerator.cs
@@ -8,7 +8,6 @@ using Ignixa.Domain.Models;
 using Ignixa.Search.Indexing;
 using Ignixa.Search.Indexing.SearchValues;
 using Ignixa.Search.Models;
-using Ignixa.Search.Sql.Catalog;
 using Microsoft.Data.SqlClient.Server;
 
 namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
@@ -33,7 +32,7 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </remarks>
 public class StringSearchParameterRowGenerator : ISearchParameterRowGenerator
 {
-    private static readonly int InlineWidth = SearchParamColumnWidths.StringText;
+    private static readonly int InlineWidth = SearchParamColumnWidths.For("StringSearchParam", "Text");
 
     public IEnumerable<SqlDataRecord> GenerateSqlDataRecords(
         IReadOnlyList<ResourceWrapper> resources,
@@ -46,7 +45,7 @@ public class StringSearchParameterRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceTypeId", SqlDbType.SmallInt),
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
-            new SqlMetaData("Text", SqlDbType.NVarChar, SearchParamColumnWidths.StringText),
+            new SqlMetaData("Text", SqlDbType.NVarChar, InlineWidth),
             new SqlMetaData("TextOverflow", SqlDbType.NVarChar, -1),
             new SqlMetaData("IsMin", SqlDbType.Bit),
             new SqlMetaData("IsMax", SqlDbType.Bit),

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenDateTimeCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenDateTimeCompositeRowGenerator.cs
@@ -17,6 +17,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenDateTimeCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code1Width = SearchParamColumnWidths.For("TokenDateTimeCompositeSearchParam", "Code1");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -40,7 +42,7 @@ public class TokenDateTimeCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code1", SqlDbType.VarChar, Code1Width),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("StartDateTime2", SqlDbType.DateTime),
             new SqlMetaData("EndDateTime2", SqlDbType.DateTime),
@@ -99,10 +101,10 @@ public class TokenDateTimeCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > Code1Width)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(4, tokenComponent.Code.Substring(0, Code1Width));
+                            record.SetString(5, tokenComponent.Code.Substring(Code1Width));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenDateTimeCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenDateTimeCompositeRowGenerator.cs
@@ -40,7 +40,7 @@ public class TokenDateTimeCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("StartDateTime2", SqlDbType.DateTime),
             new SqlMetaData("EndDateTime2", SqlDbType.DateTime),
@@ -99,10 +99,10 @@ public class TokenDateTimeCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > 128)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, 128));
-                            record.SetString(5, tokenComponent.Code.Substring(128));
+                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenNumberNumberCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenNumberNumberCompositeRowGenerator.cs
@@ -41,7 +41,7 @@ public class TokenNumberNumberCompositeRowGenerator : ISearchParameterRowGenerat
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SingleValue2", SqlDbType.Decimal, precision: 36, scale: 18),
             new SqlMetaData("LowValue2", SqlDbType.Decimal, precision: 36, scale: 18),
@@ -107,10 +107,10 @@ public class TokenNumberNumberCompositeRowGenerator : ISearchParameterRowGenerat
                                 continue;
                             }
 
-                            if (tokenComponent.Code != null && tokenComponent.Code.Length > 128)
+                            if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
                             {
-                                record.SetString(4, tokenComponent.Code.Substring(0, 128));
-                                record.SetString(5, tokenComponent.Code.Substring(128));
+                                record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                                record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
                             }
                             else
                             {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenNumberNumberCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenNumberNumberCompositeRowGenerator.cs
@@ -18,6 +18,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenNumberNumberCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code1Width = SearchParamColumnWidths.For("TokenNumberNumberCompositeSearchParam", "Code1");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -41,7 +43,7 @@ public class TokenNumberNumberCompositeRowGenerator : ISearchParameterRowGenerat
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code1", SqlDbType.VarChar, Code1Width),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SingleValue2", SqlDbType.Decimal, precision: 36, scale: 18),
             new SqlMetaData("LowValue2", SqlDbType.Decimal, precision: 36, scale: 18),
@@ -107,10 +109,10 @@ public class TokenNumberNumberCompositeRowGenerator : ISearchParameterRowGenerat
                                 continue;
                             }
 
-                            if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
+                            if (tokenComponent.Code != null && tokenComponent.Code.Length > Code1Width)
                             {
-                                record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                                record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
+                                record.SetString(4, tokenComponent.Code.Substring(0, Code1Width));
+                                record.SetString(5, tokenComponent.Code.Substring(Code1Width));
                             }
                             else
                             {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenQuantityCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenQuantityCompositeRowGenerator.cs
@@ -45,7 +45,7 @@ public class TokenQuantityCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SystemId2", SqlDbType.Int),
             new SqlMetaData("QuantityCodeId2", SqlDbType.Int),
@@ -106,10 +106,10 @@ public class TokenQuantityCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > 128)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, 128));
-                            record.SetString(5, tokenComponent.Code.Substring(128));
+                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenQuantityCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenQuantityCompositeRowGenerator.cs
@@ -17,6 +17,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenQuantityCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code1Width = SearchParamColumnWidths.For("TokenQuantityCompositeSearchParam", "Code1");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
     private readonly IReadOnlyDictionary<string, int> _quantityCodeMappings;
 
@@ -45,7 +47,7 @@ public class TokenQuantityCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code1", SqlDbType.VarChar, Code1Width),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SystemId2", SqlDbType.Int),
             new SqlMetaData("QuantityCodeId2", SqlDbType.Int),
@@ -106,10 +108,10 @@ public class TokenQuantityCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > Code1Width)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(4, tokenComponent.Code.Substring(0, Code1Width));
+                            record.SetString(5, tokenComponent.Code.Substring(Code1Width));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenSearchParameterRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenSearchParameterRowGenerator.cs
@@ -45,7 +45,7 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId", SqlDbType.Int),
-            new SqlMetaData("Code", SqlDbType.VarChar, 256),
+            new SqlMetaData("Code", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow", SqlDbType.VarChar, -1),
         };
 
@@ -97,10 +97,10 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
 
                 // Handle code overflow for very long codes
                 // Code is guaranteed to be non-null here due to guard above
-                if (tokenValue.Code.Length > 128)
+                if (tokenValue.Code.Length > SearchParamColumnWidths.TokenCode)
                 {
-                    record.SetString(4, tokenValue.Code[..128]);
-                    record.SetString(5, tokenValue.Code[128..]);
+                    record.SetString(4, tokenValue.Code[..SearchParamColumnWidths.TokenCode]);
+                    record.SetString(5, tokenValue.Code[SearchParamColumnWidths.TokenCode..]);
                 }
                 else
                 {
@@ -157,8 +157,11 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
                     identifierTypeSystemId = sysId;
                 }
 
-                // Truncate code to 128 chars to match the key used in the main table
-                var code = tokenValue.Code.Length > 128 ? tokenValue.Code[..128] : tokenValue.Code;
+                // Truncate to the inline width so this matches the Code value written to the main table,
+                // which is the key PostMergeExtensionUpdater joins on
+                var code = tokenValue.Code.Length > SearchParamColumnWidths.TokenCode
+                    ? tokenValue.Code[..SearchParamColumnWidths.TokenCode]
+                    : tokenValue.Code;
 
                 int? systemId = null;
                 if (!string.IsNullOrEmpty(tokenValue.System) &&

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenSearchParameterRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenSearchParameterRowGenerator.cs
@@ -20,6 +20,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int CodeWidth = SearchParamColumnWidths.For("TokenSearchParam", "Code");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -45,7 +47,7 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId", SqlDbType.Int),
-            new SqlMetaData("Code", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code", SqlDbType.VarChar, CodeWidth),
             new SqlMetaData("CodeOverflow", SqlDbType.VarChar, -1),
         };
 
@@ -97,10 +99,10 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
 
                 // Handle code overflow for very long codes
                 // Code is guaranteed to be non-null here due to guard above
-                if (tokenValue.Code.Length > SearchParamColumnWidths.TokenCode)
+                if (tokenValue.Code.Length > CodeWidth)
                 {
-                    record.SetString(4, tokenValue.Code[..SearchParamColumnWidths.TokenCode]);
-                    record.SetString(5, tokenValue.Code[SearchParamColumnWidths.TokenCode..]);
+                    record.SetString(4, tokenValue.Code[..CodeWidth]);
+                    record.SetString(5, tokenValue.Code[CodeWidth..]);
                 }
                 else
                 {
@@ -159,8 +161,8 @@ public class TokenSearchParameterRowGenerator : ISearchParameterRowGenerator
 
                 // Truncate to the inline width so this matches the Code value written to the main table,
                 // which is the key PostMergeExtensionUpdater joins on
-                var code = tokenValue.Code.Length > SearchParamColumnWidths.TokenCode
-                    ? tokenValue.Code[..SearchParamColumnWidths.TokenCode]
+                var code = tokenValue.Code.Length > CodeWidth
+                    ? tokenValue.Code[..CodeWidth]
                     : tokenValue.Code;
 
                 int? systemId = null;

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenStringCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenStringCompositeRowGenerator.cs
@@ -17,7 +17,6 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
 {
-    private const int StringColumnMaxLength = 128;
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -41,9 +40,9 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
-            new SqlMetaData("Text2", SqlDbType.NVarChar, 128),
+            new SqlMetaData("Text2", SqlDbType.NVarChar, SearchParamColumnWidths.StringText),
             new SqlMetaData("TextOverflow2", SqlDbType.NVarChar, -1),
         };
 
@@ -99,10 +98,10 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > 128)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, 128));
-                            record.SetString(5, tokenComponent.Code.Substring(128));
+                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {
@@ -115,10 +114,13 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
 
                         // String component
                         var textValue = stringComponent.String?.ToUpperInvariant();
-                        if (textValue != null && textValue.Length > StringColumnMaxLength)
+                        if (textValue != null && textValue.Length > SearchParamColumnWidths.StringText)
                         {
-                            record.SetString(6, textValue.Substring(0, StringColumnMaxLength));
-                            record.SetString(7, textValue.Substring(StringColumnMaxLength));
+                            // Text2 keeps a redundant prefix so the index can still seek; TextOverflow2 holds
+                            // the WHOLE value -- not the remainder -- matching StringSearchParam's convention,
+                            // which is what TokenStringLoweringRule compares against for an overflowing value.
+                            record.SetString(6, textValue.Substring(0, SearchParamColumnWidths.StringText));
+                            record.SetString(7, textValue);
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenStringCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenStringCompositeRowGenerator.cs
@@ -17,6 +17,9 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code1Width = SearchParamColumnWidths.For("TokenStringCompositeSearchParam", "Code1");
+    private static readonly int Text2Width = SearchParamColumnWidths.For("TokenStringCompositeSearchParam", "Text2");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -40,9 +43,9 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code1", SqlDbType.VarChar, Code1Width),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
-            new SqlMetaData("Text2", SqlDbType.NVarChar, SearchParamColumnWidths.StringText),
+            new SqlMetaData("Text2", SqlDbType.NVarChar, Text2Width),
             new SqlMetaData("TextOverflow2", SqlDbType.NVarChar, -1),
         };
 
@@ -98,10 +101,10 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent.Code != null && tokenComponent.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent.Code != null && tokenComponent.Code.Length > Code1Width)
                         {
-                            record.SetString(4, tokenComponent.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(5, tokenComponent.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(4, tokenComponent.Code.Substring(0, Code1Width));
+                            record.SetString(5, tokenComponent.Code.Substring(Code1Width));
                         }
                         else
                         {
@@ -114,12 +117,14 @@ public class TokenStringCompositeRowGenerator : ISearchParameterRowGenerator
 
                         // String component
                         var textValue = stringComponent.String?.ToUpperInvariant();
-                        if (textValue != null && textValue.Length > SearchParamColumnWidths.StringText)
+                        if (textValue != null && textValue.Length > Text2Width)
                         {
                             // Text2 keeps a redundant prefix so the index can still seek; TextOverflow2 holds
-                            // the WHOLE value -- not the remainder -- matching StringSearchParam's convention,
-                            // which is what TokenStringLoweringRule compares against for an overflowing value.
-                            record.SetString(6, textValue.Substring(0, SearchParamColumnWidths.StringText));
+                            // the WHOLE value -- not the remainder -- which is what TokenStringLoweringRule
+                            // compares against once a value overflows. Only the overflow convention is shared
+                            // with StringSearchParam: the case folding above is this table's own, so :exact is
+                            // not recoverable here the way it is on the leaf.
+                            record.SetString(6, textValue.Substring(0, Text2Width));
                             record.SetString(7, textValue);
                         }
                         else

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenTokenCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenTokenCompositeRowGenerator.cs
@@ -17,6 +17,9 @@ namespace Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 /// </summary>
 public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
 {
+    private static readonly int Code1Width = SearchParamColumnWidths.For("TokenTokenCompositeSearchParam", "Code1");
+    private static readonly int Code2Width = SearchParamColumnWidths.For("TokenTokenCompositeSearchParam", "Code2");
+
     private readonly IReadOnlyDictionary<string, int> _systemMappings;
 
     /// <summary>
@@ -40,10 +43,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code1", SqlDbType.VarChar, Code1Width),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SystemId2", SqlDbType.Int),
-            new SqlMetaData("Code2", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
+            new SqlMetaData("Code2", SqlDbType.VarChar, Code2Width),
             new SqlMetaData("CodeOverflow2", SqlDbType.VarChar, -1),
         };
 
@@ -99,10 +102,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent1.Code != null && tokenComponent1.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent1.Code != null && tokenComponent1.Code.Length > Code1Width)
                         {
-                            record.SetString(4, tokenComponent1.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(5, tokenComponent1.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(4, tokenComponent1.Code.Substring(0, Code1Width));
+                            record.SetString(5, tokenComponent1.Code.Substring(Code1Width));
                         }
                         else
                         {
@@ -128,10 +131,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent2.Code != null && tokenComponent2.Code.Length > SearchParamColumnWidths.TokenCode)
+                        if (tokenComponent2.Code != null && tokenComponent2.Code.Length > Code2Width)
                         {
-                            record.SetString(7, tokenComponent2.Code.Substring(0, SearchParamColumnWidths.TokenCode));
-                            record.SetString(8, tokenComponent2.Code.Substring(SearchParamColumnWidths.TokenCode));
+                            record.SetString(7, tokenComponent2.Code.Substring(0, Code2Width));
+                            record.SetString(8, tokenComponent2.Code.Substring(Code2Width));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenTokenCompositeRowGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/RowGenerators/TokenTokenCompositeRowGenerator.cs
@@ -40,10 +40,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
             new SqlMetaData("ResourceSurrogateId", SqlDbType.BigInt),
             new SqlMetaData("SearchParamId", SqlDbType.SmallInt),
             new SqlMetaData("SystemId1", SqlDbType.Int),
-            new SqlMetaData("Code1", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code1", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow1", SqlDbType.VarChar, -1),
             new SqlMetaData("SystemId2", SqlDbType.Int),
-            new SqlMetaData("Code2", SqlDbType.VarChar, 128),
+            new SqlMetaData("Code2", SqlDbType.VarChar, SearchParamColumnWidths.TokenCode),
             new SqlMetaData("CodeOverflow2", SqlDbType.VarChar, -1),
         };
 
@@ -99,10 +99,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent1.Code != null && tokenComponent1.Code.Length > 128)
+                        if (tokenComponent1.Code != null && tokenComponent1.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(4, tokenComponent1.Code.Substring(0, 128));
-                            record.SetString(5, tokenComponent1.Code.Substring(128));
+                            record.SetString(4, tokenComponent1.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(5, tokenComponent1.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {
@@ -128,10 +128,10 @@ public class TokenTokenCompositeRowGenerator : ISearchParameterRowGenerator
                             continue;
                         }
 
-                        if (tokenComponent2.Code != null && tokenComponent2.Code.Length > 128)
+                        if (tokenComponent2.Code != null && tokenComponent2.Code.Length > SearchParamColumnWidths.TokenCode)
                         {
-                            record.SetString(7, tokenComponent2.Code.Substring(0, 128));
-                            record.SetString(8, tokenComponent2.Code.Substring(128));
+                            record.SetString(7, tokenComponent2.Code.Substring(0, SearchParamColumnWidths.TokenCode));
+                            record.SetString(8, tokenComponent2.Code.Substring(SearchParamColumnWidths.TokenCode));
                         }
                         else
                         {

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/CompositeSearchParameterQueryGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/CompositeSearchParameterQueryGenerator.cs
@@ -6,6 +6,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ignixa.DataLayer.SqlEntityFramework.Indexing;
+using Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Models;
 using Ignixa.Specification.ValueSets.Normative;
@@ -18,6 +19,18 @@ namespace Ignixa.DataLayer.SqlEntityFramework.Search;
 /// </summary>
 public class CompositeSearchParameterQueryGenerator
 {
+    // Each slot resolves its own column's declared width, the same way the row generators that write it and
+    // the lowering rules that compile against it do. Above that width the value is stored split, so the
+    // predicate has to reassemble it; at or below it the overflow column must be empty, or an exact-width
+    // search would also match the truncated head of a longer code.
+    private static readonly int TokenTokenCode1Width = SearchParamColumnWidths.For("TokenTokenCompositeSearchParam", "Code1");
+    private static readonly int TokenTokenCode2Width = SearchParamColumnWidths.For("TokenTokenCompositeSearchParam", "Code2");
+    private static readonly int TokenQuantityCode1Width = SearchParamColumnWidths.For("TokenQuantityCompositeSearchParam", "Code1");
+    private static readonly int TokenStringCode1Width = SearchParamColumnWidths.For("TokenStringCompositeSearchParam", "Code1");
+    private static readonly int TokenStringText2Width = SearchParamColumnWidths.For("TokenStringCompositeSearchParam", "Text2");
+    private static readonly int TokenDateTimeCode1Width = SearchParamColumnWidths.For("TokenDateTimeCompositeSearchParam", "Code1");
+    private static readonly int RefTokenCode2Width = SearchParamColumnWidths.For("ReferenceTokenCompositeSearchParam", "Code2");
+
     private readonly FhirDbContext _context;
     private readonly SearchIndexReferenceDataCache _cache;
     private readonly ILogger<CompositeSearchParameterQueryGenerator> _logger;
@@ -170,9 +183,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply first component filter
-        if (!string.IsNullOrEmpty(token1.Code))
+        var code1 = token1.Code;
+        if (!string.IsNullOrEmpty(code1))
         {
-            query = query.Where(t => t.Code1 == token1.Code);
+            query = code1.Length > TokenTokenCode1Width
+                ? query.Where(t => t.CodeOverflow1 != null && t.Code1 + t.CodeOverflow1 == code1)
+                : query.Where(t => t.CodeOverflow1 == null && t.Code1 == code1);
         }
 
         if (systemId1.HasValue)
@@ -186,9 +202,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply second component filter
-        if (!string.IsNullOrEmpty(token2.Code))
+        var code2 = token2.Code;
+        if (!string.IsNullOrEmpty(code2))
         {
-            query = query.Where(t => t.Code2 == token2.Code);
+            query = code2.Length > TokenTokenCode2Width
+                ? query.Where(t => t.CodeOverflow2 != null && t.Code2 + t.CodeOverflow2 == code2)
+                : query.Where(t => t.CodeOverflow2 == null && t.Code2 == code2);
         }
 
         if (systemId2.HasValue)
@@ -240,9 +259,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply first component (token) filter
-        if (!string.IsNullOrEmpty(token.Code))
+        var qtyCode = token.Code;
+        if (!string.IsNullOrEmpty(qtyCode))
         {
-            query = query.Where(t => t.Code1 == token.Code);
+            query = qtyCode.Length > TokenQuantityCode1Width
+                ? query.Where(t => t.CodeOverflow1 != null && t.Code1 + t.CodeOverflow1 == qtyCode)
+                : query.Where(t => t.CodeOverflow1 == null && t.Code1 == qtyCode);
         }
 
         if (systemId1.HasValue)
@@ -296,9 +318,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply first component (token) filter
-        if (!string.IsNullOrEmpty(token.Code))
+        var strCode = token.Code;
+        if (!string.IsNullOrEmpty(strCode))
         {
-            query = query.Where(t => t.Code1 == token.Code);
+            query = strCode.Length > TokenStringCode1Width
+                ? query.Where(t => t.CodeOverflow1 != null && t.Code1 + t.CodeOverflow1 == strCode)
+                : query.Where(t => t.CodeOverflow1 == null && t.Code1 == strCode);
         }
 
         if (systemId1.HasValue)
@@ -315,7 +340,9 @@ public class CompositeSearchParameterQueryGenerator
         if (!string.IsNullOrEmpty(stringValue))
         {
             var normalizedValue = stringValue.ToUpperInvariant();
-            query = query.Where(t => t.Text2.StartsWith(normalizedValue));
+            query = normalizedValue.Length > TokenStringText2Width
+                ? query.Where(t => t.TextOverflow2 != null && t.TextOverflow2.StartsWith(normalizedValue))
+                : query.Where(t => t.Text2.StartsWith(normalizedValue));
         }
 
         return query.Select(t => t.ResourceSurrogateId);
@@ -398,9 +425,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply second component (token) filter
-        if (!string.IsNullOrEmpty(token.Code))
+        var refTokenCode = token.Code;
+        if (!string.IsNullOrEmpty(refTokenCode))
         {
-            query = query.Where(r => r.Code2 == token.Code);
+            query = refTokenCode.Length > RefTokenCode2Width
+                ? query.Where(r => r.CodeOverflow2 != null && r.Code2 + r.CodeOverflow2 == refTokenCode)
+                : query.Where(r => r.CodeOverflow2 == null && r.Code2 == refTokenCode);
         }
 
         if (systemId2.HasValue)
@@ -492,9 +522,12 @@ public class CompositeSearchParameterQueryGenerator
         }
 
         // Apply first component (token) filter
-        if (!string.IsNullOrEmpty(token.Code))
+        var dtCode = token.Code;
+        if (!string.IsNullOrEmpty(dtCode))
         {
-            query = query.Where(t => t.Code1 == token.Code);
+            query = dtCode.Length > TokenDateTimeCode1Width
+                ? query.Where(t => t.CodeOverflow1 != null && t.Code1 + t.CodeOverflow1 == dtCode)
+                : query.Where(t => t.CodeOverflow1 == null && t.Code1 == dtCode);
         }
 
         if (systemId1.HasValue)

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
@@ -6,6 +6,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ignixa.DataLayer.SqlEntityFramework.Indexing;
+using Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Search.Expressions;
 using Ignixa.Search.Indexing.SearchValues;
@@ -1509,7 +1510,7 @@ public class SearchParameterQueryGenerator
             return query.Select(sp => sp.ResourceSurrogateId);
         }
 
-        if (code.Length > 128)
+        if (code.Length > SearchParamColumnWidths.TokenCode)
         {
             return query
                 .Where(sp => sp.CodeOverflow != null &&
@@ -1732,7 +1733,7 @@ public class SearchParameterQueryGenerator
 
         IQueryable<long> query;
 
-        if (code.Length > 128)
+        if (code.Length > SearchParamColumnWidths.TokenCode)
         {
             query = baseQuery
                 .Where(sp => sp.CodeOverflow != null &&

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
@@ -21,6 +21,8 @@ namespace Ignixa.DataLayer.SqlEntityFramework.Search;
 /// </summary>
 public class SearchParameterQueryGenerator
 {
+    private static readonly int TokenCodeWidth = SearchParamColumnWidths.For("TokenSearchParam", "Code");
+
     private readonly FhirDbContext _context;
     private readonly SearchIndexReferenceDataCache _cache;
     private readonly ILogger<SearchParameterQueryGenerator> _logger;
@@ -1510,11 +1512,21 @@ public class SearchParameterQueryGenerator
             return query.Select(sp => sp.ResourceSurrogateId);
         }
 
-        if (code.Length > SearchParamColumnWidths.TokenCode)
+        if (code.Length > TokenCodeWidth)
         {
             return query
                 .Where(sp => sp.CodeOverflow != null &&
                     EF.Functions.Collate(sp.Code + sp.CodeOverflow, "Latin1_General_100_CI_AS") == code)
+                .Select(sp => sp.ResourceSurrogateId);
+        }
+
+        if (code.Length == TokenCodeWidth)
+        {
+            // At exactly the inline width the stored Code is indistinguishable from the truncated head of a
+            // longer code, so the overflow column has to be empty for this to be the whole stored value.
+            return query
+                .Where(sp => sp.CodeOverflow == null &&
+                    EF.Functions.Collate(sp.Code, "Latin1_General_100_CI_AS") == code)
                 .Select(sp => sp.ResourceSurrogateId);
         }
 
@@ -1733,11 +1745,20 @@ public class SearchParameterQueryGenerator
 
         IQueryable<long> query;
 
-        if (code.Length > SearchParamColumnWidths.TokenCode)
+        if (code.Length > TokenCodeWidth)
         {
             query = baseQuery
                 .Where(sp => sp.CodeOverflow != null &&
                     EF.Functions.Collate(sp.Code + sp.CodeOverflow, "Latin1_General_100_CI_AS") == code)
+                .Select(sp => sp.ResourceSurrogateId);
+        }
+        else if (code.Length == TokenCodeWidth)
+        {
+            // At exactly the inline width the stored Code is indistinguishable from the truncated head of a
+            // longer code, so the overflow column has to be empty for this to be the whole stored value.
+            query = baseQuery
+                .Where(sp => sp.CodeOverflow == null &&
+                    EF.Functions.Collate(sp.Code, "Latin1_General_100_CI_AS") == code)
                 .Select(sp => sp.ResourceSurrogateId);
         }
         else

--- a/test/Ignixa.Api.E2ETests/Search/DataTypes/TokenOverflowTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/DataTypes/TokenOverflowTests.cs
@@ -55,6 +55,8 @@ public class TokenOverflowTests : CapabilityDrivenTestBase, IClassFixture<TokenO
     [InlineData(1)] // PatientB - overflow
     [InlineData(2)] // PatientC - max no overflow
     [InlineData(3)] // PatientD - short no overflow
+    [InlineData(4)] // PatientE - exactly the inline Code width (boundary of the exact-width arm)
+    [InlineData(5)] // PatientF - inside the inline Code width, past the old 128 split
     public async Task GivenResourcesWithAndWithoutTokenOverflow_WhenSearchByToken_ThenCorrectResultsReturned(int patientIndex)
     {
         // Capability check
@@ -68,6 +70,8 @@ public class TokenOverflowTests : CapabilityDrivenTestBase, IClassFixture<TokenO
             1 => _fixture.IdentifierB,
             2 => _fixture.IdentifierC,
             3 => _fixture.IdentifierD,
+            4 => _fixture.IdentifierE,
+            5 => _fixture.IdentifierF,
             _ => throw new ArgumentOutOfRangeException(nameof(patientIndex))
         };
 
@@ -90,6 +94,8 @@ public class TokenOverflowTests : CapabilityDrivenTestBase, IClassFixture<TokenO
     [InlineData(1, "TestB")] // PatientB overflow + family name
     [InlineData(2, "TestC")] // PatientC max + family name
     [InlineData(3, "TestD")] // PatientD short + family name
+    [InlineData(4, "TestE")] // PatientE at the inline Code width + family name
+    [InlineData(5, "TestF")] // PatientF inside the inline Code width + family name
     public async Task GivenTokenOverflowAndString_WhenCompositeSearched_ThenCorrectResultsReturned(int patientIndex, string familyName)
     {
         // Capability check
@@ -103,6 +109,8 @@ public class TokenOverflowTests : CapabilityDrivenTestBase, IClassFixture<TokenO
             1 => _fixture.IdentifierB,
             2 => _fixture.IdentifierC,
             3 => _fixture.IdentifierD,
+            4 => _fixture.IdentifierE,
+            5 => _fixture.IdentifierF,
             _ => throw new ArgumentOutOfRangeException(nameof(patientIndex))
         };
 

--- a/test/Ignixa.Api.E2ETests/Search/DataTypes/TokenOverflowTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/DataTypes/TokenOverflowTests.cs
@@ -250,8 +250,8 @@ public class TokenOverflowTests : CapabilityDrivenTestBase, IClassFixture<TokenO
         var results = await Harness.SearchAsync("Patient",
             $"_tag={_fixture.Tag}&identifier={TokenOverflowFixture.IdentifierSystem}|");
 
-        // Assert - Should find all 4 patients
-        results.Length.ShouldBe(4, "Should find all patients with the same identifier system");
+        // Assert - Should find all 6 patients
+        results.Length.ShouldBe(6, "Should find all patients with the same identifier system");
 
         // Verify all expected patients are in results
         foreach (var patient in _fixture.Patients)

--- a/test/Ignixa.Api.E2ETests/_TestData/Fixtures/DataTypeSearch/TokenOverflowFixture.cs
+++ b/test/Ignixa.Api.E2ETests/_TestData/Fixtures/DataTypeSearch/TokenOverflowFixture.cs
@@ -24,6 +24,13 @@ public class TokenOverflowFixture : IAsyncLifetime
     /// </summary>
     private const int MaxTokenLength = 450;
 
+    /// <summary>
+    /// The real width of dbo.TokenSearchParam.Code, which is where a code actually divides between Code and
+    /// CodeOverflow. <see cref="MaxTokenLength"/> above sits well past it, so every value derived from it
+    /// overflows -- these two cover the boundary itself and the band just below it.
+    /// </summary>
+    private const int InlineCodeWidth = 256;
+
     public TokenOverflowFixture(IgnixaApiFixture apiFixture)
     {
         _apiFixture = apiFixture ?? throw new ArgumentNullException(nameof(apiFixture));
@@ -41,6 +48,8 @@ public class TokenOverflowFixture : IAsyncLifetime
     /// [1] = PatientB - identifier with overflow (500+ chars, different value), birthdate: 1985-06-20
     /// [2] = PatientC - identifier at max length (450 chars, no overflow), birthdate: 1992-03-10
     /// [3] = PatientD - identifier short (350 chars, no overflow), birthdate: 1988-11-05
+    /// [4] = PatientE - identifier at exactly the inline Code width (256 chars), birthdate: 1975-07-22
+    /// [5] = PatientF - identifier just inside the inline Code width (200 chars), birthdate: 1979-02-14
     /// </summary>
     public IReadOnlyList<ResourceJsonNode> Patients { get; private set; } = null!;
 
@@ -65,6 +74,19 @@ public class TokenOverflowFixture : IAsyncLifetime
     public string IdentifierD { get; private set; } = null!;
 
     /// <summary>
+    /// Identifier value E - exactly the inline Code width (256 chars, no overflow). Pins the boundary the
+    /// read path's exact-width arm depends on: at this length a stored Code is indistinguishable from the
+    /// truncated head of a longer one unless CodeOverflow is also required to be empty.
+    /// </summary>
+    public string IdentifierE { get; private set; } = null!;
+
+    /// <summary>
+    /// Identifier value F - 200 chars, inside the inline Code width but past the 128 this server used to
+    /// split at. Nothing else in this fixture covers that band.
+    /// </summary>
+    public string IdentifierF { get; private set; } = null!;
+
+    /// <summary>
     /// Identifier system used for all test identifiers.
     /// </summary>
     public const string IdentifierSystem = "http://test.ignixa.io/overflow";
@@ -78,6 +100,8 @@ public class TokenOverflowFixture : IAsyncLifetime
         IdentifierB = GetTokenValueWithOverflow("B");
         IdentifierC = GetTokenValueMaxNoOverflow("C");
         IdentifierD = GetTokenValueShortNoOverflow("D");
+        IdentifierE = "E".PadRight(InlineCodeWidth, 'x');
+        IdentifierF = "F".PadRight(200, 'x');
 
         // Create patients with these identifiers
         var patients = new[]
@@ -132,6 +156,34 @@ public class TokenOverflowFixture : IAsyncLifetime
                 .WithBirthDate(1988, 11, 5)
                 .WithTypedIdentifier(
                     value: IdentifierD,
+                    typeSystem: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    typeCode: "MR",
+                    typeDisplay: "Medical Record",
+                    identifierSystem: IdentifierSystem)
+                .Build(),
+
+            // PatientE - exactly the inline Code width, no overflow
+            PatientBuilderFactory.Create(_apiFixture.SchemaProvider)
+                .WithTag(Tag)
+                .WithGivenName("InlineWidth")
+                .WithFamilyName("TestE")
+                .WithBirthDate(1975, 7, 22)
+                .WithTypedIdentifier(
+                    value: IdentifierE,
+                    typeSystem: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    typeCode: "MR",
+                    typeDisplay: "Medical Record",
+                    identifierSystem: IdentifierSystem)
+                .Build(),
+
+            // PatientF - inside the inline Code width, past the old 128 split
+            PatientBuilderFactory.Create(_apiFixture.SchemaProvider)
+                .WithTag(Tag)
+                .WithGivenName("BelowInlineWidth")
+                .WithFamilyName("TestF")
+                .WithBirthDate(1979, 2, 14)
+                .WithTypedIdentifier(
+                    value: IdentifierF,
                     typeSystem: "http://terminology.hl7.org/CodeSystem/v2-0203",
                     typeCode: "MR",
                     typeDisplay: "Medical Record",

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.csproj
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Ignixa.DataLayer.SqlEntityFramework.csproj" />
+    <ProjectReference Include="../../src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.csproj
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Ignixa.DataLayer.SqlEntityFramework.csproj" />
-    <ProjectReference Include="../../src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
@@ -25,15 +25,25 @@ namespace Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.RowGenerators;
 /// silently matches nothing -- no error, just an empty result set.
 /// </summary>
 /// <remarks>
-/// The expected width comes from <see cref="SqlCatalog"/>, i.e. the DDL, which is the single source of
-/// truth all three parties derive from. What this test adds is that the generators really do derive it
-/// rather than carrying a literal that happens to agree today: they are driven for real, and a
-/// reintroduced hard-coded width shows up here as a failure.
+/// Each slot's expected width is resolved from <see cref="SqlCatalog"/> for <em>that slot's own column</em>,
+/// not from the leaf TokenSearchParam.Code width. Deriving every slot from one leaf column would agree with
+/// the generators only while the DDL stayed uniform, which is the same coupling as the literal this guards
+/// against -- a composite column narrowed in a future schema has to fail here, not pass silently.
 /// </remarks>
 public class TokenCodeOverflowSplitPointTests
 {
-    private static readonly int InlineCodeWidth =
-        SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
+    private static readonly int LeafCodeWidth = WidthOf("TokenSearchParam.Code");
+
+    /// <summary>
+    /// The declared width of the slot's own column -- the same catalog entry TokenColumnEquality resolves
+    /// when it compiles a predicate against that table.
+    /// </summary>
+    private static int WidthOf(string slot)
+    {
+        var parts = slot.Split('.');
+        return SqlCatalog.Default.Table(parts[0]).Column(parts[1]).MaxLength
+            ?? throw new InvalidOperationException($"{slot} declares no width in SqlCatalog.");
+    }
 
     private const string CompositeUrl = "http://hl7.org/fhir/SearchParameter/Observation-code-value";
 
@@ -62,7 +72,8 @@ public class TokenCodeOverflowSplitPointTests
     public void GivenACodeLongerThanTheCompilersSplitPoint_WhenTheRowGeneratorWritesIt_ThenItDividesAtExactlyThatPoint(string slot)
     {
         // Arrange — distinct fill either side of the split point, so a split at any other offset shows up
-        var code = new string('a', InlineCodeWidth) + new string('b', 37);
+        var width = WidthOf(slot);
+        var code = new string('a', width) + new string('b', 37);
 
         // Act
         var record = Emit(slot, code);
@@ -70,13 +81,13 @@ public class TokenCodeOverflowSplitPointTests
         // Assert
         var (codeOrdinal, overflowOrdinal) = Ordinals(record, slot);
         record.GetString(codeOrdinal).ShouldBe(
-            code[..InlineCodeWidth],
-            $"{slot}: the generator split the code somewhere other than the Code column's declared width, " +
+            code[..width],
+            $"{slot}: the generator split the code somewhere other than this column's declared width, " +
             "so the compiler's Code predicate compares against a prefix that is never stored");
         record.IsDBNull(overflowOrdinal).ShouldBeFalse($"{slot}: an over-long code must write a remainder");
         record.GetString(overflowOrdinal).ShouldBe(
-            code[InlineCodeWidth..],
-            $"{slot}: the remainder does not start at the Code column's declared width");
+            code[width..],
+            $"{slot}: the remainder does not start at this column's declared width");
     }
 
     [Theory]
@@ -84,7 +95,7 @@ public class TokenCodeOverflowSplitPointTests
     public void GivenACodeOfExactlyTheCompilersSplitWidth_WhenTheRowGeneratorWritesIt_ThenTheOverflowColumnIsNull(string slot)
     {
         // Arrange — the boundary the compiler's exact-width arm depends on
-        var code = new string('a', InlineCodeWidth);
+        var code = new string('a', WidthOf(slot));
 
         // Act
         var record = Emit(slot, code);
@@ -102,7 +113,7 @@ public class TokenCodeOverflowSplitPointTests
     {
         // Arrange — PostMergeExtensionUpdater locates the row it just merged by (…, SystemId, Code), so this
         // key has to be truncated exactly as GenerateSqlDataRecords truncated the Code column
-        var code = new string('a', InlineCodeWidth) + new string('b', 37);
+        var code = new string('a', LeafCodeWidth) + new string('b', 37);
         var token = new TokenSearchValue(
             system: null,
             code,
@@ -122,7 +133,7 @@ public class TokenCodeOverflowSplitPointTests
 
         // Assert
         extension.Code.ShouldBe(
-            code[..InlineCodeWidth],
+            code[..LeafCodeWidth],
             "the extension-update join key must equal the Code value written to TokenSearchParam, or the " +
             "post-merge update silently stamps nothing and :of-type stops matching this identifier");
     }

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
@@ -8,7 +8,7 @@ using Ignixa.Domain.Models;
 using Ignixa.Search.Indexing;
 using Ignixa.Search.Indexing.SearchValues;
 using Ignixa.Search.Models;
-using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Catalog;
 using Ignixa.Serialization.SourceNodes;
 using Ignixa.Specification.ValueSets.Normative;
 using Microsoft.Data.SqlClient.Server;
@@ -18,21 +18,23 @@ using Xunit;
 namespace Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.RowGenerators;
 
 /// <summary>
-/// Pins the token code-overflow split point from the writers' side. The search compiler splits a long code
-/// at <see cref="TokenColumnEquality.InlineCodeWidth"/> to build its <c>Code = @prefix AND CodeOverflow =
-/// @remainder</c> predicate; these generators are what actually put the two halves in those columns. If the
-/// two ever disagree, the compiler searches for a prefix no row stores and every over-long token code
+/// Pins the token code-overflow split point from the writers' side. Both the search compiler
+/// (TokenColumnEquality) and microsoft/fhir-server split a long code at the Code column's declared width;
+/// these generators are what actually put the two halves in those columns. If a generator ever splits
+/// somewhere else, the compiler searches for a prefix no row stores and every over-long token code
 /// silently matches nothing -- no error, just an empty result set.
 /// </summary>
 /// <remarks>
-/// This lives here, driving the real generators, precisely because Ignixa.Search.Sql's own tests cannot
-/// catch that class of divergence: the only split width available inside that assembly is whatever the rule
-/// itself uses, so a test written there agrees with any value the rule picks. The generators are the
-/// independent second source of truth, and they are deliberately left holding their own literal 128 --
-/// pointing them at the constant would collapse the two sources back into one and re-open the hole.
+/// The expected width comes from <see cref="SqlCatalog"/>, i.e. the DDL, which is the single source of
+/// truth all three parties derive from. What this test adds is that the generators really do derive it
+/// rather than carrying a literal that happens to agree today: they are driven for real, and a
+/// reintroduced hard-coded width shows up here as a failure.
 /// </remarks>
 public class TokenCodeOverflowSplitPointTests
 {
+    private static readonly int InlineCodeWidth =
+        SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
+
     private const string CompositeUrl = "http://hl7.org/fhir/SearchParameter/Observation-code-value";
 
     private static readonly IReadOnlyDictionary<string, short> ResourceTypeIdMap =
@@ -60,20 +62,21 @@ public class TokenCodeOverflowSplitPointTests
     public void GivenACodeLongerThanTheCompilersSplitPoint_WhenTheRowGeneratorWritesIt_ThenItDividesAtExactlyThatPoint(string slot)
     {
         // Arrange — distinct fill either side of the split point, so a split at any other offset shows up
-        var code = new string('a', TokenColumnEquality.InlineCodeWidth) + new string('b', 37);
+        var code = new string('a', InlineCodeWidth) + new string('b', 37);
 
         // Act
-        var (record, codeOrdinal, overflowOrdinal) = Emit(slot, code);
+        var record = Emit(slot, code);
 
         // Assert
+        var (codeOrdinal, overflowOrdinal) = Ordinals(record, slot);
         record.GetString(codeOrdinal).ShouldBe(
-            code[..TokenColumnEquality.InlineCodeWidth],
-            $"{slot}: the generator split the code somewhere other than TokenColumnEquality.InlineCodeWidth, " +
+            code[..InlineCodeWidth],
+            $"{slot}: the generator split the code somewhere other than the Code column's declared width, " +
             "so the compiler's Code predicate compares against a prefix that is never stored");
         record.IsDBNull(overflowOrdinal).ShouldBeFalse($"{slot}: an over-long code must write a remainder");
         record.GetString(overflowOrdinal).ShouldBe(
-            code[TokenColumnEquality.InlineCodeWidth..],
-            $"{slot}: the remainder does not start at TokenColumnEquality.InlineCodeWidth");
+            code[InlineCodeWidth..],
+            $"{slot}: the remainder does not start at the Code column's declared width");
     }
 
     [Theory]
@@ -81,65 +84,100 @@ public class TokenCodeOverflowSplitPointTests
     public void GivenACodeOfExactlyTheCompilersSplitWidth_WhenTheRowGeneratorWritesIt_ThenTheOverflowColumnIsNull(string slot)
     {
         // Arrange — the boundary the compiler's exact-width arm depends on
-        var code = new string('a', TokenColumnEquality.InlineCodeWidth);
+        var code = new string('a', InlineCodeWidth);
 
         // Act
-        var (record, codeOrdinal, overflowOrdinal) = Emit(slot, code);
+        var record = Emit(slot, code);
 
         // Assert
+        var (codeOrdinal, overflowOrdinal) = Ordinals(record, slot);
         record.GetString(codeOrdinal).ShouldBe(code, $"{slot}: a code of exactly the split width belongs inline, whole");
         record.IsDBNull(overflowOrdinal).ShouldBeTrue(
             $"{slot}: the compiler emits 'CodeOverflow IS NULL' for an exact-width code to stop it matching a " +
             "truncated longer one; that guard only works if this column really is NULL here");
     }
 
-    private static (SqlDataRecord Record, int CodeOrdinal, int OverflowOrdinal) Emit(string slot, string code)
+    [Fact]
+    public void GivenAnOverLongCode_WhenExtractingExtensionData_ThenTheJoinKeyMatchesTheStoredCode()
+    {
+        // Arrange — PostMergeExtensionUpdater locates the row it just merged by (…, SystemId, Code), so this
+        // key has to be truncated exactly as GenerateSqlDataRecords truncated the Code column
+        var code = new string('a', InlineCodeWidth) + new string('b', 37);
+        var token = new TokenSearchValue(
+            system: null,
+            code,
+            text: null,
+            identifierTypeSystem: "http://terminology.hl7.org/CodeSystem/v2-0203",
+            identifierTypeCode: "MR");
+        var resource = Leaf(token);
+
+        // Act
+        var extension = new TokenSearchParameterRowGenerator(NoSystemMappings)
+            .ExtractExtensionData(
+                [resource],
+                ResourceTypeIdMap,
+                SearchParamIdMap,
+                new Dictionary<ResourceWrapper, long> { [resource] = 1L })
+            .Single();
+
+        // Assert
+        extension.Code.ShouldBe(
+            code[..InlineCodeWidth],
+            "the extension-update join key must equal the Code value written to TokenSearchParam, or the " +
+            "post-merge update silently stamps nothing and :of-type stops matching this identifier");
+    }
+
+    private static (int CodeOrdinal, int OverflowOrdinal) Ordinals(SqlDataRecord record, string slot)
+    {
+        // "TokenTokenCompositeSearchParam.Code2" -> Code2 / CodeOverflow2. Resolved by name so a column
+        // added to a TVP moves the assertion with it instead of silently repointing it.
+        var codeColumn = slot.Split('.')[1];
+        var suffix = codeColumn["Code".Length..];
+        return (record.GetOrdinal(codeColumn), record.GetOrdinal($"CodeOverflow{suffix}"));
+    }
+
+    private static SqlDataRecord Emit(string slot, string code)
     {
         var token = new TokenSearchValue(system: null, code, text: null);
         var otherToken = new TokenSearchValue(system: null, "short", text: null);
 
         return slot switch
         {
-            "TokenSearchParam.Code" => (
-                Single(new TokenSearchParameterRowGenerator(NoSystemMappings), Leaf(token)), 4, 5),
+            "TokenSearchParam.Code" =>
+                Single(new TokenSearchParameterRowGenerator(NoSystemMappings), Leaf(token)),
 
-            "TokenTokenCompositeSearchParam.Code1" => (
-                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([token], [otherToken])), 4, 5),
+            "TokenTokenCompositeSearchParam.Code1" =>
+                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([token], [otherToken])),
 
-            "TokenTokenCompositeSearchParam.Code2" => (
-                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([otherToken], [token])), 7, 8),
+            "TokenTokenCompositeSearchParam.Code2" =>
+                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([otherToken], [token])),
 
-            "TokenDateTimeCompositeSearchParam.Code1" => (
+            "TokenDateTimeCompositeSearchParam.Code1" =>
                 Single(
                     new TokenDateTimeCompositeRowGenerator(NoSystemMappings),
                     Composite([token], [new DateTimeSearchValue(new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero))])),
-                4, 5),
 
-            "TokenQuantityCompositeSearchParam.Code1" => (
+            "TokenQuantityCompositeSearchParam.Code1" =>
                 Single(
                     new TokenQuantityCompositeRowGenerator(NoSystemMappings, new Dictionary<string, int>()),
                     Composite([token], [new QuantitySearchValue(system: null, code: null, 5.4m)])),
-                4, 5),
 
-            "TokenStringCompositeSearchParam.Code1" => (
+            "TokenStringCompositeSearchParam.Code1" =>
                 Single(
                     new TokenStringCompositeRowGenerator(NoSystemMappings),
                     Composite([token], [new StringSearchValue("Smith")])),
-                4, 5),
 
-            "TokenNumberNumberCompositeSearchParam.Code1" => (
+            "TokenNumberNumberCompositeSearchParam.Code1" =>
                 Single(
                     new TokenNumberNumberCompositeRowGenerator(NoSystemMappings),
                     Composite([token], [new NumberSearchValue(1m)], [new NumberSearchValue(9m)])),
-                4, 5),
 
-            "ReferenceTokenCompositeSearchParam.Code2" => (
+            "ReferenceTokenCompositeSearchParam.Code2" =>
                 Single(
                     new RefTokenCompositeRowGenerator(NoSystemMappings),
                     Composite(
                         [new ReferenceSearchValue(ReferenceKind.Internal, baseUri: null!, resourceType: "Organization", resourceId: "o1")],
                         [token])),
-                8, 9),
 
             _ => throw new ArgumentOutOfRangeException(nameof(slot), slot, "Unknown token slot."),
         };
@@ -154,15 +192,15 @@ public class TokenCodeOverflowSplitPointTests
             .Single();
     }
 
-    private static ResourceWrapper Leaf(ISearchValue value) => Resource(value);
+    private static ResourceWrapper Leaf(ISearchValue value) => Resource(value, SearchParamType.Token);
 
     private static ResourceWrapper Composite(params IReadOnlyList<ISearchValue>[] components)
-        => Resource(new CompositeIndexSearchValue(components));
+        => Resource(new CompositeIndexSearchValue(components), SearchParamType.Composite);
 
-    private static ResourceWrapper Resource(ISearchValue value)
+    private static ResourceWrapper Resource(ISearchValue value, SearchParamType type)
     {
         var searchParameter = new SearchParameterInfo(
-            "code-value", "code-value", SearchParamType.Composite, url: new Uri(CompositeUrl));
+            "code-value", "code-value", type, url: new Uri(CompositeUrl));
 
         return new ResourceWrapper(
             ResourceType: "Observation",

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenCodeOverflowSplitPointTests.cs
@@ -1,0 +1,178 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
+using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.ValueSets.Normative;
+using Microsoft.Data.SqlClient.Server;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.RowGenerators;
+
+/// <summary>
+/// Pins the token code-overflow split point from the writers' side. The search compiler splits a long code
+/// at <see cref="TokenColumnEquality.InlineCodeWidth"/> to build its <c>Code = @prefix AND CodeOverflow =
+/// @remainder</c> predicate; these generators are what actually put the two halves in those columns. If the
+/// two ever disagree, the compiler searches for a prefix no row stores and every over-long token code
+/// silently matches nothing -- no error, just an empty result set.
+/// </summary>
+/// <remarks>
+/// This lives here, driving the real generators, precisely because Ignixa.Search.Sql's own tests cannot
+/// catch that class of divergence: the only split width available inside that assembly is whatever the rule
+/// itself uses, so a test written there agrees with any value the rule picks. The generators are the
+/// independent second source of truth, and they are deliberately left holding their own literal 128 --
+/// pointing them at the constant would collapse the two sources back into one and re-open the hole.
+/// </remarks>
+public class TokenCodeOverflowSplitPointTests
+{
+    private const string CompositeUrl = "http://hl7.org/fhir/SearchParameter/Observation-code-value";
+
+    private static readonly IReadOnlyDictionary<string, short> ResourceTypeIdMap =
+        new Dictionary<string, short> { ["Observation"] = 1, ["Organization"] = 2 };
+
+    private static readonly IReadOnlyDictionary<string, short> SearchParamIdMap =
+        new Dictionary<string, short> { [CompositeUrl] = 1 };
+
+    private static readonly IReadOnlyDictionary<string, int> NoSystemMappings = new Dictionary<string, int>();
+
+    public static TheoryData<string> TokenSlots() => new()
+    {
+        "TokenSearchParam.Code",
+        "TokenTokenCompositeSearchParam.Code1",
+        "TokenTokenCompositeSearchParam.Code2",
+        "TokenDateTimeCompositeSearchParam.Code1",
+        "TokenQuantityCompositeSearchParam.Code1",
+        "TokenStringCompositeSearchParam.Code1",
+        "TokenNumberNumberCompositeSearchParam.Code1",
+        "ReferenceTokenCompositeSearchParam.Code2",
+    };
+
+    [Theory]
+    [MemberData(nameof(TokenSlots))]
+    public void GivenACodeLongerThanTheCompilersSplitPoint_WhenTheRowGeneratorWritesIt_ThenItDividesAtExactlyThatPoint(string slot)
+    {
+        // Arrange — distinct fill either side of the split point, so a split at any other offset shows up
+        var code = new string('a', TokenColumnEquality.InlineCodeWidth) + new string('b', 37);
+
+        // Act
+        var (record, codeOrdinal, overflowOrdinal) = Emit(slot, code);
+
+        // Assert
+        record.GetString(codeOrdinal).ShouldBe(
+            code[..TokenColumnEquality.InlineCodeWidth],
+            $"{slot}: the generator split the code somewhere other than TokenColumnEquality.InlineCodeWidth, " +
+            "so the compiler's Code predicate compares against a prefix that is never stored");
+        record.IsDBNull(overflowOrdinal).ShouldBeFalse($"{slot}: an over-long code must write a remainder");
+        record.GetString(overflowOrdinal).ShouldBe(
+            code[TokenColumnEquality.InlineCodeWidth..],
+            $"{slot}: the remainder does not start at TokenColumnEquality.InlineCodeWidth");
+    }
+
+    [Theory]
+    [MemberData(nameof(TokenSlots))]
+    public void GivenACodeOfExactlyTheCompilersSplitWidth_WhenTheRowGeneratorWritesIt_ThenTheOverflowColumnIsNull(string slot)
+    {
+        // Arrange — the boundary the compiler's exact-width arm depends on
+        var code = new string('a', TokenColumnEquality.InlineCodeWidth);
+
+        // Act
+        var (record, codeOrdinal, overflowOrdinal) = Emit(slot, code);
+
+        // Assert
+        record.GetString(codeOrdinal).ShouldBe(code, $"{slot}: a code of exactly the split width belongs inline, whole");
+        record.IsDBNull(overflowOrdinal).ShouldBeTrue(
+            $"{slot}: the compiler emits 'CodeOverflow IS NULL' for an exact-width code to stop it matching a " +
+            "truncated longer one; that guard only works if this column really is NULL here");
+    }
+
+    private static (SqlDataRecord Record, int CodeOrdinal, int OverflowOrdinal) Emit(string slot, string code)
+    {
+        var token = new TokenSearchValue(system: null, code, text: null);
+        var otherToken = new TokenSearchValue(system: null, "short", text: null);
+
+        return slot switch
+        {
+            "TokenSearchParam.Code" => (
+                Single(new TokenSearchParameterRowGenerator(NoSystemMappings), Leaf(token)), 4, 5),
+
+            "TokenTokenCompositeSearchParam.Code1" => (
+                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([token], [otherToken])), 4, 5),
+
+            "TokenTokenCompositeSearchParam.Code2" => (
+                Single(new TokenTokenCompositeRowGenerator(NoSystemMappings), Composite([otherToken], [token])), 7, 8),
+
+            "TokenDateTimeCompositeSearchParam.Code1" => (
+                Single(
+                    new TokenDateTimeCompositeRowGenerator(NoSystemMappings),
+                    Composite([token], [new DateTimeSearchValue(new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero))])),
+                4, 5),
+
+            "TokenQuantityCompositeSearchParam.Code1" => (
+                Single(
+                    new TokenQuantityCompositeRowGenerator(NoSystemMappings, new Dictionary<string, int>()),
+                    Composite([token], [new QuantitySearchValue(system: null, code: null, 5.4m)])),
+                4, 5),
+
+            "TokenStringCompositeSearchParam.Code1" => (
+                Single(
+                    new TokenStringCompositeRowGenerator(NoSystemMappings),
+                    Composite([token], [new StringSearchValue("Smith")])),
+                4, 5),
+
+            "TokenNumberNumberCompositeSearchParam.Code1" => (
+                Single(
+                    new TokenNumberNumberCompositeRowGenerator(NoSystemMappings),
+                    Composite([token], [new NumberSearchValue(1m)], [new NumberSearchValue(9m)])),
+                4, 5),
+
+            "ReferenceTokenCompositeSearchParam.Code2" => (
+                Single(
+                    new RefTokenCompositeRowGenerator(NoSystemMappings),
+                    Composite(
+                        [new ReferenceSearchValue(ReferenceKind.Internal, baseUri: null!, resourceType: "Organization", resourceId: "o1")],
+                        [token])),
+                8, 9),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(slot), slot, "Unknown token slot."),
+        };
+    }
+
+    private static SqlDataRecord Single(ISearchParameterRowGenerator generator, ResourceWrapper resource)
+    {
+        var resourceSurrogateIdMap = new Dictionary<ResourceWrapper, long> { [resource] = 1L };
+
+        return generator
+            .GenerateSqlDataRecords([resource], ResourceTypeIdMap, SearchParamIdMap, resourceSurrogateIdMap)
+            .Single();
+    }
+
+    private static ResourceWrapper Leaf(ISearchValue value) => Resource(value);
+
+    private static ResourceWrapper Composite(params IReadOnlyList<ISearchValue>[] components)
+        => Resource(new CompositeIndexSearchValue(components));
+
+    private static ResourceWrapper Resource(ISearchValue value)
+    {
+        var searchParameter = new SearchParameterInfo(
+            "code-value", "code-value", SearchParamType.Composite, url: new Uri(CompositeUrl));
+
+        return new ResourceWrapper(
+            ResourceType: "Observation",
+            ResourceId: "o1",
+            VersionId: "1",
+            LastModified: DateTimeOffset.UtcNow,
+            Resource: new ResourceJsonNode { ResourceType = "Observation", Id = "o1" },
+            Request: new ResourceRequest("POST", "Observation"))
+        {
+            SearchIndices = new List<object> { new SearchIndexEntry(searchParameter, value) },
+        };
+    }
+}

--- a/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenStringCompositeTextOverflowTests.cs
+++ b/test/Ignixa.DataLayer.SqlEntityFramework.IntegrationTests/RowGenerators/TokenStringCompositeTextOverflowTests.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.DataLayer.SqlEntityFramework.RowGenerators;
+using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Catalog;
+using Ignixa.Serialization.SourceNodes;
+using Ignixa.Specification.ValueSets.Normative;
+using Microsoft.Data.SqlClient.Server;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.RowGenerators;
+
+/// <summary>
+/// Pins the string slot of TokenStringCompositeSearchParam from the writer's side: Text2 keeps a redundant
+/// prefix so the index can still seek, and TextOverflow2 holds the WHOLE value rather than the remainder.
+/// </summary>
+/// <remarks>
+/// TokenStringLoweringRule switches to TextOverflow2 once the search value exceeds Text2's declared width and
+/// compares it with LIKE @value%, so a writer that stored only the remainder there would make every string
+/// component longer than that width match nothing -- silently, with an empty result set rather than an error.
+/// This mirrors <see cref="StringSearchParameterRowGeneratorTests"/> for the leaf StringSearchParam table.
+/// </remarks>
+public class TokenStringCompositeTextOverflowTests
+{
+    private static readonly int Text2Width =
+        SqlCatalog.Default.Table("TokenStringCompositeSearchParam").Column("Text2").MaxLength!.Value;
+
+    private const string CompositeUrl = "http://hl7.org/fhir/SearchParameter/Observation-code-value";
+
+    private static readonly IReadOnlyDictionary<string, short> ResourceTypeIdMap =
+        new Dictionary<string, short> { ["Observation"] = 1 };
+
+    private static readonly IReadOnlyDictionary<string, short> SearchParamIdMap =
+        new Dictionary<string, short> { [CompositeUrl] = 1 };
+
+    [Fact]
+    public void GivenAStringComponentLongerThanTheInlineWidth_WhenGeneratingRow_ThenTextOverflow2HoldsTheWholeValue()
+    {
+        // Arrange — distinct fill either side of the width, so a remainder-style split is visible
+        var value = new string('a', Text2Width) + new string('b', 44);
+
+        // Act
+        var record = Emit(value);
+
+        // Assert
+        record.GetString(record.GetOrdinal("Text2")).ShouldBe(
+            value.ToUpperInvariant()[..Text2Width],
+            "Text2 keeps the leading prefix so a StartsWith search can still seek the index");
+        record.GetString(record.GetOrdinal("TextOverflow2")).ShouldBe(
+            value.ToUpperInvariant(),
+            "TextOverflow2 must hold the WHOLE value, not the remainder: TokenStringLoweringRule compares it " +
+            "with LIKE @value% once the search value overflows, and a remainder never starts with the value");
+    }
+
+    [Fact]
+    public void GivenAStringComponentOfExactlyTheInlineWidth_WhenGeneratingRow_ThenTextOverflow2IsNull()
+    {
+        // Arrange — the boundary the lowering rule switches columns at
+        var value = new string('a', Text2Width);
+
+        // Act
+        var record = Emit(value);
+
+        // Assert
+        record.GetString(record.GetOrdinal("Text2")).ShouldBe(value.ToUpperInvariant());
+        record.IsDBNull(record.GetOrdinal("TextOverflow2")).ShouldBeTrue(
+            "a value of exactly the inline width belongs in Text2 whole, which is the column the lowering " +
+            "rule still reads at this length");
+    }
+
+    [Fact]
+    public void GivenAShortStringComponent_WhenGeneratingRow_ThenTextOverflow2IsNull()
+    {
+        // Act
+        var record = Emit("Smith");
+
+        // Assert
+        record.GetString(record.GetOrdinal("Text2")).ShouldBe("SMITH");
+        record.IsDBNull(record.GetOrdinal("TextOverflow2")).ShouldBeTrue();
+    }
+
+    private static SqlDataRecord Emit(string stringComponent)
+    {
+        var value = new CompositeIndexSearchValue(
+        [
+            [new TokenSearchValue(system: null, "short-code", text: null)],
+            [new StringSearchValue(stringComponent)],
+        ]);
+
+        var searchParameter = new SearchParameterInfo(
+            "code-value", "code-value", SearchParamType.Composite, url: new Uri(CompositeUrl));
+
+        var resource = new ResourceWrapper(
+            ResourceType: "Observation",
+            ResourceId: "o1",
+            VersionId: "1",
+            LastModified: DateTimeOffset.UtcNow,
+            Resource: new ResourceJsonNode { ResourceType = "Observation", Id = "o1" },
+            Request: new ResourceRequest("POST", "Observation"))
+        {
+            SearchIndices = new List<object> { new SearchIndexEntry(searchParameter, value) },
+        };
+
+        return new TokenStringCompositeRowGenerator(new Dictionary<string, int>())
+            .GenerateSqlDataRecords(
+                [resource],
+                ResourceTypeIdMap,
+                SearchParamIdMap,
+                new Dictionary<ResourceWrapper, long> { [resource] = 1L })
+            .Single();
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
@@ -20,13 +20,14 @@ namespace Ignixa.Search.Sql.Tests.Lowering;
 public class CompositeTokenCodeOverflowTests
 {
     /// <summary>
-    /// The point the row generators split an overflowing code at. Taken from the rule's own constant
-    /// rather than the Code column's declared width: the two differ (VARCHAR(256) vs a 128-character
-    /// split), and reading the width here would make these tests agree with any value the rule used.
-    /// That the constant matches what the generators actually write is pinned from the writers' side by
-    /// TokenCodeOverflowSplitPointTests in Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
+    /// The point an overflowing code splits at: the Code column's declared width. Every composite table's
+    /// token slot declares the same width as TokenSearchParam.Code, so one catalog lookup covers all the
+    /// slots exercised here. That the row generators really split here — rather than at a literal that
+    /// happens to agree — is pinned from the writers' side by TokenCodeOverflowSplitPointTests in
+    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
-    private const int SplitWidth = TokenColumnEquality.InlineCodeWidth;
+    private static readonly int SplitWidth =
+        Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
 
     private static readonly string OverflowedCode = new string('A', SplitWidth) + new string('B', 30);
 

--- a/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
@@ -20,12 +20,13 @@ namespace Ignixa.Search.Sql.Tests.Lowering;
 public class CompositeTokenCodeOverflowTests
 {
     /// <summary>
-    /// The point the row generators split an overflowing code at, which is the Code column's declared
-    /// width. Every composite table's token slot declares the same width as TokenSearchParam.Code, so one
-    /// catalog lookup covers all the slots exercised here.
+    /// The point the row generators split an overflowing code at. Taken from the rule's own constant
+    /// rather than the Code column's declared width: the two differ (VARCHAR(256) vs a 128-character
+    /// split), and reading the width here would make these tests agree with any value the rule used.
+    /// That the constant matches what the generators actually write is pinned from the writers' side by
+    /// TokenCodeOverflowSplitPointTests in Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
-    private static readonly int SplitWidth =
-        Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
+    private const int SplitWidth = TokenColumnEquality.InlineCodeWidth;
 
     private static readonly string OverflowedCode = new string('A', SplitWidth) + new string('B', 30);
 

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
@@ -15,13 +15,14 @@ namespace Ignixa.Search.Sql.Tests.Lowering;
 public class TokenLoweringRuleTests
 {
     /// <summary>
-    /// The point the row generators split an overflowing code at. Taken from the rule's own constant
-    /// rather than the Code column's declared width: the two differ (VARCHAR(256) vs a 128-character
-    /// split), and reading the width here would make these tests agree with any value the rule used.
-    /// That the constant matches what the generators actually write is pinned from the writers' side by
-    /// TokenCodeOverflowSplitPointTests in Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
+    /// The point an overflowing code splits at: the Code column's declared width, read from the catalog so
+    /// these tests pin the relationship to the schema rather than one schema's current number. That the row
+    /// generators really split here — rather than at a literal that happens to agree — is pinned from the
+    /// writers' side by TokenCodeOverflowSplitPointTests in
+    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
-    private const int InlineCodeWidth = TokenColumnEquality.InlineCodeWidth;
+    private static readonly int InlineCodeWidth =
+        Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
 
     private static LeafContext ContextResolving(
         SearchParameterInfo parameter,

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
@@ -15,12 +15,13 @@ namespace Ignixa.Search.Sql.Tests.Lowering;
 public class TokenLoweringRuleTests
 {
     /// <summary>
-    /// The point the row generators split an overflowing code at, which is the Code column's declared
-    /// width. Read from the catalog rather than written as a literal so these tests pin the relationship
-    /// to the schema instead of one schema's current number.
+    /// The point the row generators split an overflowing code at. Taken from the rule's own constant
+    /// rather than the Code column's declared width: the two differ (VARCHAR(256) vs a 128-character
+    /// split), and reading the width here would make these tests agree with any value the rule used.
+    /// That the constant matches what the generators actually write is pinned from the writers' side by
+    /// TokenCodeOverflowSplitPointTests in Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
-    private static readonly int InlineCodeWidth =
-        Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
+    private const int InlineCodeWidth = TokenColumnEquality.InlineCodeWidth;
 
     private static LeafContext ContextResolving(
         SearchParameterInfo parameter,

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenStringLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenStringLoweringRuleTests.cs
@@ -82,6 +82,11 @@ public class TokenStringLoweringRuleTests
         var and = cte.Predicate.ShouldBeOfType<Predicate.And>();
         var stringPredicate = and.Right.ShouldBeOfType<Predicate.Like>();
         stringPredicate.Column.Column.ShouldBe("TextOverflow2");
+        stringPredicate.Match.ShouldBe(LikeMatch.StartsWith);
+        stringPredicate.Value.Value.ShouldBe(
+            longValue,
+            "TextOverflow2 stores the whole value, so the comparison is against the whole search value -- " +
+            "matching it against a remainder here would silently return nothing for every overflowing string");
     }
 
     [Fact]


### PR DESCRIPTION
## The bug

The search compiler and the row generators disagreed about where a long token code divides between `Code` and `CodeOverflow`.

| | |
|---|---|
| every token row generator | split at a literal **128** |
| `TokenColumnEquality` (since #381) | split at `Code`'s declared width, **256** |
| `SearchParameterQueryGenerator` (the live EF read path) | gated at **128** |

So the compiler emitted `Code = @code[..256] AND CodeOverflow = @code[256..]` against rows stored as `Code = code[..128]`. **Every token code longer than 128 characters silently matched nothing** — no error, an empty result. The exact-width arm was wrong the same way: `CodeOverflow IS NULL` was emitted at length 256, where storage always had a non-null overflow.

## Which number is right: 256

Not inference — `microsoft/fhir-server`'s own source:

- `Features/Schema/Sql/Tables/TokenSearchParam.sql` — `Code varchar(256)`, identical to our `97.sql:888`
- `Features/Storage/TvpRowGeneration/Merge/TokenSearchParamListRowGenerator.cs:16` — splits at `(int)VLatest.TokenSearchParam.Code.Metadata.MaxLength`
- `VLatest.Generated.cs` is **gitignored** upstream — generated from that DDL at build time, so it can only mean 256
- every composite generator (`TokenTokenCompositeSearchParamListRowGenerator.cs:23-35` and siblings) delegates to that one leaf generator, so a single convention governs all eight slots

The `128`s here were a local invention dating to #3. These columns were never `varchar(128)` in this repo — `97.sql` declares 256 in every table and every TVP type.

Three artifacts already agreed with 256 before this change: `TokenSearchParamEntity` (`[MaxLength(256)]`), `FhirDbContext`'s `CHK_TokenSearchParam_CodeOverflow` (`LEN(Code) = 256 OR CodeOverflow IS NULL`), and the `StringSearchParam` path, which already sourced its width from `SqlCatalog`.

This matters because the package README promises adoption of an existing `microsoft/fhir-server` database *without data migration*. Under a 128 split, every token code over 128 characters in such a database is unfindable. So the fix moves the **writers** to the column width rather than moving the reader down to 128.

## What changed

- `SearchParamColumnWidths` derives both split points from `SqlCatalog`, the way fhir-server derives them from its generated column metadata
- all seven token row generators, the extension-update join key (`TokenSearchParameterRowGenerator:161`), and both EF reader gates read it
- composite TVP `SqlMetaData` widened from 128 — the client declaration was narrower than the `varchar(256)` type it feeds
- `TokenColumnEquality` back to the catalog lookup, so the `InternalsVisibleTo` from Core into the DataLayer test project is gone

### Also fixed: `TokenStringComposite.Text2`

`TokenStringCompositeRowGenerator` split `Text2` at its own `128` while `TokenStringLoweringRule` read 256 — *and* the overflow semantics differed. The leaf path documents that "TextOverflow holds the WHOLE value — not the remainder", but the composite writer stored the remainder, while the lowering rule assumed the leaf convention and emitted `TextOverflow2 LIKE @wholeValue%`. A string component of 129–256 chars was searched against a column holding 128; above 256 against a remainder that never starts with the value. Both silently matched nothing. The writer now follows the leaf convention, which is also what fhir-server's `StringSearchParamListRowGenerator` does (`overflow = searchValue.String`).

## Why CI didn't catch it

`CompositeTokenCodeOverflowTests` and `TokenLoweringRuleTests` derived their expected width from the same `SqlCatalog` lookup the rule read. They would have agreed with any value.

The guard therefore lives with the writers. `TokenCodeOverflowSplitPointTests` drives the real row generators and asserts the emitted `SqlDataRecord` divides exactly at the catalog width — 17 tests across 8 token slots, including the exact-width boundary and the `ExtractExtensionData` join key that `PostMergeExtensionUpdater` matches on. Ordinals are resolved by column name, so a TVP column insertion moves the assertion instead of silently repointing it.

**Mutation evidence:** pointing a single generator back at a literal `128` fails exactly its 2 guard cases and nothing else — including `Ignixa.Search.Sql.Tests`, which stays fully green at 1074 per TFM. No test inside that assembly can find this class of bug.

## Verification

`All.sln` 0 warnings 0 errors · `Search.Sql.Tests` 1074 per TFM · EF integration 104 → 121.

## Scope note

Upstream is at schema v116; we embed v97. All 19 intervening migrations contain **zero** table alterations, so no column width moves and this convention holds across the range. Tracked in #385.


---

## Follow-up commit: review fixes

### Corrections to the framing above

**The compiler path this PR aligns to is not live yet.** `TokenColumnEquality` and the lowering rules are
consumed only by `Ignixa.Search.Sql.Tests` — the only imports from `Ignixa.Search.Sql` into
DataLayer/Application/Api are `Catalog` and `Symbols`. So "every token code longer than 128 characters
silently matched nothing" was not a live outage: the writers and the live EF reader both used 128 and
agreed with each other. The real justification is the one further down — a `microsoft/fhir-server`
database splits at the column width, and the README promises adoption of one without data migration.

**That has a cost this PR did not state.** Moving the writers to 256 orphans rows *this* server wrote at
128. Codes over 256 still resolve (the read path reassembles `Code + CodeOverflow`, which is split-point
agnostic), and codes under 128 were never split — but **codes in the 129–256 band become silently
unfindable**. `97.sql` carries no `CHK_TokenSearchParam_CodeOverflow`, so such rows can exist.
`docs/migrations/token-code-split-width.md` documents this with queries to establish whether any do, and
the reindex if so. A reader tolerant of both conventions was considered and rejected: a permanent `OR` on
the hottest search path to serve a transitional state.

### The shared-constant fix was incomplete

`SearchParamColumnWidths` removed the literal but kept the coupling. Readers resolve the width from the
table they are querying; the writers resolved it once from `TokenSearchParam.Code` for all eight slots.
Those agree only while the DDL stays uniform — the same "happens to agree today" property the literal had.
`TokenCodeOverflowSplitPointTests` could not catch it either: it compared all eight slots against the same
leaf column the generators derived from, so for the seven composite slots it asserted a value against
itself.

It is now `SearchParamColumnWidths.For(table, column)`, with every caller naming the column it writes and
the test resolving each slot's own width. Proven by narrowing one composite column in the DDL *and*
pointing its generator back at the leaf width: exactly that slot's case fails, nothing else does.

### Defects found in the same area

- **`CompositeSearchParameterQueryGenerator` had no overflow handling at all** — six token slots plus the
  string slot, all bare equality, on the live read path. A composite token code over the inline width
  matched nothing. `ReferenceTokenComposite` and `TokenNumberNumberComposite` did not even map their
  `CodeOverflow` columns, so the capability was unreachable.
- **Exact-width false positive in both EF token readers.** `Code = @code` at exactly the inline width also
  matches the truncated head of any longer code. `TokenColumnEquality` has always required the overflow
  column to be empty here; the EF path now does too.
- **The `Text2`/`TextOverflow2` change shipped untested** — the one edit that changes stored bytes rather
  than a boundary. Now covered by `TokenStringCompositeTextOverflowTests`, mutation-checked: restoring the
  remainder-style split fails it.
- **`TokenStringLoweringRuleTests` asserted only the column name** on the overflow branch, leaving the
  whole-value contract unpinned on the reader side.
- **The E2E fixture derived every value from a fictional 450-char limit**, so all four identifiers sat
  above the real 256 width. Added 256-char and 200-char cases — the boundary and the band this PR moves.
- Dead `using`, a redundant width alias, and a comment claiming symmetry with `StringSearchParam` that the
  composite's `ToUpperInvariant()` does not actually have.

### Verification

`All.sln` builds 0 warnings 0 errors. `Search.Sql.Tests` 1074 per TFM, `SqlEntityFramework.IntegrationTests`
115 passed (was 112), `Application.Tests` 1107, `Api.Tests` 135 — all green. Two pre-existing local
failures are environment artifacts, unrelated to this area: `RepoGuards` (9, `.git` is a file in a git
worktree) and `SqlOnFhir` (2, uninitialised `sql-on-fhir-tests` submodule).

The E2E additions need SQL Server and were not run locally — CI's `e2e-tests-sql` job covers them.
