### PR TITLE
feat(search-sql): pull forward Search.Sql compiler enhancements

### DIFF
--- a/src/Application/Ignixa.Api/Endpoints/CompartmentEndpoints.cs
+++ b/src/Application/Ignixa.Api/Endpoints/CompartmentEndpoints.cs
@@ -14,6 +14,7 @@ using Ignixa.Application.Features.Bundle.Serialization;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Models;
 using Ignixa.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
@@ -248,6 +249,7 @@ public static class CompartmentEndpoints
 
         // Build SearchOptions
         var searchOptions = searchOptionsBuilder.Build(resourceType, queryParameters);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
 
         // Create SearchCompartmentQuery
         var query = new SearchCompartmentQuery(

--- a/src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs
+++ b/src/Application/Ignixa.Api/Endpoints/FhirEndpoints.cs
@@ -604,7 +604,7 @@ public static class FhirEndpoints
         // Build SearchOptions
         var searchOptions = searchOptionsBuilder.Build(resourceType, queryParameters, schemaProvider);
 
-        // Check for unsupported parameters with handling=strict
+        // Check for unsupported modifiers (always rejected) and unsupported parameters (handling=strict)
         var strictResult = CheckStrictHandling(context, searchOptions, resourceType, logger);
         if (strictResult is not null)
         {
@@ -695,7 +695,7 @@ public static class FhirEndpoints
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
         var searchOptions = searchOptionsBuilder.Build(resourceType, queryParameters, schemaProvider);
 
-        // Check for unsupported parameters with handling=strict
+        // Check for unsupported modifiers (always rejected) and unsupported parameters (handling=strict)
         var strictResult = CheckStrictHandling(context, searchOptions, resourceType, logger);
         if (strictResult is not null)
         {
@@ -1494,7 +1494,7 @@ public static class FhirEndpoints
         // This will search across all resource types (handled by SqlEntityFrameworkSearchService)
         var searchOptions = searchOptionsBuilder.Build(null, queryParameters, schemaProvider);
 
-        // Check for unsupported parameters with handling=strict
+        // Check for unsupported modifiers (always rejected) and unsupported parameters (handling=strict)
         var strictResult = CheckStrictHandling(context, searchOptions, null, logger);
         if (strictResult is not null)
         {
@@ -1583,7 +1583,7 @@ public static class FhirEndpoints
         var schemaProvider = versionContext.GetSchemaProvider(fhirSpec, tenantId);
         var searchOptions = searchOptionsBuilder.Build(null, queryParameters, schemaProvider);
 
-        // Check for unsupported parameters with handling=strict
+        // Check for unsupported modifiers (always rejected) and unsupported parameters (handling=strict)
         var strictResult = CheckStrictHandling(context, searchOptions, null, logger);
         if (strictResult is not null)
         {
@@ -1685,20 +1685,35 @@ public static class FhirEndpoints
     }
 
     /// <summary>
-    /// Checks for unsupported search parameters when strict handling is requested.
-    /// Returns a BadRequest result if strict handling is enabled and unsupported parameters exist.
+    /// Checks for unsupported search parameters and modifiers.
+    /// Returns a BadRequest result if an unsupported modifier was used, or if strict handling is
+    /// requested and unsupported parameters exist.
     /// </summary>
     /// <param name="context">The HTTP context.</param>
     /// <param name="searchOptions">The search options containing unsupported params.</param>
     /// <param name="resourceType">Optional resource type for error message context.</param>
     /// <param name="logger">Logger for warnings.</param>
-    /// <returns>BadRequest result if strict handling fails, null otherwise.</returns>
+    /// <returns>BadRequest result if the request must be rejected, null otherwise.</returns>
     private static IResult? CheckStrictHandling(
         HttpContext context,
         SearchOptions searchOptions,
         string? resourceType,
         ILogger logger)
     {
+        // FHIR R4 SHALL rejects a search suffixed by a modifier the server does not support for that
+        // parameter (https://hl7.org/fhir/R4/search.html#modifiers), unlike an unsupported *parameter*,
+        // which only SHOULD be rejected and is opt-in via Prefer: handling=strict below. Silently
+        // dropping the modifier would widen the result set instead of narrowing it, so this check is
+        // unconditional -- it does not depend on the Prefer header.
+        if (searchOptions.UnsupportedModifierParams.Count > 0)
+        {
+            logger.LogWarning(
+                "Unsupported search modifier(s) found: {UnsupportedModifierParams}",
+                string.Join(", ", searchOptions.UnsupportedModifierParams.Select(p => p.SanitizeForLog())));
+
+            return BuildUnsupportedParametersResult(searchOptions.UnsupportedModifierParams, resourceType, isModifierRejection: true);
+        }
+
         if (!PreferHeaderParser.IsStrictHandling(context.Request.Headers) ||
             searchOptions.UnsupportedParams.Count == 0)
         {
@@ -1709,12 +1724,34 @@ public static class FhirEndpoints
             "Strict handling requested but unsupported parameters found: {UnsupportedParams}",
             string.Join(", ", searchOptions.UnsupportedParams.Select(p => p.SanitizeForLog())));
 
+        return BuildUnsupportedParametersResult(searchOptions.UnsupportedParams, resourceType, isModifierRejection: false);
+    }
+
+    /// <summary>
+    /// Builds the BadRequest <see cref="OperationOutcome"/> for a set of unsupported search parameters.
+    /// </summary>
+    /// <param name="unsupportedParams">The parameter (and, for modifiers, key) names to report.</param>
+    /// <param name="resourceType">Optional resource type for error message context.</param>
+    /// <param name="isModifierRejection">
+    /// True when rejecting a SHALL-mandated unsupported modifier (see <see cref="CheckStrictHandling"/>);
+    /// false for the opt-in, strict-handling unsupported-parameter case. Only affects the diagnostics
+    /// text, so the two are distinguishable to a client instead of reading as the same generic message.
+    /// </param>
+    private static IResult BuildUnsupportedParametersResult(
+        IReadOnlyList<string> unsupportedParams,
+        string? resourceType,
+        bool isModifierRejection)
+    {
         var operationOutcome = new OperationOutcome();
-        foreach (var param in searchOptions.UnsupportedParams)
+        foreach (var param in unsupportedParams)
         {
-            var diagnostics = resourceType is not null
-                ? $"Search parameter '{param}' is not supported for resource type '{resourceType}'"
-                : $"Search parameter '{param}' is not supported";
+            var diagnostics = isModifierRejection
+                ? (resourceType is not null
+                    ? $"Search parameter '{param}' uses a modifier that is not supported for resource type '{resourceType}'"
+                    : $"Search parameter '{param}' uses a modifier that is not supported")
+                : (resourceType is not null
+                    ? $"Search parameter '{param}' is not supported for resource type '{resourceType}'"
+                    : $"Search parameter '{param}' is not supported");
 
             operationOutcome.Issue.Add(new Ignixa.Models.OperationOutcomeIssue
             {

--- a/src/Application/Ignixa.Api/Endpoints/OperationEndpoints.cs
+++ b/src/Application/Ignixa.Api/Endpoints/OperationEndpoints.cs
@@ -18,6 +18,7 @@ using Ignixa.Application.Operations.Features.Validate;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Models;
 using Ignixa.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
 using Ignixa.Serialization.Models;
@@ -673,6 +674,7 @@ public static class OperationEndpoints
 
         var queryParameters = queryParser.Parse(context.Request.Query);
         var searchOptions = searchOptionsBuilder.Build(resourceType, queryParameters, schemaProvider);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
 
         searchOptions.IncludesContinuationToken = includesContinuationToken;
 

--- a/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/ExportWorkerActivity.cs
+++ b/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/ExportWorkerActivity.cs
@@ -15,6 +15,7 @@ using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Models;
 using Ignixa.Search.Definition;
 using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
@@ -201,6 +202,7 @@ public class ExportWorkerActivity : AsyncTaskActivity<ExportWorkerInput, ExportW
 
                     // Use SearchOptionsBuilder to properly parse filters into expressions
                     var searchOptions = _searchOptionsBuilder.Build(input.ResourceType, filterParams);
+                    SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
 
                     // Add partition boundaries (surrogate ID range)
                     searchOptions.MaxItemCount = 50_000;  // Large batches (memory-safe due to streaming)

--- a/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/ExportWorkerActivity.cs
+++ b/src/Application/Ignixa.Application.BackgroundOperations/Export/Activities/ExportWorkerActivity.cs
@@ -170,6 +170,7 @@ public class ExportWorkerActivity : AsyncTaskActivity<ExportWorkerInput, ExportW
                         var groupQueryString = $"_id={Uri.EscapeDataString(input.GroupId)}&_include=Group:member&_include:iterate=Group:member";
                         var groupFilterParams = _parameterParser.Parse(groupQueryString);
                         var groupSearchOptions = _searchOptionsBuilder.Build("Group", groupFilterParams);
+                        SearchModifierNotSupportedException.ThrowIfAny(groupSearchOptions);
 
                         var patientIds = new List<string>();
                         await foreach (var resource in searchService.SearchStreamAsync(groupSearchOptions, CancellationToken.None))

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalCreate/ConditionalCreateHandler.cs
@@ -11,6 +11,7 @@ using Ignixa.Application.Features.Resource;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
@@ -89,6 +90,7 @@ public class ConditionalCreateHandler : IRequestHandler<ConditionalCreateCommand
 
         // 3. Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
         searchOptions.MaxItemCount = 2;
 
         // 4. Execute search via SearchResourcesHandler

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalDelete/ConditionalDeleteHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalDelete/ConditionalDeleteHandler.cs
@@ -1,6 +1,7 @@
 using Ignixa.Application.Features.Resource;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Medino;
@@ -60,6 +61,7 @@ public class ConditionalDeleteHandler : IRequestHandler<ConditionalDeleteCommand
         // Step 3: Build search options with appropriate max count
         int maxItemCount = isSingleMode ? 2 : (request.Count!.Value + 1);
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
         searchOptions.MaxItemCount = maxItemCount;
 
         // Step 4: Execute search to find matching resources

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalPatch/ConditionalPatchHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalPatch/ConditionalPatchHandler.cs
@@ -7,6 +7,7 @@ using Ignixa.Application.Features.Patch;
 using Ignixa.Application.Features.Resource;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Medino;
@@ -69,6 +70,7 @@ public class ConditionalPatchHandler : IRequestHandler<ConditionalPatchCommand, 
 
         // Step 3: Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
         searchOptions.MaxItemCount = 2;
 
         // Step 4: Execute search via SearchResourcesHandler

--- a/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalUpdate/ConditionalUpdateHandler.cs
+++ b/src/Application/Ignixa.Application/Features/ConditionalOperations/ConditionalUpdate/ConditionalUpdateHandler.cs
@@ -9,6 +9,7 @@ using Ignixa.Application.Features.Resource;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Abstractions;
 using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
@@ -74,6 +75,7 @@ public class ConditionalUpdateHandler : IRequestHandler<ConditionalUpdateCommand
 
         // 3. Build search options with _count=2 (we only need to know if 0, 1, or multiple)
         var searchOptions = searchOptionsBuilder.Build(request.ResourceType, queryParameters);
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
         searchOptions.MaxItemCount = 2;
 
         // 4. Execute search via SearchResourcesHandler

--- a/src/Application/Ignixa.Application/Features/Experimental/GraphQl/Resolvers/SearchResolver.cs
+++ b/src/Application/Ignixa.Application/Features/Experimental/GraphQl/Resolvers/SearchResolver.cs
@@ -11,6 +11,7 @@ using Ignixa.Application.Features.Experimental.GraphQl.Models;
 using Ignixa.Application.Features.Resource;
 using Ignixa.Application.Infrastructure;
 using Ignixa.Domain.Models;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization.Abstractions;
@@ -32,12 +33,14 @@ public sealed class SearchResolver(
         IResolverContext graphQlContext,
         CancellationToken cancellationToken)
     {
-        var searchOptions = BuildSearchOptions(resourceType, graphQlContext);
-
         logger.LogDebug("GraphQL list search {ResourceType}", resourceType);
 
         try
         {
+            // Inside the try, not before it: BuildSearchOptions can throw SearchModifierNotSupportedException
+            // (a FhirException), and it needs the same catch/FhirGraphQlErrorMapping.Map treatment as every
+            // other FhirException this method can raise, not a raw, unmapped exception out of the resolver.
+            var searchOptions = BuildSearchOptions(resourceType, graphQlContext);
             var query = new SearchResourcesQuery(resourceType, searchOptions);
             var result = await mediator.SendAsync(query, cancellationToken);
 
@@ -62,12 +65,12 @@ public sealed class SearchResolver(
         IResolverContext graphQlContext,
         CancellationToken cancellationToken)
     {
-        var searchOptions = BuildSearchOptions(resourceType, graphQlContext, requestAccurateTotal: true);
-
         logger.LogDebug("GraphQL searching {ResourceType}", resourceType);
 
         try
         {
+            // Inside the try -- see the identical comment in SearchListAsync.
+            var searchOptions = BuildSearchOptions(resourceType, graphQlContext, requestAccurateTotal: true);
             var query = new SearchResourcesQuery(resourceType, searchOptions);
             var result = await mediator.SendAsync(query, cancellationToken);
 
@@ -97,7 +100,6 @@ public sealed class SearchResolver(
         CancellationToken cancellationToken)
     {
         var additionalParams = new[] { new QueryParameter(referenceParamName, $"{sourceResourceType}/{sourceResourceId}") };
-        var searchOptions = BuildSearchOptions(targetResourceType, graphQlContext, additionalParams);
 
         logger.LogDebug(
             "GraphQL reverse search {TargetType} via {Param}={SourceType}/{SourceId}",
@@ -105,6 +107,8 @@ public sealed class SearchResolver(
 
         try
         {
+            // Inside the try -- see the identical comment in SearchListAsync.
+            var searchOptions = BuildSearchOptions(targetResourceType, graphQlContext, additionalParams);
             var query = new SearchResourcesQuery(targetResourceType, searchOptions);
             var result = await mediator.SendAsync(query, cancellationToken);
 
@@ -133,7 +137,6 @@ public sealed class SearchResolver(
         CancellationToken cancellationToken)
     {
         var additionalParams = new[] { new QueryParameter(referenceParamName, $"{sourceResourceType}/{sourceResourceId}") };
-        var searchOptions = BuildSearchOptions(targetResourceType, graphQlContext, additionalParams, requestAccurateTotal: true);
 
         logger.LogDebug(
             "GraphQL reverse connection search {TargetType} via {Param}={SourceType}/{SourceId}",
@@ -141,6 +144,8 @@ public sealed class SearchResolver(
 
         try
         {
+            // Inside the try -- see the identical comment in SearchListAsync.
+            var searchOptions = BuildSearchOptions(targetResourceType, graphQlContext, additionalParams, requestAccurateTotal: true);
             var query = new SearchResourcesQuery(targetResourceType, searchOptions);
             var result = await mediator.SendAsync(query, cancellationToken);
 
@@ -258,7 +263,16 @@ public sealed class SearchResolver(
             parameters.AddRange(additionalParameters);
 
         var builder = searchOptionsBuilderFactory.Create(fhirVersion, tenantId);
-        return builder.Build(resourceType, parameters);
+        var searchOptions = builder.Build(resourceType, parameters);
+
+        // GraphQL argument names can't carry the ':' a FHIR modifier needs (GraphQL's Name grammar forbids
+        // it), so today's four callers can't reach this through their per-field-argument loop. Guarding here
+        // anyway, once, for every caller of this method -- the same reasoning that put ThrowIfAny on every
+        // other client-input search path in this codebase: the invariant should not depend on a caller
+        // correctly reasoning about what a future argument source can or can't smuggle through.
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
+
+        return searchOptions;
     }
 }
 

--- a/src/Application/Ignixa.Application/Features/Experimental/Mcp/Tools/FhirOperations/SearchResourcesTool.cs
+++ b/src/Application/Ignixa.Application/Features/Experimental/Mcp/Tools/FhirOperations/SearchResourcesTool.cs
@@ -14,6 +14,7 @@ using Ignixa.Application.Infrastructure;
 using Ignixa.Abstractions;
 using Ignixa.Application.Features.Search;
 using Ignixa.Domain.Abstractions;
+using Ignixa.Search.Indexing;
 using Ignixa.Search.Models;
 using Ignixa.Search.Parsing;
 using Ignixa.Serialization;
@@ -123,6 +124,12 @@ Example: resourceType='Patient', searchParams={'name': 'Smith'}, elements='id,na
         // Use SearchOptionsBuilder to parse all parameters and build expressions
         var builder = _builderFactory.Create(fhirVersion);
         var searchOptions = builder.Build(resourceType, queryParameters, schemaProvider);
+
+        // searchParams is a client-supplied Dictionary<string, string> with no key constraint, so an
+        // unsupported modifier (e.g. "identifier:above") reaches here the same way an HTTP query string
+        // does. Build() only classifies it; without this, the search would silently run widened/unfiltered
+        // instead of the FHIR R4 SHALL-mandated rejection every other client-input search path enforces.
+        SearchModifierNotSupportedException.ThrowIfAny(searchOptions);
 
         // Update the FHIR request context with the resolved tenant ID
         // The middleware has already created the context, we just need to update the tenant

--- a/src/Core/Ignixa.Search.Sql.Generators/DdlTableParser.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/DdlTableParser.cs
@@ -20,10 +20,16 @@ public static class DdlTableParser
         @"(\s+CONSTRAINT\s+\S+\s+DEFAULT\s+\S+)?" +
         @"(\s+DEFAULT\s+\S+)?" +
         @"(\s+IDENTITY\s*\([^)]*\))?" +
-        // Optional: SQL Server defaults an undeclared column to nullable, and 65 columns across the
-        // non-search tables rely on that. The search-index tables all declare it explicitly, so this
-        // changes nothing the compiler reads.
-        @"(\s+(?<nullability>NOT\s+NULL|NULL))?" +
+        // Mandatory, not optional: ParseColumns only ever runs on catalog-filtered tables (the
+        // tableNameFilter check gates it before this regex sees a line), and those all declare
+        // nullability explicitly -- the 65 columns elsewhere that rely on SQL Server's implicit-nullable
+        // default live in non-catalog tables this parser never reaches. Making the group optional let a
+        // NOT NULL following any CONSTRAINT clause other than "CONSTRAINT name DEFAULT value" (e.g. a
+        // CHECK constraint, or a DEFAULT with a space in its literal) fall through to the trailing
+        // catch-all below and parse as nullable instead of throwing -- silently wrong, not silently
+        // absent, which this parser's own philosophy (throw on anything it can't confidently read)
+        // exists to prevent.
+        @"\s+(?<nullability>NOT\s+NULL|NULL)" +
         // IDENTITY appears on either side of the nullability clause across this schema
         // (Resource declares it before, PackageResource after), so both positions are optional.
         @"(\s+IDENTITY\s*\([^)]*\))?" +
@@ -157,8 +163,10 @@ public static class DdlTableParser
         }
 
         var collation = match.Groups["collation"].Success ? match.Groups["collation"].Value : null;
-        var isNullable = !match.Groups["nullability"].Value.Replace(" ", string.Empty)
-            .Equals("NOTNULL", StringComparison.OrdinalIgnoreCase);
+        // TrimStart + StartsWith rather than a literal-space Replace: the regex's \s+ between NOT and
+        // NULL accepts a tab, which a single-character space Replace would miss.
+        var isNullable = !match.Groups["nullability"].Value.TrimStart()
+            .StartsWith("NOT", StringComparison.OrdinalIgnoreCase);
 
         return new DdlColumn(name, sqlType, maxLength, collation, isNullable);
     }

--- a/src/Core/Ignixa.Search.Sql.Generators/DdlTableParser.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/DdlTableParser.cs
@@ -20,7 +20,13 @@ public static class DdlTableParser
         @"(\s+CONSTRAINT\s+\S+\s+DEFAULT\s+\S+)?" +
         @"(\s+DEFAULT\s+\S+)?" +
         @"(\s+IDENTITY\s*\([^)]*\))?" +
-        @"\s+(?<nullability>NOT\s+NULL|NULL)" +
+        // Optional: SQL Server defaults an undeclared column to nullable, and 65 columns across the
+        // non-search tables rely on that. The search-index tables all declare it explicitly, so this
+        // changes nothing the compiler reads.
+        @"(\s+(?<nullability>NOT\s+NULL|NULL))?" +
+        // IDENTITY appears on either side of the nullability clause across this schema
+        // (Resource declares it before, PackageResource after), so both positions are optional.
+        @"(\s+IDENTITY\s*\([^)]*\))?" +
         @"(\s+CONSTRAINT\s+.+)?$",
         RegexOptions.IgnoreCase);
 

--- a/src/Core/Ignixa.Search.Sql.Generators/Ignixa.Search.Sql.Generators.csproj
+++ b/src/Core/Ignixa.Search.Sql.Generators/Ignixa.Search.Sql.Generators.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <Description>Source generator for Ignixa.Search.Sql's SqlCatalog -- reads the real search-index DDL (97.sql) and generates the table/column facts SqlCatalog.Default exposes, instead of hand-transcribing them.</Description>
+    <Description>Source generator for Ignixa.Search.Sql's SqlCatalog -- reads the real search-index DDL (the decomposed table scripts under Ignixa.DataLayer.SqlServer.Database/Tables) and generates the table/column facts SqlCatalog.Default exposes, instead of hand-transcribing them.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
@@ -1,36 +1,53 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace Ignixa.Search.Sql.Generators;
 
 /// <summary>
-/// Reads 97.sql (via AdditionalFiles) and generates SqlCatalog.BuildFromDdl()'s implementation --
-/// table/column facts sourced directly from the real DDL, not hand-transcribed.
+/// Reads the decomposed table DDL files (via AdditionalFiles) and generates SqlCatalog.BuildFromDdl()'s
+/// implementation -- table/column facts sourced directly from the real DDL, not hand-transcribed.
 /// </summary>
 [Generator]
 public sealed class SqlCatalogGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var ddlFile = context.AdditionalTextsProvider
-            .Where(static file => file.Path.EndsWith("97.sql", StringComparison.OrdinalIgnoreCase))
+        var ddlFiles = context.AdditionalTextsProvider
+            .Where(static file => file.Path.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
             .Collect();
 
-        context.RegisterSourceOutput(ddlFile, static (spc, files) =>
+        context.RegisterSourceOutput(ddlFiles, static (spc, files) =>
         {
             if (files.Length == 0)
             {
                 return;
             }
 
-            var ddlText = files[0].GetText(spc.CancellationToken)?.ToString() ?? string.Empty;
+            var ddlText = string.Join(
+                "\n",
+                files.Select(f => f.GetText(spc.CancellationToken)?.ToString() ?? string.Empty));
+            // The search-index tables the compiler lowers against, plus the tables the data layer
+            // hand-writes SQL against (terminology, packages, background jobs, the event store) so those
+            // identifiers come from the real DDL -- a renamed column becomes a build failure rather than a
+            // runtime error 207.
+            //
+            // Deliberately a named set rather than every table. The parser handles the DDL vocabulary these
+            // tables use; the wider schema also contains computed columns (EventLog's PERSISTED
+            // PartitionId), which it does not model. Widening further means teaching it those constructs
+            // first -- worth doing when something needs them, not speculatively.
             var tables = DdlTableParser.ParseTables(ddlText,
                 name => name.EndsWith("SearchParam", StringComparison.Ordinal)
                     || name == "ResourceType"
                     || name == "Resource"
-                    || name == "TokenText");
+                    || name == "TokenText"
+                    || name.StartsWith("Term", StringComparison.Ordinal)
+                    || name == "SourceEvents"
+                    || name == "BackgroundJobs"
+                    || name == "PackageResource"
+                    || name == "System");
 
             spc.AddSource("SqlCatalog.g.cs", Emit(tables));
         });

--- a/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogGenerator.cs
@@ -29,25 +29,7 @@ public sealed class SqlCatalogGenerator : IIncrementalGenerator
             var ddlText = string.Join(
                 "\n",
                 files.Select(f => f.GetText(spc.CancellationToken)?.ToString() ?? string.Empty));
-            // The search-index tables the compiler lowers against, plus the tables the data layer
-            // hand-writes SQL against (terminology, packages, background jobs, the event store) so those
-            // identifiers come from the real DDL -- a renamed column becomes a build failure rather than a
-            // runtime error 207.
-            //
-            // Deliberately a named set rather than every table. The parser handles the DDL vocabulary these
-            // tables use; the wider schema also contains computed columns (EventLog's PERSISTED
-            // PartitionId), which it does not model. Widening further means teaching it those constructs
-            // first -- worth doing when something needs them, not speculatively.
-            var tables = DdlTableParser.ParseTables(ddlText,
-                name => name.EndsWith("SearchParam", StringComparison.Ordinal)
-                    || name == "ResourceType"
-                    || name == "Resource"
-                    || name == "TokenText"
-                    || name.StartsWith("Term", StringComparison.Ordinal)
-                    || name == "SourceEvents"
-                    || name == "BackgroundJobs"
-                    || name == "PackageResource"
-                    || name == "System");
+            var tables = DdlTableParser.ParseTables(ddlText, SqlCatalogTableFilter.IsCatalogTable);
 
             spc.AddSource("SqlCatalog.g.cs", Emit(tables));
         });

--- a/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogTableFilter.cs
+++ b/src/Core/Ignixa.Search.Sql.Generators/SqlCatalogTableFilter.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Ignixa.Search.Sql.Generators;
+
+/// <summary>
+/// The set of tables <see cref="SqlCatalogGenerator"/> reads from the decomposed DDL: the search-index
+/// tables the compiler lowers against, plus the tables the data layer hand-writes SQL against
+/// (terminology, packages, background jobs, the event store) so those identifiers come from the real
+/// DDL -- a renamed column becomes a build failure rather than a runtime error 207.
+/// </summary>
+/// <remarks>
+/// Deliberately a named set rather than every table. The parser handles the DDL vocabulary these tables
+/// use; the wider schema also contains computed columns (EventLog's PERSISTED PartitionId), which it
+/// does not model. Widening further means teaching it those constructs first -- worth doing when
+/// something needs them, not speculatively.
+/// <para>
+/// Split out of <see cref="SqlCatalogGenerator"/> (rather than a public method on it) so callers that
+/// only need the filter -- notably the schema-parity guard test, which checks these tables' DDL against
+/// the DB provisioning script -- don't have to load the generator's <c>Microsoft.CodeAnalysis</c>
+/// dependency, an analyzer-only reference not available at ordinary runtime.
+/// </para>
+/// </remarks>
+public static class SqlCatalogTableFilter
+{
+    public static bool IsCatalogTable(string tableName) =>
+        tableName.EndsWith("SearchParam", StringComparison.Ordinal)
+            || tableName == "ResourceType"
+            || tableName == "Resource"
+            || tableName == "TokenText"
+            || tableName.StartsWith("Term", StringComparison.Ordinal)
+            || tableName == "SourceEvents"
+            || tableName == "BackgroundJobs"
+            || tableName == "PackageResource"
+            || tableName == "System";
+}

--- a/src/Core/Ignixa.Search.Sql/Ast/OffsetSpec.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/OffsetSpec.cs
@@ -1,8 +1,25 @@
 namespace Ignixa.Search.Sql.Ast;
 
 /// <summary>
-/// An OFFSET/FETCH page: skip <paramref name="Offset"/> rows, return at most <paramref name="Limit"/>.
+/// An OFFSET/FETCH page: skip <paramref name="Offset"/> rows, return the <paramref name="Limit"/> rows of
+/// the page, plus one lookahead row past its end when <paramref name="ProbeExtraRow"/> is set.
 /// Mutually exclusive with keyset <see cref="PageSpec"/> and with a TOP cap — T-SQL rejects the
 /// combination (error 10741).
 /// </summary>
-public sealed record OffsetSpec(int Offset, int Limit);
+/// <param name="Offset">Rows skipped before the page begins.</param>
+/// <param name="Limit">
+/// The TRUE page size: how many rows the caller intends to hand back. Never pre-incremented for has-more
+/// detection — a caller that over-fetches says so through <paramref name="ProbeExtraRow"/> instead.
+/// </param>
+/// <param name="ProbeExtraRow">
+/// Fetch one row beyond the page so the caller can tell whether a further page exists. That row is a
+/// lookahead, not a member of the page, and the distinction is load-bearing for _include/_revinclude:
+/// include stages seed only from the first <paramref name="Limit"/> rows of the match page, so a probe row
+/// the caller later trims cannot leave its included resources stranded in the bundle. Folding the +1 into
+/// <paramref name="Limit"/> makes that distinction unrepresentable, which is exactly why it is a flag.
+/// </param>
+public sealed record OffsetSpec(int Offset, int Limit, bool ProbeExtraRow = false)
+{
+    /// <summary>Rows the emitted FETCH NEXT asks for: the page, plus its probe row when there is one.</summary>
+    public int FetchCount => Limit + (ProbeExtraRow ? 1 : 0);
+}

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -93,6 +93,16 @@ public static class PlanExplainer
                 "page", "page", PlanRowKind.PageSpec, PrintPageSpec(page, ref parameterOrdinal), []));
         }
 
+        // Mutually exclusive with Page (SqlBuilder rejects both), and consumes the same next two ordinals
+        // Emit binds for OFFSET/FETCH -- immediately after the seek/page predicate, whether or not the plan
+        // also carries Includes: WriteMatchPageCte binds them in the same relative order EmitMatchOnlyShape
+        // does at the top level, so this row's position holds for both shapes.
+        if (plan.OffsetPage is { } offsetPage)
+        {
+            rows.Add(new PlanExplainRow(
+                "offsetPage", "offsetPage", PlanRowKind.OffsetSpec, PrintOffsetSpec(offsetPage, ref parameterOrdinal), []));
+        }
+
         if (plan.CountOnly)
         {
             rows.Add(new PlanExplainRow("countOnly", "countOnly", PlanRowKind.CountOnly, "true", []));
@@ -160,6 +170,19 @@ public static class PlanExplainer
         var typeParam = page.BoundaryResourceTypeId is null ? "none" : $"@p{parameterOrdinal++}";
         var sidParam = $"@p{parameterOrdinal++}";
         return $"PageSpec(boundary=[{string.Join(",", boundary)}], type={typeParam}, sid={sidParam})";
+    }
+
+    /// <summary>
+    /// Renders the OFFSET/FETCH clause Emit binds for <see cref="OffsetSpec"/> -- two ordinals, offset then
+    /// fetch count. Fetch count is <see cref="OffsetSpec.FetchCount"/> (the page size plus its probe row,
+    /// when <see cref="OffsetSpec.ProbeExtraRow"/> is set), matching what Emit actually binds, not the
+    /// caller-facing <see cref="OffsetSpec.Limit"/>.
+    /// </summary>
+    private static string PrintOffsetSpec(OffsetSpec offset, ref int parameterOrdinal)
+    {
+        var offsetParam = $"@p{parameterOrdinal++}";
+        var fetchParam = $"@p{parameterOrdinal++}";
+        return $"OffsetSpec(offset={offsetParam}, fetch={fetchParam})";
     }
 
     /// <summary>

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using Ignixa.Search.Expressions;
+using Ignixa.Search.Sql.Builders;
 using static Ignixa.Search.Sql.Builders.SqlLabels;
 
 namespace Ignixa.Search.Sql.Ast;
@@ -59,6 +60,24 @@ public static class PlanExplainer
                 label, CteLabel(i), KindOf(plan.Ctes[i]), body, ReferencedCteIndexesOf(plan.Ctes[i])));
         }
 
+        // EmitIncludesShape wraps the root CTE in a synthetic cteMatchPage (and, when trimming a probe row,
+        // a further cteMatchSeed) that plan.Ctes never lists -- SqlBuilder builds their SQL text ad hoc from
+        // plan fields rather than as CteDefinition entries. These rows are pure labels: matchPage's own
+        // where/order-by/offset content is already fully counted by the root row's WHERE splice above and
+        // the page/surrogateRange/searchParameterHash/offsetPage rows below (WriteMatchPageCte binds those
+        // in the same relative order EmitMatchOnlyShape does), so neither row advances parameterOrdinal.
+        if (!plan.CountOnly && plan.Includes is { Count: > 0 } matchPageIncludes)
+        {
+            rows.Add(new PlanExplainRow(
+                "matchPage", "matchPage", PlanRowKind.MatchPageCte, PrintMatchPageCte(plan), []));
+
+            if (SqlBuilder.SeedsFromTrimmedMatchPage(plan, matchPageIncludes))
+            {
+                rows.Add(new PlanExplainRow(
+                    "matchSeed", "matchSeed", PlanRowKind.MatchSeedCte, PrintMatchSeedCte(plan), []));
+            }
+        }
+
         // Emitted between the CTE graph and the include stages, matching where SqlBuilder binds it:
         // EmitIncludesShape binds the two boundary values after the match-page CTE and before the stage
         // loop, and include-stage CTEs bind nothing, so these are the first stage-level ordinals. Rendering
@@ -91,6 +110,21 @@ public static class PlanExplainer
         {
             rows.Add(new PlanExplainRow(
                 "page", "page", PlanRowKind.PageSpec, PrintPageSpec(page, ref parameterOrdinal), []));
+        }
+
+        // BuildMatchWhereClauses appends these two, in this order, right after the page/seek predicate and
+        // before ORDER BY -- both rows must sit here, between page and offsetPage, or their ordinals collide
+        // with whatever OFFSET/FETCH consumes next.
+        if (plan.SurrogateRange is { } surrogateRange)
+        {
+            rows.Add(new PlanExplainRow(
+                "surrogateRange", "surrogateRange", PlanRowKind.SurrogateRange, PrintSurrogateRange(ref parameterOrdinal), []));
+        }
+
+        if (plan.SearchParameterHash is not null)
+        {
+            rows.Add(new PlanExplainRow(
+                "searchParameterHash", "searchParameterHash", PlanRowKind.SearchParameterHash, PrintSearchParameterHash(ref parameterOrdinal), []));
         }
 
         // Mutually exclusive with Page (SqlBuilder rejects both), and consumes the same next two ordinals
@@ -171,6 +205,47 @@ public static class PlanExplainer
         var sidParam = $"@p{parameterOrdinal++}";
         return $"PageSpec(boundary=[{string.Join(",", boundary)}], type={typeParam}, sid={sidParam})";
     }
+
+    /// <summary>
+    /// Renders the export-sharding surrogate-id window SqlBuilder's <c>AppendSurrogateRangeClauses</c> binds
+    /// -- always exactly two ordinals, start then end.
+    /// </summary>
+    private static string PrintSurrogateRange(ref int parameterOrdinal)
+    {
+        var startParam = $"@p{parameterOrdinal++}";
+        var endParam = $"@p{parameterOrdinal++}";
+        return $"SurrogateRange(start={startParam}, end={endParam})";
+    }
+
+    /// <summary>
+    /// Renders the reindex-eligibility hash comparison SqlBuilder's <c>EmitSearchParameterHashClause</c>
+    /// binds -- one ordinal, the hash a resource's own <c>SearchParamHash</c> must differ from.
+    /// </summary>
+    private static string PrintSearchParameterHash(ref int parameterOrdinal)
+        => $"SearchParameterHash(hash=@p{parameterOrdinal++})";
+
+    /// <summary>
+    /// Summarizes the synthetic cteMatchPage WriteMatchPageCte builds for an includes-shape plan: its own
+    /// TOP cap (a literal, never a bound parameter) and which joins it carries. Both booleans mirror
+    /// SqlBuilder's own decisions exactly (<see cref="SqlBuilder.NeedsResourceJoin"/> for the resource join;
+    /// sort joins follow whenever the plan sorts at all) so this label can't drift from what Emit does.
+    /// </summary>
+    private static string PrintMatchPageCte(QueryPlan plan)
+    {
+        var top = plan.Top is { } n ? n.ToString(CultureInfo.InvariantCulture) : "none";
+        var sortJoins = plan.Sort is not null;
+        var resourceJoin = SqlBuilder.NeedsResourceJoin(plan, includesProjection: false);
+        return $"MatchPageCte(top={top}, sortJoins={(sortJoins ? "true" : "false")}, resourceJoin={(resourceJoin ? "true" : "false")})";
+    }
+
+    /// <summary>
+    /// Summarizes the synthetic cteMatchSeed WriteMatchSeedCte builds to trim an over-fetched match page's
+    /// probe row before include stages seed from it. <see cref="OffsetSpec.Limit"/>, not
+    /// <see cref="OffsetSpec.FetchCount"/> -- the seed keeps only the true page, not the lookahead row past
+    /// its end. A literal TOP, like matchPage's own; binds no ordinal.
+    /// </summary>
+    private static string PrintMatchSeedCte(QueryPlan plan)
+        => $"MatchSeedCte(limit={plan.OffsetPage!.Limit.ToString(CultureInfo.InvariantCulture)})";
 
     /// <summary>
     /// Renders the OFFSET/FETCH clause Emit binds for <see cref="OffsetSpec"/> -- two ordinals, offset then

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanExplainer.cs
@@ -78,10 +78,55 @@ public static class PlanExplainer
             }
         }
 
-        // Emitted between the CTE graph and the include stages, matching where SqlBuilder binds it:
-        // EmitIncludesShape binds the two boundary values after the match-page CTE and before the stage
-        // loop, and include-stage CTEs bind nothing, so these are the first stage-level ordinals. Rendering
-        // this row after the inc rows would read the same but claim the wrong @pN.
+        if (plan.Sort is { } sort)
+        {
+            rows.Add(new PlanExplainRow("sort", "sort", PlanRowKind.SortSpec, PrintSortSpec(sort), []));
+        }
+
+        // EmitCountOnlyShape never reads Page or OffsetPage -- COUNT_BIG has no page to seek or window, and
+        // SqlBuilder emits neither clause for it (pinned by GivenACountOnlyPlanWithOffsetPage_WhenEmitted_
+        // ThenOffsetFetchIsNotEmitted). Gate both rows the same way or Describe() claims ordinals Emit never
+        // binds for a CountOnly plan.
+        if (!plan.CountOnly && plan.Page is { } page)
+        {
+            rows.Add(new PlanExplainRow(
+                "page", "page", PlanRowKind.PageSpec, PrintPageSpec(page, ref parameterOrdinal), []));
+        }
+
+        // BuildMatchWhereClauses (EmitMatchOnlyShape/WriteMatchPageCte) and EmitCountOnlyShape both append
+        // these two, in this order, right after the page/seek predicate (when there is one) and before
+        // ORDER BY -- unlike Page/OffsetPage, CountOnly plans DO bind these, so no CountOnly gate here.
+        if (plan.SurrogateRange is { } surrogateRange)
+        {
+            rows.Add(new PlanExplainRow(
+                "surrogateRange", "surrogateRange", PlanRowKind.SurrogateRange, PrintSurrogateRange(ref parameterOrdinal), []));
+        }
+
+        if (plan.SearchParameterHash is not null)
+        {
+            rows.Add(new PlanExplainRow(
+                "searchParameterHash", "searchParameterHash", PlanRowKind.SearchParameterHash, PrintSearchParameterHash(ref parameterOrdinal), []));
+        }
+
+        // Mutually exclusive with Page (SqlBuilder rejects both) and, like Page, never bound for CountOnly.
+        // Consumes the same next two ordinals Emit binds for OFFSET/FETCH -- immediately after the seek/page
+        // predicate, whether or not the plan also carries Includes: WriteMatchPageCte binds them in the same
+        // relative order EmitMatchOnlyShape does at the top level, so this row's position holds for both shapes.
+        if (!plan.CountOnly && plan.OffsetPage is { } offsetPage)
+        {
+            rows.Add(new PlanExplainRow(
+                "offsetPage", "offsetPage", PlanRowKind.OffsetSpec, PrintOffsetSpec(offsetPage, ref parameterOrdinal), []));
+        }
+
+        // Bound last among the ordinal-consuming rows: EmitIncludesShape calls WriteMatchPageCte -- which
+        // binds everything above (OuterPredicate through OffsetPage) via BuildMatchWhereClauses plus its own
+        // ORDER BY/OFFSET-FETCH -- to completion BEFORE binding the resume boundary, and only then starts the
+        // stage loop. Rendering this row any earlier (it used to sit right after the CTE graph) claimed
+        // ordinals that page/surrogateRange/searchParameterHash/offsetPage hadn't consumed yet in the real
+        // SQL, so every row from here on named the wrong bound value whenever IncludesPage's Resume combined
+        // with SurrogateRange or SearchParameterHash -- exactly the combination SqlBuilder's own
+        // RejectUnsupportedCombinations guard message recommends ("bound the match set with SurrogateRange
+        // and page the include rows with ResultShape.IncludesPage.Resume").
         if (plan.IncludeBoundary is not null)
         {
             rows.Add(new PlanExplainRow(
@@ -99,42 +144,6 @@ public static class PlanExplainer
                 rows.Add(new PlanExplainRow(
                     IncludeLabel(i), IncludeLabel(i), PlanRowKind.IncludeStage, PrintIncludeStage(includes[i]), []));
             }
-        }
-
-        if (plan.Sort is { } sort)
-        {
-            rows.Add(new PlanExplainRow("sort", "sort", PlanRowKind.SortSpec, PrintSortSpec(sort), []));
-        }
-
-        if (plan.Page is { } page)
-        {
-            rows.Add(new PlanExplainRow(
-                "page", "page", PlanRowKind.PageSpec, PrintPageSpec(page, ref parameterOrdinal), []));
-        }
-
-        // BuildMatchWhereClauses appends these two, in this order, right after the page/seek predicate and
-        // before ORDER BY -- both rows must sit here, between page and offsetPage, or their ordinals collide
-        // with whatever OFFSET/FETCH consumes next.
-        if (plan.SurrogateRange is { } surrogateRange)
-        {
-            rows.Add(new PlanExplainRow(
-                "surrogateRange", "surrogateRange", PlanRowKind.SurrogateRange, PrintSurrogateRange(ref parameterOrdinal), []));
-        }
-
-        if (plan.SearchParameterHash is not null)
-        {
-            rows.Add(new PlanExplainRow(
-                "searchParameterHash", "searchParameterHash", PlanRowKind.SearchParameterHash, PrintSearchParameterHash(ref parameterOrdinal), []));
-        }
-
-        // Mutually exclusive with Page (SqlBuilder rejects both), and consumes the same next two ordinals
-        // Emit binds for OFFSET/FETCH -- immediately after the seek/page predicate, whether or not the plan
-        // also carries Includes: WriteMatchPageCte binds them in the same relative order EmitMatchOnlyShape
-        // does at the top level, so this row's position holds for both shapes.
-        if (plan.OffsetPage is { } offsetPage)
-        {
-            rows.Add(new PlanExplainRow(
-                "offsetPage", "offsetPage", PlanRowKind.OffsetSpec, PrintOffsetSpec(offsetPage, ref parameterOrdinal), []));
         }
 
         if (plan.CountOnly)
@@ -226,14 +235,16 @@ public static class PlanExplainer
 
     /// <summary>
     /// Summarizes the synthetic cteMatchPage WriteMatchPageCte builds for an includes-shape plan: its own
-    /// TOP cap (a literal, never a bound parameter) and which joins it carries. Both booleans mirror
-    /// SqlBuilder's own decisions exactly (<see cref="SqlBuilder.NeedsResourceJoin"/> for the resource join;
-    /// sort joins follow whenever the plan sorts at all) so this label can't drift from what Emit does.
+    /// TOP cap (a literal, never a bound parameter) and which joins it carries. Both booleans call the exact
+    /// SqlBuilder decisions they report (<see cref="SqlBuilder.NeedsResourceJoin"/>, <see cref="SqlBuilder.EmitSortJoins"/>)
+    /// rather than approximating them, so this label can't drift from what Emit does. sortJoins is NOT simply
+    /// "does the plan sort" -- EmitSortJoins skips LastUpdated/ResourceType keys and the MissingPrimary
+    /// phase's own primary key, so a plan sorted only by one of those needs no join at all.
     /// </summary>
     private static string PrintMatchPageCte(QueryPlan plan)
     {
         var top = plan.Top is { } n ? n.ToString(CultureInfo.InvariantCulture) : "none";
-        var sortJoins = plan.Sort is not null;
+        var sortJoins = SqlBuilder.EmitSortJoins(plan.Sort).Length > 0;
         var resourceJoin = SqlBuilder.NeedsResourceJoin(plan, includesProjection: false);
         return $"MatchPageCte(top={top}, sortJoins={(sortJoins ? "true" : "false")}, resourceJoin={(resourceJoin ? "true" : "false")})";
     }

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
@@ -35,9 +35,17 @@ public static class PlanRowKind
 
     public const string IncludeBoundary = "includeBoundary";
 
+    public const string MatchPageCte = "matchPageCte";
+
+    public const string MatchSeedCte = "matchSeedCte";
+
     public const string SortSpec = "sortSpec";
 
     public const string PageSpec = "pageSpec";
+
+    public const string SurrogateRange = "surrogateRange";
+
+    public const string SearchParameterHash = "searchParameterHash";
 
     public const string OffsetSpec = "offsetSpec";
 

--- a/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Ast/PlanRowKind.cs
@@ -39,5 +39,7 @@ public static class PlanRowKind
 
     public const string PageSpec = "pageSpec";
 
+    public const string OffsetSpec = "offsetSpec";
+
     public const string CountOnly = "countOnly";
 }

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -1117,8 +1117,14 @@ internal static class SqlBuilder
         _ => throw new NotSupportedException($"Unknown ChainDirection '{direction}'."),
     };
 
-    /// <summary>Renders the joins to each sort key's search-param table (INNER for the primary key, LEFT for tie-breakers), filtered to the IsMin/IsMax row for the key's direction.</summary>
-    private static string EmitSortJoins(SortSpec? sort)
+    /// <summary>
+    /// Renders the joins to each sort key's search-param table (INNER for the primary key, LEFT for
+    /// tie-breakers), filtered to the IsMin/IsMax row for the key's direction. Internal (not private) so
+    /// PlanExplainer's matchPage row can check whether this actually emits anything -- LastUpdated/
+    /// ResourceType keys and the MissingPrimary phase's own primary key need no join, so "does the plan
+    /// sort" is not the same question as "does matchPage carry a sort join."
+    /// </summary>
+    internal static string EmitSortJoins(SortSpec? sort)
     {
         if (sort is null)
         {

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -554,6 +554,15 @@ internal static class SqlBuilder
         // Gated on SeedFromMatch too, so a plan whose every stage seeds off an earlier stage emits no
         // unreferenced CTE. Binds no parameters, keeping the resume boundary below at the first stage-level
         // ordinal.
+        //
+        // NOTE: only OffsetSpec.ProbeExtraRow is checked here -- a Top-capped (keyset) page has no equivalent
+        // flag, even though some Top callers use the same "ask for one more than the page size" convention to
+        // detect hasMore (see SearchPaging.Keyset's remarks). Until a caller in this repo actually drives
+        // Top-capped paging together with Include stages, extending this trim to Top would be speculative: it
+        // would either need every Top caller to follow the same convention, or a ProbeExtraRow-equivalent flag
+        // on SearchPaging.Keyset threaded through Lower/PlanExplainer. Tracked as a known gap, not silently
+        // missed -- see GivenAnUnpagedPlanWithAnInclude_WhenEmitted_ThenTheIncludeStageSeedsFromTheWholeMatchPage
+        // in EmitProbeRowIncludeSeedTests, which pins today's (unprotected) behavior for that combination.
         var seedsFromTrimmedPage = plan.OffsetPage is { ProbeExtraRow: true } && includes.Any(stage => stage.SeedFromMatch);
         if (seedsFromTrimmedPage)
         {

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -289,11 +289,14 @@ internal static class SqlBuilder
         }
 
         // Guarded independently of Lower.Run because QueryPlan is a public construction surface.
-        if (plan.OffsetPage is { } offsetSpec && (offsetSpec.Offset < 0 || offsetSpec.Limit <= 0))
+        // A zero Limit is legal only alongside a probe row: the page itself is empty but the lookahead row
+        // still makes the fetch positive. See OffsetSpec.
+        if (plan.OffsetPage is { } offsetSpec && (offsetSpec.Offset < 0 || offsetSpec.Limit < 0 || offsetSpec.FetchCount <= 0))
         {
             throw new NotSupportedException(
                 $"OffsetPage must skip a non-negative row count and fetch a positive one; got Offset " +
-                $"{offsetSpec.Offset} and Limit {offsetSpec.Limit}. OFFSET/FETCH rejects both at runtime.");
+                $"{offsetSpec.Offset}, Limit {offsetSpec.Limit} and ProbeExtraRow {offsetSpec.ProbeExtraRow}, " +
+                $"fetching {offsetSpec.FetchCount}. OFFSET/FETCH rejects both at runtime.");
         }
 
         // Guarded independently of Lower.Run because QueryPlan is a public construction surface. Every node
@@ -524,7 +527,7 @@ internal static class SqlBuilder
 
         if (plan.OffsetPage is { } offsetPage)
         {
-            writer.Append($"\nOFFSET {EmitParam(new SqlParameterRef(offsetPage.Offset), parameters)} ROWS FETCH NEXT {EmitParam(new SqlParameterRef(offsetPage.Limit), parameters)} ROWS ONLY");
+            writer.Append($"\nOFFSET {EmitParam(new SqlParameterRef(offsetPage.Offset), parameters)} ROWS FETCH NEXT {EmitParam(new SqlParameterRef(offsetPage.FetchCount), parameters)} ROWS ONLY");
         }
     }
 
@@ -546,6 +549,17 @@ internal static class SqlBuilder
         writer.Append(",\n");
         WriteMatchPageCte(plan, writer, parameters);
 
+        // An over-fetched page's last row is a has-more probe the caller discards, so it must not seed
+        // includes; a page that did not over-fetch has no such row and seeds from the whole match page.
+        // Gated on SeedFromMatch too, so a plan whose every stage seeds off an earlier stage emits no
+        // unreferenced CTE. Binds no parameters, keeping the resume boundary below at the first stage-level
+        // ordinal.
+        var seedsFromTrimmedPage = plan.OffsetPage is { ProbeExtraRow: true } && includes.Any(stage => stage.SeedFromMatch);
+        if (seedsFromTrimmedPage)
+        {
+            WriteMatchSeedCte(plan, writer);
+        }
+
         // Bind the boundary here — after the match-page CTE, before the stage loop — so it takes the first
         // stage-level @pN, preserving the leading-ordinal invariant EmitCteBlocks documents. Include CTEs bind
         // no parameters; the predicate it feeds is emitted later by EmitGlobalIncludesPage.
@@ -553,9 +567,11 @@ internal static class SqlBuilder
             ? (EmitParam(new SqlParameterRef(boundary.TypeId), parameters), EmitParam(new SqlParameterRef(boundary.SurrogateId), parameters))
             : null;
 
+        var matchSeedLabel = seedsFromTrimmedPage ? MatchSeed : MatchPage;
+
         for (var i = 0; i < includes.Count; i++)
         {
-            WriteIncludeStageCtes(writer, includes[i], i, visibility, plan.IncludesOnly);
+            WriteIncludeStageCtes(writer, includes[i], i, visibility, plan.IncludesOnly, matchSeedLabel);
         }
 
         writer.Append("\n");
@@ -707,10 +723,40 @@ internal static class SqlBuilder
 
             if (plan.OffsetPage is { } matchOffsetPage)
             {
-                writer.Append($"\n    OFFSET {EmitParam(new SqlParameterRef(matchOffsetPage.Offset), parameters)} ROWS FETCH NEXT {EmitParam(new SqlParameterRef(matchOffsetPage.Limit), parameters)} ROWS ONLY");
+                writer.Append($"\n    OFFSET {EmitParam(new SqlParameterRef(matchOffsetPage.Offset), parameters)} ROWS FETCH NEXT {EmitParam(new SqlParameterRef(matchOffsetPage.FetchCount), parameters)} ROWS ONLY");
             }
 
             writer.Append("\n)");
+        }
+    }
+
+    /// <summary>
+    /// Writes the cteMatchSeed CTE: the <see cref="MatchPage"/> rows that are genuinely ON the page, with
+    /// its has-more probe row trimmed off, in the match page's own order.
+    /// </summary>
+    /// <remarks>
+    /// An over-fetching page returns Limit + 1 rows so the caller can detect a further page, then discards
+    /// that last row. Seeding include stages from the full match page resolves includes for the discarded
+    /// row too, and nothing downstream can undo that: the assembled bundle records no link from an included
+    /// resource back to the match it came from, and an include reachable from BOTH a kept match and the
+    /// probe row must survive. Trimming has to happen here, where the ordering is still known.
+    ///
+    /// TOP over the already-paged CTE rather than a narrowed FETCH NEXT, because T-SQL rejects TOP and
+    /// OFFSET/FETCH in the same query (error 10741) and the match page must still return its probe row.
+    /// The ORDER BY repeats the match page's ordering through the SortValueN columns it projects — take
+    /// "first Limit rows" under any other ordering and the wrong row is dropped.
+    /// </remarks>
+    private static void WriteMatchSeedCte(QueryPlan plan, SqlTextWriter writer)
+    {
+        writer.Append(",\n");
+        using (writer.Section(MatchSeed, SqlRangeKind.MatchSeed))
+        {
+            writer.Append(
+                $"{MatchSeed} AS (\n" +
+                $"    SELECT TOP ({plan.OffsetPage!.Limit}) T1, Sid1\n" +
+                $"    FROM {MatchPage}\n" +
+                $"    ORDER BY {EmitSortValueOrderBy(plan.Sort)}\n" +
+                ")");
         }
     }
 
@@ -725,12 +771,13 @@ internal static class SqlBuilder
         IncludeStage stage,
         int index,
         ResourceVisibility visibility,
-        bool includesOnly)
+        bool includesOnly,
+        string matchSeedLabel)
     {
         writer.Append(",\n");
         using (writer.Section(IncludeLabel(index), SqlRangeKind.Include))
         {
-            writer.Append($"{IncludeLabel(index)} AS (\n{EmitIncludeStage(stage, visibility, includesOnly)}\n)");
+            writer.Append($"{IncludeLabel(index)} AS (\n{EmitIncludeStage(stage, visibility, includesOnly, matchSeedLabel)}\n)");
         }
 
         if (includesOnly)
@@ -1244,11 +1291,20 @@ internal static class SqlBuilder
     /// <see cref="EmitOrderBy"/>.
     /// </summary>
     private static string EmitOuterOrderByForIncludes(SortSpec? sort)
+        => $"IsMatch DESC, {EmitSortValueOrderBy(sort)}";
+
+    /// <summary>
+    /// Renders the match page's own ordering as read back through the SortValueN columns it projects, for
+    /// consumers that select from the CTE rather than build it — the includes assembly's ORDER BY (via
+    /// <see cref="EmitOuterOrderByForIncludes"/>) and the match-seed CTE's TOP (see
+    /// <see cref="WriteMatchSeedCte"/>). The single producer of that ordering, so "the first N rows of the
+    /// match page" cannot come to mean something different in one caller than the other.
+    /// </summary>
+    private static string EmitSortValueOrderBy(SortSpec? sort)
     {
         var activeIndices = ActiveKeyIndices(sort);
         var terms = activeIndices.Select((idx, ordinal) =>
-            $"SortValue{ordinal} {(sort!.Keys[idx].Direction == SortOrder.Ascending ? "ASC" : "DESC")}")
-            .Prepend("IsMatch DESC");
+            $"SortValue{ordinal} {(sort!.Keys[idx].Direction == SortOrder.Ascending ? "ASC" : "DESC")}");
         if (!HasCustomSortKey(sort))
         {
             terms = terms.Append("T1 ASC");
@@ -1464,7 +1520,8 @@ internal static class SqlBuilder
     private static string EmitIncludeStage(
         IncludeStage stage,
         ResourceVisibility visibility,
-        bool includesOnly)
+        bool includesOnly,
+        string matchSeedLabel)
     {
         var (selectColumns, seedTypeColumn, outputTypeColumn, outputSurrogateColumn, seedCorrelationAlias) = stage.Direction switch
         {
@@ -1490,7 +1547,7 @@ internal static class SqlBuilder
         }
 
         whereClauses.Add("rsp.BaseUri IS NULL");
-        whereClauses.Add(EmitSeedExists(stage, seedCorrelationAlias, includesOnly));
+        whereClauses.Add(EmitSeedExists(stage, seedCorrelationAlias, includesOnly, matchSeedLabel));
 
         if (stage.Constraints is { Count: > 0 } constraints)
         {
@@ -1536,12 +1593,16 @@ internal static class SqlBuilder
     /// (<see cref="IncludeLimitLabel"/>); an IncludesOnly page seeds from the stage body (<see cref="IncludeLabel"/>),
     /// unfiltered by the resume boundary so an <c>:iterate</c> stage on page 2 still sees page-1 targets.
     /// </param>
-    private static string EmitSeedExists(IncludeStage stage, string correlationAlias, bool includesOnly)
+    /// <param name="matchSeedLabel">
+    /// Which label the match seed is read through: <see cref="MatchSeed"/> when the page over-fetches a
+    /// has-more probe row that must not pull includes of its own, otherwise <see cref="MatchPage"/> itself.
+    /// </param>
+    private static string EmitSeedExists(IncludeStage stage, string correlationAlias, bool includesOnly, string matchSeedLabel)
     {
         var branches = new List<string>();
         if (stage.SeedFromMatch)
         {
-            branches.Add($"SELECT 1 FROM {MatchPage} m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
+            branches.Add($"SELECT 1 FROM {matchSeedLabel} m WHERE m.T1 = {correlationAlias}.ResourceTypeId AND m.Sid1 = {correlationAlias}.ResourceSurrogateId");
         }
 
         foreach (var seedStageIndex in stage.SeedStages)

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlBuilder.cs
@@ -563,7 +563,7 @@ internal static class SqlBuilder
         // on SearchPaging.Keyset threaded through Lower/PlanExplainer. Tracked as a known gap, not silently
         // missed -- see GivenAnUnpagedPlanWithAnInclude_WhenEmitted_ThenTheIncludeStageSeedsFromTheWholeMatchPage
         // in EmitProbeRowIncludeSeedTests, which pins today's (unprotected) behavior for that combination.
-        var seedsFromTrimmedPage = plan.OffsetPage is { ProbeExtraRow: true } && includes.Any(stage => stage.SeedFromMatch);
+        var seedsFromTrimmedPage = SeedsFromTrimmedMatchPage(plan, includes);
         if (seedsFromTrimmedPage)
         {
             WriteMatchSeedCte(plan, writer);
@@ -602,6 +602,15 @@ internal static class SqlBuilder
             writer.Append(EmitOuterOrderByForIncludes(plan.Sort));
         }
     }
+
+    /// <summary>
+    /// Whether the trimmed cteMatchSeed CTE is emitted for an includes-shape plan -- see the NOTE above this
+    /// call site in <see cref="EmitIncludesShape"/> for why only <see cref="OffsetSpec.ProbeExtraRow"/> is
+    /// checked, not an equivalent Top-capped flag. Internal so PlanExplainer's matchSeed row uses the
+    /// identical condition rather than a second copy that can drift.
+    /// </summary>
+    internal static bool SeedsFromTrimmedMatchPage(QueryPlan plan, IReadOnlyList<IncludeStage> includes)
+        => plan.OffsetPage is { ProbeExtraRow: true } && includes.Any(stage => stage.SeedFromMatch);
 
     /// <summary>The derived-table alias the global includes page wraps its stage union in.</summary>
     private const string IncludeUnionAlias = "includeUnion";
@@ -922,13 +931,14 @@ internal static class SqlBuilder
 
     /// <summary>
     /// Whether a shape must join dbo.Resource: true when any plan feature references an <c>r.</c> column.
-    /// Centralised so a missing shape is a runtime bind error, not a test failure.
+    /// Centralised so a missing shape is a runtime bind error, not a test failure. Internal (not private) so
+    /// PlanExplainer's matchPage row reads the identical decision instead of a second copy that can drift.
     /// </summary>
     /// <param name="plan">The query plan being emitted.</param>
     /// <param name="includesProjection">
     /// Whether the calling shape projects through this join. False for CountOnly and the includes match arm.
     /// </param>
-    private static bool NeedsResourceJoin(QueryPlan plan, bool includesProjection)
+    internal static bool NeedsResourceJoin(QueryPlan plan, bool includesProjection)
         => plan.OuterPredicate is not null
             || plan.SearchParameterHash is not null
             || (includesProjection && plan.Projection is { Columns.Count: > 0 });

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlLabels.cs
@@ -14,6 +14,14 @@ public static class SqlLabels
     /// <summary>The match-page CTE. A real SQL identifier, not just a range label.</summary>
     public const string MatchPage = "cteMatchPage";
 
+    /// <summary>
+    /// The match-seed CTE: <see cref="MatchPage"/> minus its has-more probe row, which is what
+    /// _include/_revinclude stages seed from. Emitted only when the page over-fetches
+    /// (<c>OffsetSpec.ProbeExtraRow</c>); otherwise stages seed from <see cref="MatchPage"/> itself.
+    /// A real SQL identifier, not just a range label.
+    /// </summary>
+    public const string MatchSeed = "cteMatchSeed";
+
     /// <summary>The range label for a WHERE clause body.</summary>
     public const string Where = "where";
 

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
@@ -11,12 +11,18 @@ public static class SqlRangeKind
     /// <summary>A plan CTE's definition. Joins to the row whose canonical label is <see cref="SqlLabels.CteLabel"/>.</summary>
     public const string Cte = "cte";
 
-    /// <summary>The match-page CTE that applies paging to the match CTE. No row is named for it.</summary>
+    /// <summary>
+    /// The match-page CTE that applies paging to the match CTE, labelled <see cref="SqlLabels.MatchPage"/>.
+    /// Described by <see cref="Ast.PlanRowKind.MatchPageCte"/>'s row, whose own label ("matchPage") is a
+    /// plan-level pseudo-label like <c>sort</c>/<c>page</c>, not the SQL identifier this constant names --
+    /// the two aren't joined by string equality, the same as every other non-CTE row in this list.
+    /// </summary>
     public const string MatchPage = "matchPage";
 
     /// <summary>
     /// The match-seed CTE that trims the has-more probe row off the match page before include stages seed
-    /// from it, labelled <see cref="SqlLabels.MatchSeed"/>. No row is named for it.
+    /// from it, labelled <see cref="SqlLabels.MatchSeed"/>. Described by <see cref="Ast.PlanRowKind.MatchSeedCte"/>'s
+    /// row when SqlBuilder.SeedsFromTrimmedMatchPage decides it's needed; same pseudo-label caveat as <see cref="MatchPage"/>.
     /// </summary>
     public const string MatchSeed = "matchSeed";
 

--- a/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
+++ b/src/Core/Ignixa.Search.Sql/Builders/SqlRangeKind.cs
@@ -14,6 +14,12 @@ public static class SqlRangeKind
     /// <summary>The match-page CTE that applies paging to the match CTE. No row is named for it.</summary>
     public const string MatchPage = "matchPage";
 
+    /// <summary>
+    /// The match-seed CTE that trims the has-more probe row off the match page before include stages seed
+    /// from it, labelled <see cref="SqlLabels.MatchSeed"/>. No row is named for it.
+    /// </summary>
+    public const string MatchSeed = "matchSeed";
+
     /// <summary>A WHERE clause body. No row is named for it.</summary>
     public const string Where = "where";
 

--- a/src/Core/Ignixa.Search.Sql/Compilation/CompilationContextMapping.cs
+++ b/src/Core/Ignixa.Search.Sql/Compilation/CompilationContextMapping.cs
@@ -31,7 +31,9 @@ internal static class CompilationContextMapping
     public static FrozenDictionary<string, string> NotApplicable { get; } = new Dictionary<string, string>(StringComparer.Ordinal)
     {
         [nameof(SearchOptions.MaxItemCount)] =
-            "Callers transform it before a search runs — SearchResourcesHandler requests MaxItemCount + 1 to detect 'has more' — so forwarding it as a row cap would silently fight that transformation. Row capping is SearchPaging.Keyset.Top on ResultShape.Matches.",
+            "A page size, not a row cap: the adapter layer pairs it with ProbeExtraRow and a decoded continuation token to build the OffsetSpec on ResultShape.Matches. Forwarding it as a cap as well would apply the same number twice. Row capping is SearchPaging.Keyset.Top on ResultShape.Matches.",
+        [nameof(SearchOptions.ProbeExtraRow)] =
+            "Reaches the compiler as OffsetSpec.ProbeExtraRow, built by the adapter layer alongside MaxItemCount. The AST models the over-fetch structurally, so there is nothing left for a separate compilation input to say.",
         [nameof(SearchOptions.ContinuationToken)] =
             "Decoding it into a keyset or OFFSET page is adapter logic in a different layer. The decoded result arrives as the SearchPaging on ResultShape.Matches.",
         [nameof(SearchOptions.Elements)] =
@@ -42,6 +44,8 @@ internal static class CompilationContextMapping
             "A serialization-time projection, like Elements.",
         [nameof(SearchOptions.UnsupportedParams)] =
             "Builder output describing what it could not honour; it shapes the OperationOutcome, not the SQL.",
+        [nameof(SearchOptions.UnsupportedModifierParams)] =
+            "Builder output, like UnsupportedParams: the subset R4 says SHALL be rejected rather than ignored. It decides an HTTP status at the API boundary, never a CTE.",
         [nameof(SearchOptions.BundleIssues)] =
             "Builder output, like UnsupportedParams.",
         [nameof(SearchOptions.ResourceType)] =

--- a/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
+++ b/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
@@ -25,11 +25,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\DataLayer\Ignixa.DataLayer.SqlEntityFramework\Resources\97.sql" />
+    <AdditionalFiles Include="..\..\DataLayer\Ignixa.DataLayer.SqlServer.Database\Tables\*.sql" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Ignixa.Search.Sql.Tests" />
+    <!-- TokenCodeSplitPointGuardTests compares TokenColumnEquality.InlineCodeWidth against what the
+         SqlServer token row generators actually write. The constant stays internal: it is a storage
+         convention this compiler must match, not public API a consumer should depend on. -->
+    <InternalsVisibleTo Include="Ignixa.DataLayer.SqlServer.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
+++ b/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\DataLayer\Ignixa.DataLayer.SqlServer.Database\Tables\*.sql" />
+    <AdditionalFiles Include="..\..\DataLayer\Ignixa.DataLayer.SqlServer.Database\Tables\*.sql" Link="DataLayerDdl\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
+++ b/src/Core/Ignixa.Search.Sql/Ignixa.Search.Sql.csproj
@@ -30,10 +30,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Ignixa.Search.Sql.Tests" />
-    <!-- TokenCodeSplitPointGuardTests compares TokenColumnEquality.InlineCodeWidth against what the
-         SqlServer token row generators actually write. The constant stays internal: it is a storage
-         convention this compiler must match, not public API a consumer should depend on. -->
-    <InternalsVisibleTo Include="Ignixa.DataLayer.SqlServer.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Ignixa.Search.Sql/Lowering/Leaf/LeafLoweringDispatcher.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Leaf/LeafLoweringDispatcher.cs
@@ -58,6 +58,7 @@ internal static class LeafLoweringDispatcher
     {
         StringSearchValue s => StringLoweringRule.Lower(predicate, s, context, resourceTypeId),
         TokenSearchValue t => TokenLoweringRule.Lower(predicate, t, context, resourceTypeId),
+        OfTypeTokenSearchValue o => OfTypeLoweringRule.Lower(predicate, o, context, resourceTypeId),
         ReferenceSearchValue r => ReferenceLoweringRule.Lower(predicate, r, context, resourceTypeId),
         UriSearchValue u => UriLoweringRule.Lower(predicate, u, context, resourceTypeId),
         NumberSearchValue n => NumberLoweringRule.Lower(predicate, n, context, resourceTypeId),

--- a/src/Core/Ignixa.Search.Sql/Lowering/Leaf/OfTypeLoweringRule.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Leaf/OfTypeLoweringRule.cs
@@ -1,0 +1,60 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Catalog;
+
+namespace Ignixa.Search.Sql.Lowering.Leaf;
+
+/// <summary>
+/// Lowers an <c>:of-type</c> identifier search to a single ParamSource over TokenSearchParam, conjoining
+/// the identifier value (Code/CodeOverflow) with the Identifier.type code and, when the search names one,
+/// the Identifier.type system.
+/// <para>
+/// One source with conjoined predicates -- not an intersection of three sources -- is the whole point: the
+/// three conditions must hold on the <em>same</em> TokenSearchParam row, because a row is one Identifier.
+/// A patient carrying MR|12345 and SS|67890 satisfies "some row has type SS" and "some row has value 12345"
+/// separately, yet <c>:of-type=…|SS|12345</c> must not match them.
+/// </para>
+/// </summary>
+internal static class OfTypeLoweringRule
+{
+    public static CteDefinition.ParamSource Lower(SearchParameterPredicateExpression predicate, OfTypeTokenSearchValue value, LeafContext context, short? resourceTypeId)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var table = SqlCatalog.Default.Table("TokenSearchParam");
+
+        return new CteDefinition.ParamSource(
+            table,
+            resourceTypeId,
+            context.SearchParamId(predicate.Parameter),
+            BuildPredicate(table, value, context));
+    }
+
+    private static Predicate BuildPredicate(TableDescriptor table, OfTypeTokenSearchValue value, LeafContext context)
+    {
+        var valueEquality = TokenColumnEquality.CodeEquality(table, "Code", "CodeOverflow", value.IdentifierValue, context)
+            ?? throw new NotSupportedException(
+                "An :of-type search carried no identifier value -- a type alone selects every identifier of that type, which is not what the modifier means.");
+
+        Predicate typed = new Predicate.And(
+            new Predicate.Equal(new SqlColumnRef(table.TableName, "IdentifierTypeCode"), context.Parameter(value.TypeCode)),
+            valueEquality);
+
+        // The |code|value form omits the type system deliberately (FHIR allows it), so IdentifierTypeSystemId
+        // goes unconstrained rather than being matched against NULL: rows written before the system was known
+        // carry NULL there and still have the right type code.
+        if (value.TypeSystem is not { Length: > 0 } typeSystem)
+        {
+            return typed;
+        }
+
+        return context.SystemId(typeSystem) is { } typeSystemId
+            ? new Predicate.And(
+                new Predicate.Equal(new SqlColumnRef(table.TableName, "IdentifierTypeSystemId"), context.Parameter(typeSystemId)),
+                typed)
+            : new Predicate.False($"No resource uses the identifier type system '{typeSystem}'.");
+    }
+}

--- a/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Lower.cs
@@ -60,11 +60,16 @@ internal static class Lower
                     "SearchPaging.Offset requires an OffsetSpec. Use SearchPaging.Keyset, or leave Paging null, " +
                     "to compile without an OFFSET/FETCH page.");
 
-            if (offsetPage.Offset < 0 || offsetPage.Limit <= 0)
+            // A zero Limit is legal only alongside a probe row: that is the phase-boundary case where the
+            // whole remaining budget IS the lookahead row (see the two-phase sort executor), and it still
+            // fetches one row.
+            if (offsetPage.Offset < 0 || offsetPage.Limit < 0 || offsetPage.FetchCount <= 0)
             {
                 throw new NotSupportedException(
                     $"OffsetSpec must skip a non-negative row count and fetch a positive one; got Offset " +
-                    $"{offsetPage.Offset} and Limit {offsetPage.Limit}. OFFSET/FETCH rejects both at runtime.");
+                    $"{offsetPage.Offset}, Limit {offsetPage.Limit} and ProbeExtraRow " +
+                    $"{offsetPage.ProbeExtraRow}, fetching {offsetPage.FetchCount}. OFFSET/FETCH rejects " +
+                    $"both at runtime.");
             }
         }
 
@@ -550,7 +555,7 @@ internal static class Lower
 
         if (expression is SearchParameterPredicateExpression predicate)
         {
-            return ResourceColumnLoweringRule.TryLower(predicate, leafContext);
+            return TryLowerResourceColumnPredicate(predicate, leafContext);
         }
 
         if (expression is not MultiaryExpression { MultiaryOperation: MultiaryOperator.Or } or)
@@ -571,6 +576,28 @@ internal static class Lower
         }
 
         return combined;
+    }
+
+    /// <summary>Lowers a single resource-column predicate, rewriting a <c>:not</c>-modified one the way
+    /// <see cref="TryGetNegatedInner"/> rewrites its CTE-path equivalent.</summary>
+    /// <remarks>
+    /// <c>_id:not=a,b</c> reaches <see cref="TryLowerResourceColumn"/> as a NotExpression because
+    /// SearchExpressionBinder.BindAlternatives lifts the modifier off the items it wraps in an Or; a
+    /// single-valued <c>_id:not=a</c> binds through BindAtomic instead, which has no Or to lift onto and so
+    /// leaves the modifier on the predicate. Both spellings mean the same thing, so both must lower to the
+    /// same Predicate.Not. ResourceColumnLoweringRule still rejects every other modifier, since dropping one
+    /// of those would silently widen the match rather than negate it.
+    /// </remarks>
+    private static Predicate? TryLowerResourceColumnPredicate(SearchParameterPredicateExpression predicate, LeafContext leafContext)
+    {
+        if (predicate.Modifier?.SearchModifierCode != SearchModifierCode.Not)
+        {
+            return ResourceColumnLoweringRule.TryLower(predicate, leafContext);
+        }
+
+        var positive = new SearchParameterPredicateExpression(predicate.Parameter, predicate.Comparator, modifier: null, predicate.Value) { Span = predicate.Span };
+        var inner = ResourceColumnLoweringRule.TryLower(positive, leafContext);
+        return inner is null ? null : new Predicate.Not(inner);
     }
 
     /// <summary>Lowers a chain's target expression or a union leg within its own scope, folding any resource-column

--- a/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/StructuralContext.cs
@@ -202,7 +202,10 @@ internal sealed class StructuralContext
                 "Lower.Run's top-level extraction pass (via ResourceColumnLoweringRule) handles these. Guarding here, " +
                 "at the dispatch choke point, covers every caller of Lower/LowerComposite structurally. Throwing " +
                 "rather than routing a resource column into an unrelated table, which would silently produce a " +
-                "wrong-scope or always-empty match.");
+                "wrong-scope or always-empty match. This commonly happens when a resource-column predicate arrives " +
+                "nested inside an And/Or that wasn't flattened before reaching Lower.Run -- e.g. a caller composing " +
+                "And(otherExpression, existingAnd) instead of splicing into existingAnd's own children. Flatten the " +
+                "composed expression before calling Lower.");
         }
     }
 

--- a/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/TokenColumnEquality.cs
@@ -27,7 +27,7 @@ internal static class TokenColumnEquality
             _ => new Predicate.Equal(new SqlColumnRef(table.TableName, systemColumn), context.Parameter(systemId!.Value)),
         };
 
-        Predicate? codePredicate = BuildCodePredicate(table, codeColumn, overflowColumn, value.Code, context);
+        Predicate? codePredicate = CodeEquality(table, codeColumn, overflowColumn, value.Code, context);
 
         return (systemPredicate, codePredicate) switch
         {
@@ -38,7 +38,14 @@ internal static class TokenColumnEquality
         };
     }
 
-    private static Predicate? BuildCodePredicate(TableDescriptor table, string codeColumn, string overflowColumn, string? code, LeafContext context)
+    /// <summary>
+    /// The code half of the equality on its own, for callers that pair it with something other than a token
+    /// system (<c>:of-type</c> pairs it with the identifier type columns). Shared rather than reimplemented
+    /// because the overflow split point is schema-derived: a second copy would be the one that drifts from
+    /// the DDL, and a drifted split silently matches nothing for every overflowing code.
+    /// Returns <see langword="null"/> for an absent code, leaving the pairing to the caller.
+    /// </summary>
+    public static Predicate? CodeEquality(TableDescriptor table, string codeColumn, string overflowColumn, string? code, LeafContext context)
     {
         var column = new SqlColumnRef(table.TableName, codeColumn);
         var overflow = new SqlColumnRef(table.TableName, overflowColumn);

--- a/src/Core/Ignixa.Search.Sql/Symbols/SymbolCollectingVisitor.cs
+++ b/src/Core/Ignixa.Search.Sql/Symbols/SymbolCollectingVisitor.cs
@@ -55,6 +55,14 @@ internal sealed class SymbolCollectingVisitor : ExpressionRewriter<object?>
             TokenSystems.Add(tokenSystem);
         }
 
+        // :of-type's identifier type system is a System-table string too (the writers resolve it through the
+        // same map), but it hangs off OfTypeTokenSearchValue, which is not a TokenSearchValue -- so the arm
+        // above never sees it and lowering would throw KeyNotFoundException on the id lookup.
+        if (expression.Value is OfTypeTokenSearchValue { TypeSystem: { Length: > 0 } identifierTypeSystem })
+        {
+            TokenSystems.Add(identifierTypeSystem);
+        }
+
         if (expression.Value is QuantitySearchValue quantityValue)
         {
             if (quantityValue.System is { Length: > 0 } qSystem)

--- a/src/Core/Ignixa.Search/Expressions/IrProjector.cs
+++ b/src/Core/Ignixa.Search/Expressions/IrProjector.cs
@@ -18,10 +18,10 @@ namespace Ignixa.Search.Expressions;
 /// <see cref="Parsing.ParameterTrace"/>: every traced parse would pay for it, and only a renderer ever
 /// wants it. Callers project <c>trace.Ir</c> at the point they need rows.
 /// <para>
-/// Covers the untyped field-level kinds as well as the typed ones: <c>:text</c> and <c>:of-type</c> bind
-/// through <c>SearchValueExpressionBuilderHelper</c> and so put a bare <see cref="StringExpression"/> or a
-/// multiary of them into a parameter's IR. Those are ordinary FHIR searches, not exotica, so refusing to
-/// project them would make <see cref="Describe"/> throw on real traffic. The remaining field-level kinds
+/// Covers the untyped field-level kinds as well as the typed ones: <c>:text</c> binds through
+/// <c>SearchValueExpressionBuilderHelper</c> and so puts a bare <see cref="StringExpression"/> into a
+/// parameter's IR. That is an ordinary FHIR search, not exotica, so refusing to project it would make
+/// <see cref="Describe"/> throw on real traffic. The remaining field-level kinds
 /// (<see cref="BinaryExpression"/>, <see cref="MissingFieldExpression"/>) have no binder path into a traced
 /// IR — the legacy factories that make them feed the EF query generator, not a parse — so they are left to
 /// the loud <see cref="NotSupportedException"/> arm rather than given tokens nothing can produce.

--- a/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacyExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacyExpressionParser.cs
@@ -301,7 +301,7 @@ public sealed class LegacyExpressionParser : IExpressionParser
 
             if (searchParameter.Type == SearchParamType.Reference && searchParameter.TargetResourceTypes.Contains(modifier, StringComparer.OrdinalIgnoreCase)) return new SearchModifier(SearchModifierCode.Type, modifier);
 
-            throw new InvalidSearchOperationException(
+            throw new SearchModifierNotSupportedException(
                 string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
         }
     }

--- a/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchParameterExpressionParser.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchParameterExpressionParser.cs
@@ -67,7 +67,7 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
         if (modifier?.SearchModifierCode == SearchModifierCode.Text)
         {
             if (searchParameter.Type != SearchParamType.Token)
-                throw new InvalidSearchOperationException(
+                throw new SearchModifierNotSupportedException(
                     string.Format(CultureInfo.InvariantCulture, Resources.ModifierNotSupported, modifier, searchParameter.Code));
 
             outputExpression = Expression.StartsWith(FieldName.TokenText, null, value, true);
@@ -75,7 +75,7 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
         else if (modifier?.SearchModifierCode == SearchModifierCode.OfType)
         {
             if (searchParameter.Type != SearchParamType.Token)
-                throw new InvalidSearchOperationException(
+                throw new SearchModifierNotSupportedException(
                     string.Format(CultureInfo.InvariantCulture, Resources.ModifierNotSupported, modifier, searchParameter.Code));
 
             outputExpression = BuildOfTypeExpression(searchParameter, value);
@@ -85,7 +85,7 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
             if (searchParameter.Type == SearchParamType.Composite)
             {
                 if (modifier != null)
-                    throw new InvalidSearchOperationException(
+                    throw new SearchModifierNotSupportedException(
                         string.Format(CultureInfo.InvariantCulture, Resources.ModifierNotSupported, modifier, searchParameter.Code));
 
                 IReadOnlyList<string> orParts = value.SplitByOrSeparator();
@@ -265,7 +265,7 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
             {
                 if (string.Equals(referenceSearchValue.ResourceType, modifier.ResourceType, StringComparison.OrdinalIgnoreCase)) return source;
 
-                throw new InvalidSearchOperationException(
+                throw new SearchModifierNotSupportedException(
                     string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
             }
 
@@ -279,7 +279,7 @@ public sealed class LegacySearchParameterExpressionParser : ISearchParameterExpr
             }
             catch (ArgumentException)
             {
-                throw new InvalidSearchOperationException(
+                throw new SearchModifierNotSupportedException(
                     string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
             }
         }

--- a/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchValueExpressionBuilderHelper.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/Legacy/LegacySearchValueExpressionBuilderHelper.cs
@@ -295,7 +295,7 @@ internal sealed class LegacySearchValueExpressionBuilderHelper : ISearchValueVis
 
     private void ThrowModifierNotSupported()
     {
-        throw new InvalidSearchOperationException(
+        throw new SearchModifierNotSupportedException(
             string.Format(Resources.ModifierNotSupported, _modifier, _searchParameterName));
     }
 

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchExpressionBinder.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchExpressionBinder.cs
@@ -81,7 +81,7 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
             if (searchParameter.Type != SearchParamType.Token ||
                 syntax is not AtomicValueSyntax text)
             {
-                throw new InvalidSearchOperationException(string.Format(
+                throw new SearchModifierNotSupportedException(string.Format(
                     CultureInfo.InvariantCulture,
                     Resources.ModifierNotSupported,
                     modifier,
@@ -167,7 +167,7 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
     {
         if (searchParameter.Type != SearchParamType.Token)
         {
-            throw new InvalidSearchOperationException(string.Format(
+            throw new SearchModifierNotSupportedException(string.Format(
                 CultureInfo.InvariantCulture,
                 Resources.ModifierNotSupported,
                 SearchModifierCode.OfType.ToString(),
@@ -181,12 +181,16 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
             syntax.IdentifierValue);
         OfTypeTokenSearchValue value = atomicValueParser.ParseOfType(raw);
 
-        return new SearchValueExpressionBuilderHelper().Build(
-            searchParameter.Code,
+        // Keep the typed value rather than flattening it into an AND of field-level StringExpressions. The
+        // flattened form loses the fact that the three conditions describe one Identifier: the SQL backend
+        // lowers an AND by intersecting its children as separate index sources, which would match a resource
+        // holding the type on one identifier and the value on another.
+        return new SearchPredicateExpressionBuilder().Build(
+            searchParameter,
             modifier: null,
             SearchComparator.Eq,
-            componentIndex: null,
-            value);
+            value,
+            syntax.Span);
     }
 
     private Expression BindComposite(
@@ -196,7 +200,7 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
     {
         if (modifier is not null)
         {
-            throw new InvalidSearchOperationException(string.Format(
+            throw new SearchModifierNotSupportedException(string.Format(
                 CultureInfo.InvariantCulture,
                 Resources.ModifierNotSupported,
                 modifier,
@@ -328,9 +332,10 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
 
         // Validate the modifier/comparator against the value type here, at parse time, by running the
         // value through the same builder the SQL backend uses and discarding the result. An unsupported
-        // combination (e.g. a comparator on a string, ':exact' on a date) throws
-        // InvalidSearchOperationException now, inside SearchOptionsBuilder's parse-time catch, so the
-        // parameter is gracefully ignored -- rather than surfacing later as a hard failure during lowering.
+        // combination surfaces now, inside SearchOptionsBuilder's parse-time catch, rather than later as a
+        // hard failure during lowering. An unsupported modifier throws SearchModifierNotSupportedException,
+        // which the builder records separately from an unsupported parameter: R4 says the former SHALL be
+        // rejected while the latter SHOULD be ignored.
         _ = new SearchValueExpressionBuilderHelper().Build(searchParameter.Code, modifier, syntax.Comparator, componentIndex, value);
 
         return new SearchPredicateExpressionBuilder().Build(
@@ -357,7 +362,7 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
                 return reference;
             }
 
-            throw new InvalidSearchOperationException(
+            throw new SearchModifierNotSupportedException(
                 string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
         }
 
@@ -371,7 +376,7 @@ internal sealed class SearchExpressionBinder(SearchAtomicValueParser atomicValue
         }
         catch (ArgumentException)
         {
-            throw new InvalidSearchOperationException(
+            throw new SearchModifierNotSupportedException(
                 string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
         }
     }

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeyBinder.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchKeyBinder.cs
@@ -244,7 +244,7 @@ internal sealed class SearchKeyBinder(ISearchParameterDefinitionManager definiti
             return new SearchModifier(SearchModifierCode.Type, modifier);
         }
 
-        throw new InvalidSearchOperationException(
+        throw new SearchModifierNotSupportedException(
             string.Format(Resources.ModifierNotSupported, modifier, searchParameter.Code));
     }
 

--- a/src/Core/Ignixa.Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Core/Ignixa.Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -335,7 +335,7 @@ internal sealed class SearchValueExpressionBuilderHelper : ISearchValueVisitor
 
     private void ThrowModifierNotSupported()
     {
-        throw new InvalidSearchOperationException(
+        throw new SearchModifierNotSupportedException(
             string.Format(Resources.ModifierNotSupported, _modifier, _searchParameterName));
     }
 

--- a/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using Ignixa.Search.Models;
 
 namespace Ignixa.Search.Indexing;
@@ -62,7 +63,11 @@ public class SearchModifierNotSupportedException : InvalidSearchOperationExcepti
             return;
         }
 
-        throw new SearchModifierNotSupportedException(
-            $"Search parameter(s) use a modifier that is not supported: {string.Join(", ", options.UnsupportedModifierParams)}");
+        var parameterList = string.Join(", ", options.UnsupportedModifierParams.Select(p => $"'{p}'"));
+        var message = string.IsNullOrEmpty(options.ResourceType)
+            ? $"Search parameter(s) use a modifier that is not supported: {parameterList}"
+            : $"Search parameter(s) use a modifier that is not supported for resource type '{options.ResourceType}': {parameterList}";
+
+        throw new SearchModifierNotSupportedException(message);
     }
 }

--- a/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Ignixa.Search.Models;
+
 namespace Ignixa.Search.Indexing;
 
 /// <summary>
@@ -39,5 +41,28 @@ public class SearchModifierNotSupportedException : InvalidSearchOperationExcepti
     public SearchModifierNotSupportedException(string message)
         : base(message)
     {
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="options"/> recorded a client search modifier the server does not
+    /// support for that parameter. Every caller that runs a client-supplied search against the
+    /// compiler -- not just the HTTP search endpoints -- must call this, because <see
+    /// cref="Parsing.SearchOptionsBuilder"/> never throws for this case on its own: it records the
+    /// modifier in <see cref="SearchOptions.UnsupportedModifierParams"/> and keeps building, so a
+    /// caller that skips this check silently executes the widened, unfiltered search instead of the
+    /// SHALL-mandated rejection.
+    /// </summary>
+    /// <param name="options">The options produced by <see cref="Parsing.SearchOptionsBuilder"/>.</param>
+    public static void ThrowIfAny(SearchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.UnsupportedModifierParams.Count == 0)
+        {
+            return;
+        }
+
+        throw new SearchModifierNotSupportedException(
+            $"Search parameter(s) use a modifier that is not supported: {string.Join(", ", options.UnsupportedModifierParams)}");
     }
 }

--- a/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
+++ b/src/Core/Ignixa.Search/Indexing/SearchModifierNotSupportedException.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Ignixa.Search.Indexing;
+
+/// <summary>
+/// Thrown when a search parameter carries a modifier the server does not support for that parameter,
+/// for example <c>_id:above</c> or <c>birthdate:exact</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// FHIR R4 treats this as a different class of failure from an unknown or unsupported search
+/// <i>parameter</i>. For a parameter, the spec says servers "SHOULD ignore unknown or unsupported
+/// parameters" because proxies and HTTP stacks inject parameters the client never sent. For a modifier
+/// it is a SHALL: "Server SHALL reject any search request that ... is suffixed by a modifier that the
+/// server does not support for that parameter ... using an HTTP 400 error with an OperationOutcome with
+/// a clear error message."
+/// </para>
+/// <para>
+/// The distinction matters because the two failure modes are not equally recoverable. Dropping an
+/// unrecognised parameter narrows nothing the client asked for, and the self link tells them what was
+/// used. Dropping a modifier silently <i>widens</i> the result set — <c>_id:above=abc</c> becomes an
+/// unfiltered search — and a client reading only the entry list cannot distinguish "no filter applied"
+/// from "filter applied, everything matched".
+/// </para>
+/// <para>
+/// Deriving from <see cref="InvalidSearchOperationException"/> keeps every existing handler that catches
+/// the base type working unchanged; callers that want the stricter treatment catch this type first.
+/// </para>
+/// </remarks>
+public class SearchModifierNotSupportedException : InvalidSearchOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchModifierNotSupportedException"/> class.
+    /// </summary>
+    /// <param name="message">The message describing the unsupported modifier and parameter.</param>
+    public SearchModifierNotSupportedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Core/Ignixa.Search/Models/SearchOptions.cs
+++ b/src/Core/Ignixa.Search/Models/SearchOptions.cs
@@ -46,6 +46,7 @@ public sealed class SearchOptions
         ArgumentNullException.ThrowIfNull(other);
 
         MaxItemCount = other.MaxItemCount;
+        ProbeExtraRow = other.ProbeExtraRow;
         ContinuationToken = other.ContinuationToken;
         Expression = other.Expression;
         Sort = other.Sort;
@@ -55,6 +56,7 @@ public sealed class SearchOptions
         Total = other.Total;
         Summary = other.Summary;
         UnsupportedParams = other.UnsupportedParams;
+        UnsupportedModifierParams = other.UnsupportedModifierParams;
         BundleIssues = other.BundleIssues;
         ResourceType = other.ResourceType;
         ResourceTypes = other.ResourceTypes;
@@ -71,6 +73,23 @@ public sealed class SearchOptions
     /// Gets or sets the maximum number of items to return per page.
     /// </summary>
     public int MaxItemCount { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets whether the data layer should fetch one row beyond <see cref="MaxItemCount"/> so the
+    /// caller can detect a further page. That row is a lookahead the caller trims, never a member of the
+    /// page.
+    /// </summary>
+    /// <remarks>
+    /// The flag exists because the data layer cannot otherwise tell a page of N apart from a page of N-1
+    /// plus a probe row: both arrive as a single <see cref="MaxItemCount"/>. It used to guess, by assuming
+    /// every caller had pre-added the +1 and subtracting it back off — which was true of the paged search
+    /// handler and of nobody else, so $includes, $export, IPS, $everything, member-match and the
+    /// conditional handlers all silently lost a row's worth of page. Guessing wrong is not merely an
+    /// off-by-one in the row count: the guessed page size is what seeds <c>_include</c>/<c>_revinclude</c>
+    /// resolution, so an under-guess strands the last match row's included resources outside the bundle,
+    /// and an over-guess pulls in resources for a match row the caller is about to trim.
+    /// </remarks>
+    public bool ProbeExtraRow { get; set; }
 
     /// <summary>
     /// Gets or sets the continuation token for paging.
@@ -116,6 +135,20 @@ public sealed class SearchOptions
     /// Gets or sets any unsupported search parameters encountered.
     /// </summary>
     public IReadOnlyList<string> UnsupportedParams { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets the search parameters that carried a modifier this server does not support for them,
+    /// for example <c>_id:above</c>. Always a subset of <see cref="UnsupportedParams"/>.
+    /// </summary>
+    /// <remarks>
+    /// Tracked apart from <see cref="UnsupportedParams"/> because FHIR R4 gives the two cases different
+    /// force: an unknown or unsupported <i>parameter</i> SHOULD be ignored, whereas a request suffixed by
+    /// an unsupported <i>modifier</i> SHALL be rejected with a 400. Both are dropped from
+    /// <see cref="Expression"/> either way, so a caller that chooses to honour <c>handling=lenient</c> can
+    /// keep serving the query; the list exists so the HTTP boundary can apply the stricter default without
+    /// this layer having to know about headers.
+    /// </remarks>
+    public IReadOnlyList<string> UnsupportedModifierParams { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Gets or sets issues related to the search (e.g., unsupported parameters).

--- a/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
+++ b/src/Core/Ignixa.Search/Parsing/SearchOptionsBuilder.cs
@@ -77,6 +77,7 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
         var revIncludeParameters = new List<(string ParameterName, string Value)>();
         var elementsParameters = new List<string>();
         var unsupportedParameters = new List<string>();
+        var unsupportedModifierParameters = new List<string>();
         var typeFilterParameters = new List<string>();
 
         // For system-wide search (resourceType is null), we need to first extract _type parameters
@@ -251,6 +252,28 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
                         dataType: null));
                 }
             }
+            catch (SearchModifierNotSupportedException ex)
+            {
+                // R4 splits these two catches apart deliberately. An unsupported *parameter* SHOULD be
+                // ignored; a request suffixed by an unsupported *modifier* SHALL be rejected. Both are
+                // dropped from the expression here so a caller honouring handling=lenient can still serve
+                // the query, but the modifier case is also listed separately so the HTTP boundary can
+                // apply the stricter default.
+                unsupportedParameters.Add(param.Name);
+                unsupportedModifierParameters.Add(param.Name);
+                if (outcomes is not null && param.Category == ParameterCategory.Search)
+                {
+                    outcomes.Add(new ParameterTrace(
+                        ordinal: searchOrdinal++,
+                        key: param.Name,
+                        keySyntax: null,
+                        value: param.Value,
+                        valueSyntax: null,
+                        ir: null,
+                        outcome: new ParameterOutcome.Ignored(ex.Message, null),
+                        dataType: null));
+                }
+            }
             catch (InvalidSearchOperationException ex)
             {
                 unsupportedParameters.Add(param.Name);
@@ -362,6 +385,7 @@ public class SearchOptionsBuilder : ISearchOptionsBuilder
 
         // STEP 8: Record unsupported parameters and create Bundle issues
         options.UnsupportedParams = unsupportedParameters;
+        options.UnsupportedModifierParams = unsupportedModifierParameters;
         foreach (var param in unsupportedParameters)
         {
             var diagnostics = $"Search parameter '{param}' is not supported";

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/BackgroundJobs.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/BackgroundJobs.sql
@@ -1,0 +1,44 @@
+CREATE TABLE dbo.BackgroundJobs (
+    TenantId                INT             NOT NULL,
+    JobId                   NVARCHAR (36)   NOT NULL,
+    JobType                 INT             NOT NULL,
+    OrchestrationInstanceId NVARCHAR (100)  NULL,
+    Status                  NVARCHAR (20)   NOT NULL,
+    Definition              NVARCHAR (MAX)  NOT NULL,
+    Progress                NVARCHAR (MAX)  NULL,
+    Result                  NVARCHAR (MAX)  NULL,
+    CreateDate              DATETIMEOFFSET  NOT NULL,
+    StartDate               DATETIMEOFFSET  NULL,
+    EndDate                 DATETIMEOFFSET  NULL,
+    HeartbeatDate           DATETIMEOFFSET  NOT NULL,
+    Worker                  NVARCHAR (256)  NULL,
+    ErrorMessage            NVARCHAR (1000) NULL,
+    CancelRequested         BIT             NOT NULL,
+    CONSTRAINT PK_BackgroundJobs PRIMARY KEY (TenantId, JobId)
+);
+
+GO
+
+CREATE INDEX IX_BackgroundJobs_CreateDate
+    ON dbo.BackgroundJobs(CreateDate);
+
+GO
+
+CREATE INDEX IX_BackgroundJobs_HeartbeatDate
+    ON dbo.BackgroundJobs(HeartbeatDate);
+
+GO
+
+CREATE INDEX IX_BackgroundJobs_OrchestrationInstanceId
+    ON dbo.BackgroundJobs(OrchestrationInstanceId)
+    WHERE OrchestrationInstanceId IS NOT NULL;
+
+GO
+
+CREATE INDEX IX_BackgroundJobs_TenantId_JobType
+    ON dbo.BackgroundJobs(TenantId, JobType);
+
+GO
+
+CREATE INDEX IX_BackgroundJobs_TenantId_Status
+    ON dbo.BackgroundJobs(TenantId, Status);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ClaimType.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ClaimType.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.ClaimType (
+    ClaimTypeId TINYINT       IDENTITY (1, 1) NOT NULL,
+    Name        VARCHAR (128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CONSTRAINT UQ_ClaimType_ClaimTypeId UNIQUE (ClaimTypeId),
+    CONSTRAINT PKC_ClaimType PRIMARY KEY CLUSTERED (Name) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/CompartmentAssignment.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/CompartmentAssignment.sql
@@ -1,0 +1,23 @@
+CREATE TABLE dbo.CompartmentAssignment (
+    ResourceTypeId      SMALLINT     NOT NULL,
+    ResourceSurrogateId BIGINT       NOT NULL,
+    CompartmentTypeId   TINYINT      NOT NULL,
+    ReferenceResourceId VARCHAR (64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory           BIT          NOT NULL,
+    CONSTRAINT PKC_CompartmentAssignment PRIMARY KEY CLUSTERED (ResourceTypeId, ResourceSurrogateId, CompartmentTypeId, ReferenceResourceId) WITH (DATA_COMPRESSION = PAGE) ON PartitionScheme_ResourceTypeId (ResourceTypeId)
+);
+
+GO
+
+ALTER TABLE dbo.CompartmentAssignment
+    ADD CONSTRAINT DF_CompartmentAssignment_IsHistory DEFAULT 0 FOR IsHistory;
+
+GO
+
+ALTER TABLE dbo.CompartmentAssignment SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE NONCLUSTERED INDEX IX_CompartmentAssignment_CompartmentTypeId_ReferenceResourceId
+    ON dbo.CompartmentAssignment(ResourceTypeId, CompartmentTypeId, ReferenceResourceId, ResourceSurrogateId) WHERE IsHistory = 0 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/CompartmentType.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/CompartmentType.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.CompartmentType (
+    CompartmentTypeId TINYINT       IDENTITY (1, 1) NOT NULL,
+    Name              VARCHAR (128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CONSTRAINT UQ_CompartmentType_CompartmentTypeId UNIQUE (CompartmentTypeId),
+    CONSTRAINT PKC_CompartmentType PRIMARY KEY CLUSTERED (Name) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/DateTimeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/DateTimeSearchParam.sql
@@ -1,0 +1,48 @@
+CREATE TABLE dbo.DateTimeSearchParam (
+    ResourceTypeId      SMALLINT      NOT NULL,
+    ResourceSurrogateId BIGINT        NOT NULL,
+    SearchParamId       SMALLINT      NOT NULL,
+    StartDateTime       DATETIME2 (7) NOT NULL,
+    EndDateTime         DATETIME2 (7) NOT NULL,
+    IsLongerThanADay    BIT           NOT NULL,
+    IsMin               BIT           CONSTRAINT date_IsMin_Constraint DEFAULT 0 NOT NULL,
+    IsMax               BIT           CONSTRAINT date_IsMax_Constraint DEFAULT 0 NOT NULL
+);
+
+GO
+
+ALTER TABLE dbo.DateTimeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_DateTimeSearchParam
+    ON dbo.DateTimeSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_StartDateTime_EndDateTime_INCLUDE_IsLongerThanADay_IsMin_IsMax
+    ON dbo.DateTimeSearchParam(SearchParamId, StartDateTime, EndDateTime)
+    INCLUDE(IsLongerThanADay, IsMin, IsMax)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_EndDateTime_StartDateTime_INCLUDE_IsLongerThanADay_IsMin_IsMax
+    ON dbo.DateTimeSearchParam(SearchParamId, EndDateTime, StartDateTime)
+    INCLUDE(IsLongerThanADay, IsMin, IsMax)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_StartDateTime_EndDateTime_INCLUDE_IsMin_IsMax_WHERE_IsLongerThanADay_1
+    ON dbo.DateTimeSearchParam(SearchParamId, StartDateTime, EndDateTime)
+    INCLUDE(IsMin, IsMax) WHERE IsLongerThanADay = 1
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_EndDateTime_StartDateTime_INCLUDE_IsMin_IsMax_WHERE_IsLongerThanADay_1
+    ON dbo.DateTimeSearchParam(SearchParamId, EndDateTime, StartDateTime)
+    INCLUDE(IsMin, IsMax) WHERE IsLongerThanADay = 1
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/EventAgentCheckpoint.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/EventAgentCheckpoint.sql
@@ -1,0 +1,7 @@
+CREATE TABLE dbo.EventAgentCheckpoint (
+    CheckpointId            VARCHAR (64)       NOT NULL,
+    LastProcessedDateTime   DATETIMEOFFSET (7),
+    LastProcessedIdentifier VARCHAR (64)      ,
+    UpdatedOn               DATETIME2 (7)      DEFAULT sysutcdatetime() NOT NULL,
+    CONSTRAINT PK_EventAgentCheckpoint PRIMARY KEY CLUSTERED (CheckpointId)
+) ON [PRIMARY];

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/EventLog.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/EventLog.sql
@@ -1,0 +1,15 @@
+CREATE TABLE dbo.EventLog (
+    PartitionId  AS              isnull(CONVERT (TINYINT, EventId % 8), 0) PERSISTED,
+    EventId      BIGINT          IDENTITY (1, 1) NOT NULL,
+    EventDate    DATETIME        NOT NULL,
+    Process      VARCHAR (100)   NOT NULL,
+    Status       VARCHAR (10)    NOT NULL,
+    Mode         VARCHAR (200)   NULL,
+    Action       VARCHAR (20)    NULL,
+    Target       VARCHAR (100)   NULL,
+    Rows         BIGINT          NULL,
+    Milliseconds INT             NULL,
+    EventText    NVARCHAR (3500) NULL,
+    SPID         SMALLINT        NOT NULL,
+    HostName     VARCHAR (64)    NOT NULL CONSTRAINT PKC_EventLog_EventDate_EventId_PartitionId PRIMARY KEY CLUSTERED (EventDate, EventId, PartitionId) ON EventLogPartitionScheme (PartitionId)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/IndexProperties.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/IndexProperties.sql
@@ -1,0 +1,7 @@
+CREATE TABLE dbo.IndexProperties (
+    TableName     VARCHAR (100) NOT NULL,
+    IndexName     VARCHAR (200) NOT NULL,
+    PropertyName  VARCHAR (100) NOT NULL,
+    PropertyValue VARCHAR (100) NOT NULL,
+    CreateDate    DATETIME      CONSTRAINT DF_IndexProperties_CreateDate DEFAULT getUTCdate() NOT NULL CONSTRAINT PKC_IndexProperties_TableName_IndexName_PropertyName PRIMARY KEY CLUSTERED (TableName, IndexName, PropertyName)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/JobQueue.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/JobQueue.sql
@@ -1,0 +1,39 @@
+CREATE TABLE dbo.JobQueue (
+    QueueType       TINYINT        NOT NULL,
+    GroupId         BIGINT         NOT NULL,
+    JobId           BIGINT         NOT NULL,
+    PartitionId     AS             CONVERT (TINYINT, JobId % 16) PERSISTED,
+    Definition      VARCHAR (MAX)  NOT NULL,
+    DefinitionHash  VARBINARY (20) NOT NULL,
+    Version         BIGINT         CONSTRAINT DF_JobQueue_Version DEFAULT datediff_big(millisecond, '0001-01-01', getUTCdate()) NOT NULL,
+    Status          TINYINT        CONSTRAINT DF_JobQueue_Status DEFAULT 0 NOT NULL,
+    Priority        TINYINT        CONSTRAINT DF_JobQueue_Priority DEFAULT 100 NOT NULL,
+    Data            BIGINT         NULL,
+    Result          VARCHAR (MAX)  NULL,
+    CreateDate      DATETIME       CONSTRAINT DF_JobQueue_CreateDate DEFAULT getUTCdate() NOT NULL,
+    StartDate       DATETIME       NULL,
+    EndDate         DATETIME       NULL,
+    HeartbeatDate   DATETIME       CONSTRAINT DF_JobQueue_HeartbeatDate DEFAULT getUTCdate() NOT NULL,
+    Worker          VARCHAR (100)  NULL,
+    Info            VARCHAR (1000) NULL,
+    CancelRequested BIT            CONSTRAINT DF_JobQueue_CancelRequested DEFAULT 0 NOT NULL CONSTRAINT PKC_JobQueue_QueueType_PartitionId_JobId PRIMARY KEY CLUSTERED (QueueType, PartitionId, JobId) ON TinyintPartitionScheme (QueueType),
+    CONSTRAINT U_JobQueue_QueueType_JobId UNIQUE (QueueType, JobId)
+);
+
+GO
+
+CREATE INDEX IX_QueueType_PartitionId_Status_Priority
+    ON dbo.JobQueue(PartitionId, Status, Priority)
+    ON TinyintPartitionScheme (QueueType);
+
+GO
+
+CREATE INDEX IX_QueueType_GroupId
+    ON dbo.JobQueue(QueueType, GroupId)
+    ON TinyintPartitionScheme (QueueType);
+
+GO
+
+CREATE INDEX IX_QueueType_DefinitionHash
+    ON dbo.JobQueue(QueueType, DefinitionHash)
+    ON TinyintPartitionScheme (QueueType);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/NumberSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/NumberSearchParam.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dbo.NumberSearchParam (
+    ResourceTypeId      SMALLINT         NOT NULL,
+    ResourceSurrogateId BIGINT           NOT NULL,
+    SearchParamId       SMALLINT         NOT NULL,
+    SingleValue         DECIMAL (36, 18) NULL,
+    LowValue            DECIMAL (36, 18) NOT NULL,
+    HighValue           DECIMAL (36, 18) NOT NULL
+);
+
+GO
+
+ALTER TABLE dbo.NumberSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_NumberSearchParam
+    ON dbo.NumberSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_SingleValue_WHERE_SingleValue_NOT_NULL
+    ON dbo.NumberSearchParam(SearchParamId, SingleValue) WHERE SingleValue IS NOT NULL
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_LowValue_HighValue
+    ON dbo.NumberSearchParam(SearchParamId, LowValue, HighValue)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_HighValue_LowValue
+    ON dbo.NumberSearchParam(SearchParamId, HighValue, LowValue)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/PackageResource.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/PackageResource.sql
@@ -1,0 +1,47 @@
+CREATE TABLE dbo.PackageResource (
+    PackageResourceId       BIGINT         NOT NULL IDENTITY (1, 1),
+    PackageId                NVARCHAR (256) NOT NULL,
+    PackageVersion           NVARCHAR (100) NOT NULL,
+    ResourceType             NVARCHAR (64)  NOT NULL,
+    Canonical                NVARCHAR (512) NOT NULL,
+    Version                  NVARCHAR (100) NULL,
+    ResourceId               NVARCHAR (64)  NOT NULL,
+    ResourceJson             NVARCHAR (MAX) NOT NULL,
+    FhirVersion              NVARCHAR (10)  NOT NULL,
+    LoadedDate               DATETIMEOFFSET DEFAULT getUTCdate() NOT NULL,
+    IsActive                 BIT            DEFAULT 1 NOT NULL,
+    ContentHash              NVARCHAR (64)   NULL,
+    ImportCompletedDate      DATETIMEOFFSET  NULL,
+    ImportErrorMessage       NVARCHAR (1000) NULL,
+    ImportStartDate          DATETIMEOFFSET  NULL,
+    ImportedConceptCount     INT             NULL,
+    TerminologyImportStatus  NVARCHAR (20)   NULL,
+    CONSTRAINT PK_PackageResource PRIMARY KEY (PackageResourceId)
+);
+
+GO
+
+CREATE UNIQUE INDEX UQ_PackageResource_Identity
+    ON dbo.PackageResource(PackageId, PackageVersion, ResourceType, ResourceId);
+
+GO
+
+CREATE INDEX IX_PackageResource_Canonical_Version
+    ON dbo.PackageResource(Canonical, Version)
+    WHERE IsActive = 1;
+
+GO
+
+CREATE INDEX IX_PackageResource_ResourceType_Canonical
+    ON dbo.PackageResource(ResourceType, Canonical)
+    WHERE IsActive = 1;
+
+GO
+
+CREATE INDEX IX_PackageResource_Package
+    ON dbo.PackageResource(PackageId, PackageVersion);
+
+GO
+
+CREATE INDEX IX_PackageResource_LoadedDate
+    ON dbo.PackageResource(LoadedDate);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Parameters.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Parameters.sql
@@ -1,0 +1,10 @@
+CREATE TABLE dbo.Parameters (
+    Id          VARCHAR (100)   NOT NULL,
+    Date        DATETIME        NULL,
+    Number      FLOAT           NULL,
+    Bigint      BIGINT          NULL,
+    Char        VARCHAR (4000)  NULL,
+    Binary      VARBINARY (MAX) NULL,
+    UpdatedDate DATETIME        NULL,
+    UpdatedBy   NVARCHAR (255)  NULL CONSTRAINT PKC_Parameters_Id PRIMARY KEY CLUSTERED (Id) WITH (IGNORE_DUP_KEY = ON)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ParametersHistory.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ParametersHistory.sql
@@ -1,0 +1,11 @@
+CREATE TABLE dbo.ParametersHistory (
+    ChangeId    INT             IDENTITY (1, 1) NOT NULL,
+    Id          VARCHAR (100)   NOT NULL,
+    Date        DATETIME        NULL,
+    Number      FLOAT           NULL,
+    Bigint      BIGINT          NULL,
+    Char        VARCHAR (4000)  NULL,
+    Binary      VARBINARY (MAX) NULL,
+    UpdatedDate DATETIME        NULL,
+    UpdatedBy   NVARCHAR (255)  NULL
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/QuantityCode.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/QuantityCode.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.QuantityCode (
+    QuantityCodeId INT            IDENTITY (1, 1) NOT NULL,
+    Value          NVARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CONSTRAINT UQ_QuantityCode_QuantityCodeId UNIQUE (QuantityCodeId),
+    CONSTRAINT PKC_QuantityCode PRIMARY KEY CLUSTERED (Value) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/QuantitySearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/QuantitySearchParam.sql
@@ -1,0 +1,41 @@
+CREATE TABLE dbo.QuantitySearchParam (
+    ResourceTypeId      SMALLINT         NOT NULL,
+    ResourceSurrogateId BIGINT           NOT NULL,
+    SearchParamId       SMALLINT         NOT NULL,
+    SystemId            INT              NULL,
+    QuantityCodeId      INT              NULL,
+    SingleValue         DECIMAL (36, 18) NULL,
+    LowValue            DECIMAL (36, 18) NOT NULL,
+    HighValue           DECIMAL (36, 18) NOT NULL
+);
+
+GO
+
+ALTER TABLE dbo.QuantitySearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_QuantitySearchParam
+    ON dbo.QuantitySearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_QuantityCodeId_SingleValue_INCLUDE_SystemId_WHERE_SingleValue_NOT_NULL
+    ON dbo.QuantitySearchParam(SearchParamId, QuantityCodeId, SingleValue)
+    INCLUDE(SystemId) WHERE SingleValue IS NOT NULL
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_QuantityCodeId_LowValue_HighValue_INCLUDE_SystemId
+    ON dbo.QuantitySearchParam(SearchParamId, QuantityCodeId, LowValue, HighValue)
+    INCLUDE(SystemId)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_QuantityCodeId_HighValue_LowValue_INCLUDE_SystemId
+    ON dbo.QuantitySearchParam(SearchParamId, QuantityCodeId, HighValue, LowValue)
+    INCLUDE(SystemId)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReferenceSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReferenceSearchParam.sql
@@ -1,0 +1,25 @@
+CREATE TABLE dbo.ReferenceSearchParam (
+    ResourceTypeId           SMALLINT      NOT NULL,
+    ResourceSurrogateId      BIGINT        NOT NULL,
+    SearchParamId            SMALLINT      NOT NULL,
+    BaseUri                  VARCHAR (128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId  SMALLINT      NULL,
+    ReferenceResourceId      VARCHAR (64)  COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion INT           NULL
+);
+
+GO
+
+ALTER TABLE dbo.ReferenceSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_ReferenceSearchParam
+    ON dbo.ReferenceSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE UNIQUE INDEX IXU_ReferenceResourceId_ReferenceResourceTypeId_SearchParamId_BaseUri_ResourceSurrogateId_ResourceTypeId
+    ON dbo.ReferenceSearchParam(ReferenceResourceId, ReferenceResourceTypeId, SearchParamId, BaseUri, ResourceSurrogateId, ResourceTypeId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReferenceTokenCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReferenceTokenCompositeSearchParam.sql
@@ -1,0 +1,29 @@
+CREATE TABLE dbo.ReferenceTokenCompositeSearchParam (
+    ResourceTypeId            SMALLINT      NOT NULL,
+    ResourceSurrogateId       BIGINT        NOT NULL,
+    SearchParamId             SMALLINT      NOT NULL,
+    BaseUri1                  VARCHAR (128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId1  SMALLINT      NULL,
+    ReferenceResourceId1      VARCHAR (64)  COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion1 INT           NULL,
+    SystemId2                 INT           NULL,
+    Code2                     VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CodeOverflow2             VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.ReferenceTokenCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_ReferenceTokenCompositeSearchParam
+    ON dbo.ReferenceTokenCompositeSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_ReferenceResourceId1_Code2_INCLUDE_ReferenceResourceTypeId1_BaseUri1_SystemId2
+    ON dbo.ReferenceTokenCompositeSearchParam(SearchParamId, ReferenceResourceId1, Code2)
+    INCLUDE(ReferenceResourceTypeId1, BaseUri1, SystemId2) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReindexJob.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReindexJob.sql
@@ -1,0 +1,8 @@
+CREATE TABLE dbo.ReindexJob (
+    Id                VARCHAR (64)  COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Status            VARCHAR (10)  NOT NULL,
+    HeartbeatDateTime DATETIME2 (7) NULL,
+    RawJobRecord      VARCHAR (MAX) NOT NULL,
+    JobVersion        ROWVERSION    NOT NULL,
+    CONSTRAINT PKC_ReindexJob PRIMARY KEY CLUSTERED (Id)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Resource.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Resource.sql
@@ -1,0 +1,51 @@
+CREATE TABLE dbo.Resource (
+    ResourceTypeId       SMALLINT        NOT NULL,
+    ResourceId           VARCHAR (64)    COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Version              INT             NOT NULL,
+    IsHistory            BIT             NOT NULL,
+    ResourceSurrogateId  BIGINT          NOT NULL,
+    IsDeleted            BIT             NOT NULL,
+    RequestMethod        VARCHAR (10)    NULL,
+    RawResource          VARBINARY (MAX) NOT NULL,
+    IsRawResourceMetaSet BIT             DEFAULT 0 NOT NULL,
+    SearchParamHash      VARCHAR (64)    NULL,
+    TransactionId        BIGINT          NULL,
+    HistoryTransactionId BIGINT          NULL CONSTRAINT PKC_Resource PRIMARY KEY CLUSTERED (ResourceTypeId, ResourceSurrogateId) WITH (DATA_COMPRESSION = PAGE) ON PartitionScheme_ResourceTypeId (ResourceTypeId),
+    CONSTRAINT CH_Resource_RawResource_Length CHECK (RawResource > 0x0)
+);
+
+GO
+
+ALTER TABLE dbo.Resource SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE INDEX IX_ResourceTypeId_TransactionId
+    ON dbo.Resource(ResourceTypeId, TransactionId) WHERE TransactionId IS NOT NULL
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_ResourceTypeId_HistoryTransactionId
+    ON dbo.Resource(ResourceTypeId, HistoryTransactionId) WHERE HistoryTransactionId IS NOT NULL
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceId_Version
+    ON dbo.Resource(ResourceTypeId, ResourceId, Version)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceId
+    ON dbo.Resource(ResourceTypeId, ResourceId)
+    INCLUDE(Version, IsDeleted) WHERE IsHistory = 0
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceSurrgateId
+    ON dbo.Resource(ResourceTypeId, ResourceSurrogateId) WHERE IsHistory = 0
+                                                               AND IsDeleted = 0
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeData.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeData.sql
@@ -1,0 +1,14 @@
+CREATE TABLE dbo.ResourceChangeData (
+    Id                   BIGINT        IDENTITY (1, 1) NOT NULL,
+    Timestamp            DATETIME2 (7) CONSTRAINT DF_ResourceChangeData_Timestamp DEFAULT sysutcdatetime() NOT NULL,
+    ResourceId           VARCHAR (64)  NOT NULL,
+    ResourceTypeId       SMALLINT      NOT NULL,
+    ResourceVersion      INT           NOT NULL,
+    ResourceChangeTypeId TINYINT       NOT NULL
+) ON PartitionScheme_ResourceChangeData_Timestamp (Timestamp);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_ResourceChangeData
+    ON dbo.ResourceChangeData(Id ASC) WITH (ONLINE = ON)
+    ON PartitionScheme_ResourceChangeData_Timestamp (Timestamp);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeDataStaging.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeDataStaging.sql
@@ -1,0 +1,23 @@
+CREATE TABLE dbo.ResourceChangeDataStaging (
+    Id                   BIGINT        IDENTITY (1, 1) NOT NULL,
+    Timestamp            DATETIME2 (7) CONSTRAINT DF_ResourceChangeDataStaging_Timestamp DEFAULT sysutcdatetime() NOT NULL,
+    ResourceId           VARCHAR (64)  NOT NULL,
+    ResourceTypeId       SMALLINT      NOT NULL,
+    ResourceVersion      INT           NOT NULL,
+    ResourceChangeTypeId TINYINT       NOT NULL
+) ON [PRIMARY];
+
+GO
+
+CREATE CLUSTERED INDEX IXC_ResourceChangeDataStaging
+    ON dbo.ResourceChangeDataStaging(Id ASC, Timestamp ASC) WITH (ONLINE = ON)
+    ON [PRIMARY];
+
+GO
+
+ALTER TABLE dbo.ResourceChangeDataStaging WITH CHECK
+    ADD CONSTRAINT CHK_ResourceChangeDataStaging_partition CHECK (Timestamp < CONVERT (DATETIME2 (7), N'9999-12-31 23:59:59.9999999'));
+
+GO
+
+ALTER TABLE dbo.ResourceChangeDataStaging CHECK CONSTRAINT CHK_ResourceChangeDataStaging_partition;

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeType.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceChangeType.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.ResourceChangeType (
+    ResourceChangeTypeId TINYINT       NOT NULL,
+    Name                 NVARCHAR (50) NOT NULL,
+    CONSTRAINT PK_ResourceChangeType PRIMARY KEY CLUSTERED (ResourceChangeTypeId),
+    CONSTRAINT UQ_ResourceChangeType_Name UNIQUE NONCLUSTERED (Name)
+) ON [PRIMARY];

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceTtl.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceTtl.sql
@@ -1,0 +1,12 @@
+CREATE TABLE dbo.ResourceTtl (
+    ResourceTypeId SMALLINT      NOT NULL,
+    ResourceId     VARCHAR (64)  COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ExpiresAt      DATETIMEOFFSET NOT NULL,
+    TransactionId  BIGINT        NULL,
+    CONSTRAINT PK_ResourceTtl PRIMARY KEY (ResourceTypeId, ResourceId)
+);
+
+GO
+
+CREATE INDEX IX_ResourceTtl_ExpiresAt
+    ON dbo.ResourceTtl(ExpiresAt);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceType.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceType.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.ResourceType (
+    ResourceTypeId SMALLINT      IDENTITY (1, 1) NOT NULL,
+    Name           NVARCHAR (50) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CONSTRAINT UQ_ResourceType_ResourceTypeId UNIQUE (ResourceTypeId),
+    CONSTRAINT PKC_ResourceType PRIMARY KEY CLUSTERED (Name) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceWriteClaim.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceWriteClaim.sql
@@ -1,0 +1,10 @@
+CREATE TABLE dbo.ResourceWriteClaim (
+    ResourceSurrogateId BIGINT         NOT NULL,
+    ClaimTypeId         TINYINT        NOT NULL,
+    ClaimValue          NVARCHAR (128) NOT NULL
+);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_ResourceWriteClaim
+    ON dbo.ResourceWriteClaim(ResourceSurrogateId, ClaimTypeId) WITH (DATA_COMPRESSION = PAGE);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SchemaMigrationProgress.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SchemaMigrationProgress.sql
@@ -1,0 +1,4 @@
+CREATE TABLE dbo.SchemaMigrationProgress (
+    Timestamp DATETIME2 (3)  DEFAULT CURRENT_TIMESTAMP,
+    Message   NVARCHAR (MAX)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SchemaVersion.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SchemaVersion.sql
@@ -1,0 +1,5 @@
+CREATE TABLE dbo.SchemaVersion (
+    Version   INT             NOT NULL,
+    AppliedAt DATETIMEOFFSET  NOT NULL DEFAULT sysutcdatetime(),
+    CONSTRAINT PK_SchemaVersion PRIMARY KEY (Version)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SearchParam.sql
@@ -1,0 +1,9 @@
+CREATE TABLE dbo.SearchParam (
+    SearchParamId        SMALLINT           IDENTITY (1, 1) NOT NULL,
+    Uri                  VARCHAR (128)      COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Status               VARCHAR (20)       NOT NULL,
+    LastUpdated          DATETIMEOFFSET (7) NOT NULL,
+    IsPartiallySupported BIT                NOT NULL,
+    CONSTRAINT UQ_SearchParam_SearchParamId UNIQUE (SearchParamId),
+    CONSTRAINT PKC_SearchParam PRIMARY KEY CLUSTERED (Uri) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SourceEvents.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SourceEvents.sql
@@ -1,0 +1,24 @@
+CREATE TABLE dbo.SourceEvents (
+    EventId       BIGINT         NOT NULL IDENTITY (1, 1),
+    StreamId      NVARCHAR (256) NOT NULL,
+    EventType     NVARCHAR (100) NOT NULL,
+    EventData     NVARCHAR (MAX) NOT NULL,
+    Timestamp     DATETIMEOFFSET DEFAULT sysutcdatetime() NOT NULL,
+    TransactionId BIGINT         DEFAULT 0 NOT NULL,
+    CONSTRAINT PK_SourceEvents PRIMARY KEY (EventId)
+);
+
+GO
+
+CREATE INDEX IX_SourceEvents_StreamId_EventId
+    ON dbo.SourceEvents(StreamId, EventId);
+
+GO
+
+CREATE INDEX IX_SourceEvents_EventId
+    ON dbo.SourceEvents(EventId);
+
+GO
+
+CREATE INDEX IX_SourceEvents_TransactionId
+    ON dbo.SourceEvents(TransactionId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/StringSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/StringSearchParam.sql
@@ -1,0 +1,33 @@
+CREATE TABLE dbo.StringSearchParam (
+    ResourceTypeId      SMALLINT       NOT NULL,
+    ResourceSurrogateId BIGINT         NOT NULL,
+    SearchParamId       SMALLINT       NOT NULL,
+    Text                NVARCHAR (256) COLLATE Latin1_General_100_CI_AI_SC NOT NULL,
+    TextOverflow        NVARCHAR (MAX) COLLATE Latin1_General_100_CI_AI_SC NULL,
+    IsMin               BIT            CONSTRAINT string_IsMin_Constraint DEFAULT 0 NOT NULL,
+    IsMax               BIT            CONSTRAINT string_IsMax_Constraint DEFAULT 0 NOT NULL
+);
+
+GO
+
+ALTER TABLE dbo.StringSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_StringSearchParam
+    ON dbo.StringSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Text_INCLUDE_TextOverflow_IsMin_IsMax
+    ON dbo.StringSearchParam(SearchParamId, Text)
+    INCLUDE(TextOverflow, IsMin, IsMax) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Text_INCLUDE_IsMin_IsMax_WHERE_TextOverflow_NOT_NULL
+    ON dbo.StringSearchParam(SearchParamId, Text)
+    INCLUDE(IsMin, IsMax) WHERE TextOverflow IS NOT NULL WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/System.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/System.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dbo.System (
+    SystemId INT            IDENTITY (1, 1) NOT NULL,
+    Value    NVARCHAR (256) NOT NULL,
+    CONSTRAINT UQ_System_SystemId UNIQUE (SystemId),
+    CONSTRAINT PKC_System PRIMARY KEY CLUSTERED (Value) WITH (DATA_COMPRESSION = PAGE)
+);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TaskInfo.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TaskInfo.sql
@@ -1,0 +1,31 @@
+CREATE TABLE [dbo].[TaskInfo] (
+    [TaskId]            VARCHAR (64)  NOT NULL,
+    [QueueId]           VARCHAR (64)  NOT NULL,
+    [Status]            SMALLINT      NOT NULL,
+    [TaskTypeId]        SMALLINT      NOT NULL,
+    [RunId]             VARCHAR (50)  NULL,
+    [IsCanceled]        BIT           NOT NULL,
+    [RetryCount]        SMALLINT      NOT NULL,
+    [MaxRetryCount]     SMALLINT      NOT NULL,
+    [HeartbeatDateTime] DATETIME2 (7) NULL,
+    [InputData]         VARCHAR (MAX) NOT NULL,
+    [TaskContext]       VARCHAR (MAX) NULL,
+    [Result]            VARCHAR (MAX) NULL,
+    [CreateDateTime]    DATETIME2 (7) CONSTRAINT DF_TaskInfo_CreateDate DEFAULT SYSUTCDATETIME() NOT NULL,
+    [StartDateTime]     DATETIME2 (7) NULL,
+    [EndDateTime]       DATETIME2 (7) NULL,
+    [Worker]            VARCHAR (100) NULL,
+    [RestartInfo]       VARCHAR (MAX) NULL,
+    [ParentTaskId]      VARCHAR (64)  NULL,
+    CONSTRAINT PKC_TaskInfo PRIMARY KEY CLUSTERED (TaskId) WITH (DATA_COMPRESSION = PAGE)
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY];
+
+GO
+
+CREATE NONCLUSTERED INDEX IX_QueueId_Status
+    ON dbo.TaskInfo(QueueId, Status);
+
+GO
+
+CREATE NONCLUSTERED INDEX IX_QueueId_ParentTaskId
+    ON dbo.TaskInfo(QueueId, ParentTaskId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermCodeSystem.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermCodeSystem.sql
@@ -1,0 +1,26 @@
+CREATE TABLE dbo.TermCodeSystem (
+    TermCodeSystemId BIGINT         NOT NULL IDENTITY (1, 1),
+    PackageResourceId BIGINT        NOT NULL,
+    SystemId          INT           NOT NULL,
+    Version           NVARCHAR (100) NULL,
+    ConceptCount      INT           NOT NULL,
+    Content           NVARCHAR (50) NOT NULL,
+    IsHierarchical    BIT           NOT NULL,
+    CaseSensitive     BIT           NOT NULL,
+    Compositional     BIT           NOT NULL,
+    ImportedDate      DATETIMEOFFSET DEFAULT getUTCdate() NOT NULL,
+    CONSTRAINT PK_TermCodeSystem PRIMARY KEY (TermCodeSystemId),
+    CONSTRAINT FK_TermCodeSystem_PackageResource FOREIGN KEY (PackageResourceId) REFERENCES dbo.PackageResource (PackageResourceId) ON DELETE CASCADE,
+    CONSTRAINT FK_TermCodeSystem_System FOREIGN KEY (SystemId) REFERENCES dbo.System (SystemId)
+);
+
+GO
+
+CREATE INDEX IX_TermCodeSystem_PackageResourceId
+    ON dbo.TermCodeSystem(PackageResourceId);
+
+GO
+
+CREATE UNIQUE INDEX UQ_TermCodeSystem_System_Version
+    ON dbo.TermCodeSystem(SystemId, Version)
+    WHERE Version IS NOT NULL;

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConcept.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConcept.sql
@@ -1,0 +1,39 @@
+CREATE TABLE dbo.TermConcept (
+    TermConceptId    BIGINT         NOT NULL IDENTITY (1, 1),
+    TermCodeSystemId BIGINT         NOT NULL,
+    Code             NVARCHAR (256) NOT NULL,
+    Display          NVARCHAR (500) NULL,
+    Definition       NVARCHAR (4000) NULL,
+    ParentConceptId  BIGINT         NULL,
+    Level            INT            NOT NULL,
+    IsActive         BIT            NOT NULL,
+    PropertiesJson   NVARCHAR (MAX) NULL,
+    CONSTRAINT PK_TermConcept PRIMARY KEY (TermConceptId),
+    CONSTRAINT FK_TermConcept_CodeSystem FOREIGN KEY (TermCodeSystemId) REFERENCES dbo.TermCodeSystem (TermCodeSystemId) ON DELETE CASCADE,
+    CONSTRAINT FK_TermConcept_Parent FOREIGN KEY (ParentConceptId) REFERENCES dbo.TermConcept (TermConceptId)
+);
+
+GO
+
+CREATE INDEX IX_TermConcept_CodeSystem_Code_Active
+    ON dbo.TermConcept(TermCodeSystemId, Code, IsActive)
+    INCLUDE(Display, Definition);
+
+GO
+
+CREATE INDEX IX_TermConcept_Display
+    ON dbo.TermConcept(Display)
+    INCLUDE(TermCodeSystemId, Code)
+    WHERE Display IS NOT NULL;
+
+GO
+
+CREATE INDEX IX_TermConcept_Parent
+    ON dbo.TermConcept(ParentConceptId, Level)
+    INCLUDE(Code, Display)
+    WHERE ParentConceptId IS NOT NULL;
+
+GO
+
+CREATE UNIQUE INDEX UQ_TermConcept_CodeSystem_Code
+    ON dbo.TermConcept(TermCodeSystemId, Code);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConceptMap.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConceptMap.sql
@@ -1,0 +1,23 @@
+CREATE TABLE dbo.TermConceptMap (
+    TermConceptMapId BIGINT         NOT NULL IDENTITY (1, 1),
+    PackageResourceId BIGINT        NOT NULL,
+    Canonical         NVARCHAR (512) NOT NULL,
+    Version           NVARCHAR (100) NULL,
+    Name              NVARCHAR (256) NOT NULL,
+    SourceCanonical   NVARCHAR (512) NULL,
+    TargetCanonical   NVARCHAR (512) NULL,
+    ImportedDate      DATETIMEOFFSET DEFAULT getUTCdate() NOT NULL,
+    CONSTRAINT PK_TermConceptMap PRIMARY KEY (TermConceptMapId),
+    CONSTRAINT FK_TermConceptMap_PackageResource FOREIGN KEY (PackageResourceId) REFERENCES dbo.PackageResource (PackageResourceId) ON DELETE CASCADE
+);
+
+GO
+
+CREATE INDEX IX_TermConceptMap_PackageResourceId
+    ON dbo.TermConceptMap(PackageResourceId);
+
+GO
+
+CREATE UNIQUE INDEX UQ_TermConceptMap_Canonical_Version
+    ON dbo.TermConceptMap(Canonical, Version)
+    WHERE Version IS NOT NULL;

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConceptMapElement.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermConceptMapElement.sql
@@ -1,0 +1,35 @@
+CREATE TABLE dbo.TermConceptMapElement (
+    TermConceptMapElementId BIGINT NOT NULL IDENTITY (1, 1),
+    TermConceptMapId BIGINT NOT NULL,
+    SourceSystemId INT NOT NULL,
+    SourceCode NVARCHAR (256) NOT NULL,
+    SourceDisplay NVARCHAR (500) NULL,
+    TargetSystemId INT NULL,
+    TargetCode NVARCHAR (256) NULL,
+    TargetDisplay NVARCHAR (500) NULL,
+    Equivalence NVARCHAR (50) NOT NULL,
+    Comment NVARCHAR (MAX) NULL,
+    GroupIndex INT NOT NULL,
+    CONSTRAINT PK_TermConceptMapElement PRIMARY KEY (TermConceptMapElementId),
+    CONSTRAINT FK_TermConceptMapElement_ConceptMap FOREIGN KEY (TermConceptMapId) REFERENCES dbo.TermConceptMap (TermConceptMapId) ON DELETE CASCADE,
+    CONSTRAINT FK_TermConceptMapElement_SourceSystem FOREIGN KEY (SourceSystemId) REFERENCES dbo.System (SystemId),
+    CONSTRAINT FK_TermConceptMapElement_TargetSystem FOREIGN KEY (TargetSystemId) REFERENCES dbo.System (SystemId)
+);
+
+GO
+
+CREATE INDEX IX_TermConceptMapElement_Source
+    ON dbo.TermConceptMapElement(SourceSystemId, SourceCode)
+    INCLUDE(TermConceptMapId, TargetSystemId, TargetCode, Equivalence);
+
+GO
+
+CREATE INDEX IX_TermConceptMapElement_Target
+    ON dbo.TermConceptMapElement(TargetSystemId, TargetCode)
+    INCLUDE(TermConceptMapId, SourceSystemId, SourceCode, Equivalence)
+    WHERE TargetSystemId IS NOT NULL;
+
+GO
+
+CREATE INDEX IX_TermConceptMapElement_TermConceptMapId
+    ON dbo.TermConceptMapElement(TermConceptMapId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermValueSet.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermValueSet.sql
@@ -1,0 +1,33 @@
+CREATE TABLE dbo.TermValueSet (
+    TermValueSetId         BIGINT         NOT NULL IDENTITY (1, 1),
+    PackageResourceId      BIGINT         NOT NULL,
+    Canonical              NVARCHAR (512) NOT NULL,
+    Version                NVARCHAR (100) NULL,
+    Name                   NVARCHAR (256) NOT NULL,
+    Immutable              BIT            NOT NULL,
+    IsExpanded             BIT            NOT NULL,
+    LastExpansionDate      DATETIMEOFFSET NULL,
+    ExpansionCodeCount     INT            NULL,
+    IsPartialExpansion     BIT            DEFAULT 0 NOT NULL,
+    PartialExpansionReason NVARCHAR (1024) NULL,
+    ImportedDate           DATETIMEOFFSET DEFAULT getUTCdate() NOT NULL,
+    CONSTRAINT PK_TermValueSet PRIMARY KEY (TermValueSetId),
+    CONSTRAINT FK_TermValueSet_PackageResource FOREIGN KEY (PackageResourceId) REFERENCES dbo.PackageResource (PackageResourceId) ON DELETE CASCADE
+);
+
+GO
+
+CREATE INDEX IX_TermValueSet_Canonical
+    ON dbo.TermValueSet(Canonical)
+    INCLUDE(Version, IsExpanded);
+
+GO
+
+CREATE INDEX IX_TermValueSet_PackageResourceId
+    ON dbo.TermValueSet(PackageResourceId);
+
+GO
+
+CREATE UNIQUE INDEX UQ_TermValueSet_Canonical_Version
+    ON dbo.TermValueSet(Canonical, Version)
+    WHERE Version IS NOT NULL;

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermValueSetExpansion.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TermValueSetExpansion.sql
@@ -1,0 +1,38 @@
+CREATE TABLE dbo.TermValueSetExpansion (
+    TermValueSetExpansionId BIGINT         NOT NULL IDENTITY (1, 1),
+    TermValueSetId          BIGINT         NOT NULL,
+    SystemId                INT            NOT NULL,
+    Code                    NVARCHAR (256) NOT NULL,
+    Display                 NVARCHAR (500) NULL,
+    SystemVersion           NVARCHAR (100) NULL,
+    IsActive                BIT            NOT NULL,
+    Ordinal                 INT            NOT NULL,
+    CONSTRAINT PK_TermValueSetExpansion PRIMARY KEY (TermValueSetExpansionId),
+    CONSTRAINT FK_TermValueSetExpansion_System FOREIGN KEY (SystemId) REFERENCES dbo.System (SystemId),
+    CONSTRAINT FK_TermValueSetExpansion_ValueSet FOREIGN KEY (TermValueSetId) REFERENCES dbo.TermValueSet (TermValueSetId) ON DELETE CASCADE
+);
+
+GO
+
+CREATE INDEX IX_TermValueSetExpansion_Display
+    ON dbo.TermValueSetExpansion(Display)
+    INCLUDE(TermValueSetId, SystemId, Code)
+    WHERE Display IS NOT NULL AND IsActive = 1;
+
+GO
+
+CREATE INDEX IX_TermValueSetExpansion_SystemId
+    ON dbo.TermValueSetExpansion(SystemId);
+
+GO
+
+CREATE INDEX IX_TermValueSetExpansion_ValueSet_Ordinal
+    ON dbo.TermValueSetExpansion(TermValueSetId, Ordinal)
+    INCLUDE(SystemId, Code, Display)
+    WHERE IsActive = 1;
+
+GO
+
+CREATE INDEX IX_TermValueSetExpansion_ValueSet_System_Code
+    ON dbo.TermValueSetExpansion(TermValueSetId, SystemId, Code)
+    WHERE IsActive = 1;

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenDateTimeCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenDateTimeCompositeSearchParam.sql
@@ -1,0 +1,49 @@
+CREATE TABLE dbo.TokenDateTimeCompositeSearchParam (
+    ResourceTypeId      SMALLINT      NOT NULL,
+    ResourceSurrogateId BIGINT        NOT NULL,
+    SearchParamId       SMALLINT      NOT NULL,
+    SystemId1           INT           NULL,
+    Code1               VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    StartDateTime2      DATETIME2 (7) NOT NULL,
+    EndDateTime2        DATETIME2 (7) NOT NULL,
+    IsLongerThanADay2   BIT           NOT NULL,
+    CodeOverflow1       VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenDateTimeCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenDateTimeCompositeSearchParam
+    ON dbo.TokenDateTimeCompositeSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_StartDateTime2_EndDateTime2_INCLUDE_SystemId1_IsLongerThanADay2
+    ON dbo.TokenDateTimeCompositeSearchParam(SearchParamId, Code1, StartDateTime2, EndDateTime2)
+    INCLUDE(SystemId1, IsLongerThanADay2) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_EndDateTime2_StartDateTime2_INCLUDE_SystemId1_IsLongerThanADay2
+    ON dbo.TokenDateTimeCompositeSearchParam(SearchParamId, Code1, EndDateTime2, StartDateTime2)
+    INCLUDE(SystemId1, IsLongerThanADay2) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_StartDateTime2_EndDateTime2_INCLUDE_SystemId1_WHERE_IsLongerThanADay2_1
+    ON dbo.TokenDateTimeCompositeSearchParam(SearchParamId, Code1, StartDateTime2, EndDateTime2)
+    INCLUDE(SystemId1) WHERE IsLongerThanADay2 = 1 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_EndDateTime2_StartDateTime2_INCLUDE_SystemId1_WHERE_IsLongerThanADay2_1
+    ON dbo.TokenDateTimeCompositeSearchParam(SearchParamId, Code1, EndDateTime2, StartDateTime2)
+    INCLUDE(SystemId1) WHERE IsLongerThanADay2 = 1 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenNumberNumberCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenNumberNumberCompositeSearchParam.sql
@@ -1,0 +1,39 @@
+CREATE TABLE dbo.TokenNumberNumberCompositeSearchParam (
+    ResourceTypeId      SMALLINT         NOT NULL,
+    ResourceSurrogateId BIGINT           NOT NULL,
+    SearchParamId       SMALLINT         NOT NULL,
+    SystemId1           INT              NULL,
+    Code1               VARCHAR (256)    COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SingleValue2        DECIMAL (36, 18) NULL,
+    LowValue2           DECIMAL (36, 18) NULL,
+    HighValue2          DECIMAL (36, 18) NULL,
+    SingleValue3        DECIMAL (36, 18) NULL,
+    LowValue3           DECIMAL (36, 18) NULL,
+    HighValue3          DECIMAL (36, 18) NULL,
+    HasRange            BIT              NOT NULL,
+    CodeOverflow1       VARCHAR (MAX)    COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenNumberNumberCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenNumberNumberCompositeSearchParam
+    ON dbo.TokenNumberNumberCompositeSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_SingleValue2_SingleValue3_INCLUDE_SystemId1_WHERE_HasRange_0
+    ON dbo.TokenNumberNumberCompositeSearchParam(SearchParamId, Code1, SingleValue2, SingleValue3)
+    INCLUDE(SystemId1) WHERE HasRange = 0 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_LowValue2_HighValue2_LowValue3_HighValue3_INCLUDE_SystemId1_WHERE_HasRange_1
+    ON dbo.TokenNumberNumberCompositeSearchParam(SearchParamId, Code1, LowValue2, HighValue2, LowValue3, HighValue3)
+    INCLUDE(SystemId1) WHERE HasRange = 1 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenQuantityCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenQuantityCompositeSearchParam.sql
@@ -1,0 +1,44 @@
+CREATE TABLE dbo.TokenQuantityCompositeSearchParam (
+    ResourceTypeId      SMALLINT         NOT NULL,
+    ResourceSurrogateId BIGINT           NOT NULL,
+    SearchParamId       SMALLINT         NOT NULL,
+    SystemId1           INT              NULL,
+    Code1               VARCHAR (256)    COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2           INT              NULL,
+    QuantityCodeId2     INT              NULL,
+    SingleValue2        DECIMAL (36, 18) NULL,
+    LowValue2           DECIMAL (36, 18) NULL,
+    HighValue2          DECIMAL (36, 18) NULL,
+    CodeOverflow1       VARCHAR (MAX)    COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenQuantityCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenQuantityCompositeSearchParam
+    ON dbo.TokenQuantityCompositeSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_SingleValue2_INCLUDE_QuantityCodeId2_SystemId1_SystemId2_WHERE_SingleValue2_NOT_NULL
+    ON dbo.TokenQuantityCompositeSearchParam(SearchParamId, Code1, SingleValue2)
+    INCLUDE(QuantityCodeId2, SystemId1, SystemId2) WHERE SingleValue2 IS NOT NULL WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_LowValue2_HighValue2_INCLUDE_QuantityCodeId2_SystemId1_SystemId2_WHERE_LowValue2_NOT_NULL
+    ON dbo.TokenQuantityCompositeSearchParam(SearchParamId, Code1, LowValue2, HighValue2)
+    INCLUDE(QuantityCodeId2, SystemId1, SystemId2) WHERE LowValue2 IS NOT NULL WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_HighValue2_LowValue2_INCLUDE_QuantityCodeId2_SystemId1_SystemId2_WHERE_LowValue2_NOT_NULL
+    ON dbo.TokenQuantityCompositeSearchParam(SearchParamId, Code1, HighValue2, LowValue2)
+    INCLUDE(QuantityCodeId2, SystemId1, SystemId2) WHERE LowValue2 IS NOT NULL WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenSearchParam.sql
@@ -1,0 +1,47 @@
+CREATE TABLE dbo.TokenSearchParam (
+    ResourceTypeId         SMALLINT       NOT NULL,
+    ResourceSurrogateId    BIGINT         NOT NULL,
+    SearchParamId          SMALLINT       NOT NULL,
+    SystemId                INT           NULL,
+    Code                    VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CodeOverflow            VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL,
+    IdentifierTypeCode      NVARCHAR (256) NULL,
+    IdentifierTypeSystemId  INT            NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenSearchParam
+    ON dbo.TokenSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code_INCLUDE_SystemId
+    ON dbo.TokenSearchParam(SearchParamId, Code)
+    INCLUDE(SystemId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_TokenSearchParam_SearchParamId_SystemId_Code
+    ON dbo.TokenSearchParam(SearchParamId, SystemId, Code)
+    INCLUDE(ResourceTypeId, ResourceSurrogateId)
+    WHERE SystemId IS NOT NULL;
+
+GO
+
+CREATE INDEX IX_TokenSearchParam_SystemId_Code
+    ON dbo.TokenSearchParam(SystemId, Code)
+    INCLUDE(ResourceTypeId, ResourceSurrogateId)
+    WHERE SystemId IS NOT NULL;
+
+GO
+
+CREATE INDEX IX_TokenSearchParam_ResourceTypeId_SearchParamId
+    ON dbo.TokenSearchParam(ResourceTypeId, SearchParamId)
+    INCLUDE(SystemId, Code);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenStringCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenStringCompositeSearchParam.sql
@@ -1,0 +1,34 @@
+CREATE TABLE dbo.TokenStringCompositeSearchParam (
+    ResourceTypeId      SMALLINT       NOT NULL,
+    ResourceSurrogateId BIGINT         NOT NULL,
+    SearchParamId       SMALLINT       NOT NULL,
+    SystemId1           INT            NULL,
+    Code1               VARCHAR (256)  COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Text2               NVARCHAR (256) COLLATE Latin1_General_CI_AI NOT NULL,
+    TextOverflow2       NVARCHAR (MAX) COLLATE Latin1_General_CI_AI NULL,
+    CodeOverflow1       VARCHAR (MAX)  COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenStringCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenStringCompositeSearchParam
+    ON dbo.TokenStringCompositeSearchParam(ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_Text2_INCLUDE_SystemId1_TextOverflow2
+    ON dbo.TokenStringCompositeSearchParam(SearchParamId, Code1, Text2)
+    INCLUDE(SystemId1, TextOverflow2) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_Text2_INCLUDE_SystemId1_WHERE_TextOverflow2_NOT_NULL
+    ON dbo.TokenStringCompositeSearchParam(SearchParamId, Code1, Text2)
+    INCLUDE(SystemId1) WHERE TextOverflow2 IS NOT NULL WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenText.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenText.sql
@@ -1,0 +1,28 @@
+CREATE TABLE dbo.TokenText (
+    ResourceTypeId      SMALLINT       NOT NULL,
+    ResourceSurrogateId BIGINT         NOT NULL,
+    SearchParamId       SMALLINT       NOT NULL,
+    Text                NVARCHAR (400) COLLATE Latin1_General_CI_AI NOT NULL,
+    IsHistory           BIT            NOT NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenText
+    ADD CONSTRAINT DF_TokenText_IsHistory DEFAULT 0 FOR IsHistory;
+
+GO
+
+ALTER TABLE dbo.TokenText SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenText
+    ON dbo.TokenText(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE NONCLUSTERED INDEX IX_TokenText_SearchParamId_Text
+    ON dbo.TokenText(ResourceTypeId, SearchParamId, Text, ResourceSurrogateId) WHERE IsHistory = 0 WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenTokenCompositeSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenTokenCompositeSearchParam.sql
@@ -1,0 +1,28 @@
+CREATE TABLE dbo.TokenTokenCompositeSearchParam (
+    ResourceTypeId      SMALLINT      NOT NULL,
+    ResourceSurrogateId BIGINT        NOT NULL,
+    SearchParamId       SMALLINT      NOT NULL,
+    SystemId1           INT           NULL,
+    Code1               VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2           INT           NULL,
+    Code2               VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    CodeOverflow1       VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL,
+    CodeOverflow2       VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL
+);
+
+GO
+
+ALTER TABLE dbo.TokenTokenCompositeSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_TokenTokenCompositeSearchParam
+    ON dbo.TokenTokenCompositeSearchParam(ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Code1_Code2_INCLUDE_SystemId1_SystemId2
+    ON dbo.TokenTokenCompositeSearchParam(SearchParamId, Code1, Code2)
+    INCLUDE(SystemId1, SystemId2) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Transactions.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/Transactions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE dbo.Transactions (
+    SurrogateIdRangeFirstValue  BIGINT         NOT NULL,
+    SurrogateIdRangeLastValue   BIGINT         NOT NULL,
+    Definition                  VARCHAR (2000) NULL,
+    IsCompleted                 BIT            CONSTRAINT DF_Transactions_IsCompleted DEFAULT 0 NOT NULL,
+    IsSuccess                   BIT            CONSTRAINT DF_Transactions_IsSuccess DEFAULT 0 NOT NULL,
+    IsVisible                   BIT            CONSTRAINT DF_Transactions_IsVisible DEFAULT 0 NOT NULL,
+    IsHistoryMoved              BIT            CONSTRAINT DF_Transactions_IsHistoryMoved DEFAULT 0 NOT NULL,
+    CreateDate                  DATETIME       CONSTRAINT DF_Transactions_CreateDate DEFAULT getUTCdate() NOT NULL,
+    EndDate                     DATETIME       NULL,
+    VisibleDate                 DATETIME       NULL,
+    HistoryMovedDate            DATETIME       NULL,
+    HeartbeatDate               DATETIME       CONSTRAINT DF_Transactions_HeartbeatDate DEFAULT getUTCdate() NOT NULL,
+    FailureReason               VARCHAR (MAX)  NULL,
+    IsControlledByClient        BIT            CONSTRAINT DF_Transactions_IsControlledByClient DEFAULT 1 NOT NULL,
+    InvisibleHistoryRemovedDate DATETIME       NULL CONSTRAINT PKC_Transactions_SurrogateIdRangeFirstValue PRIMARY KEY CLUSTERED (SurrogateIdRangeFirstValue)
+);
+
+GO
+
+CREATE INDEX IX_IsVisible
+    ON dbo.Transactions(IsVisible);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/UriSearchParam.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/UriSearchParam.sql
@@ -1,0 +1,24 @@
+CREATE TABLE dbo.UriSearchParam (
+    ResourceTypeId      SMALLINT      NOT NULL,
+    ResourceSurrogateId BIGINT        NOT NULL,
+    SearchParamId       SMALLINT      NOT NULL,
+    Uri                 VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Fragment             NVARCHAR (128) NULL,
+    Version               NVARCHAR (64)  NULL
+);
+
+GO
+
+ALTER TABLE dbo.UriSearchParam SET (LOCK_ESCALATION = AUTO);
+
+GO
+
+CREATE CLUSTERED INDEX IXC_UriSearchParam
+    ON dbo.UriSearchParam(ResourceTypeId, ResourceSurrogateId, SearchParamId) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);
+
+GO
+
+CREATE INDEX IX_SearchParamId_Uri
+    ON dbo.UriSearchParam(SearchParamId, Uri) WITH (DATA_COMPRESSION = PAGE)
+    ON PartitionScheme_ResourceTypeId (ResourceTypeId);

--- a/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/WatchdogLeases.sql
+++ b/src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/WatchdogLeases.sql
@@ -1,0 +1,8 @@
+CREATE TABLE dbo.WatchdogLeases (
+    Watchdog              VARCHAR (100) NOT NULL,
+    LeaseHolder           VARCHAR (100) CONSTRAINT DF_WatchdogLeases_LeaseHolder DEFAULT '' NOT NULL,
+    LeaseEndTime          DATETIME      CONSTRAINT DF_WatchdogLeases_LeaseEndTime DEFAULT 0 NOT NULL,
+    RemainingLeaseTimeSec AS            datediff(second, getUTCdate(), LeaseEndTime),
+    LeaseRequestor        VARCHAR (100) CONSTRAINT DF_WatchdogLeases_LeaseRequestor DEFAULT '' NOT NULL,
+    LeaseRequestTime      DATETIME      CONSTRAINT DF_WatchdogLeases_LeaseRequestTime DEFAULT 0 NOT NULL CONSTRAINT PKC_WatchdogLeases_Watchdog PRIMARY KEY CLUSTERED (Watchdog)
+);

--- a/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalCreateTests.cs
+++ b/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalCreateTests.cs
@@ -95,6 +95,34 @@ public class ConditionalCreateTests : CapabilityDrivenTestBase
     }
 
     /// <summary>
+    /// Tests conditional create criteria carrying a modifier the server does not support.
+    /// Expected: Returns 400 Bad Request rather than silently widening the If-None-Exist criteria.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case). Conditional create must reject it too -- dropping the modifier would
+    /// widen the duplicate-check search, which could cause an unwanted create instead of the expected
+    /// 412/200 idempotent response.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenConditionalCreate_ThenReturnsBadRequest()
+    {
+        // Arrange
+        var patient = CreatePatient().WithFamilyName("UnsupportedModifierCreate").Build();
+
+        // Act - POST with If-None-Exist: _id:above=abc (:above is not a supported modifier for _id)
+        var response = await Harness.PostResourceWithHeadersAsync(
+            patient,
+            new Dictionary<string, string>
+            {
+                ["If-None-Exist"] = "_id:above=abc"
+            });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen create criteria");
+    }
+
+    /// <summary>
     /// Tests conditional create with _id parameter when no match exists.
     /// Expected: Creates a new resource with server-assigned ID.
     /// </summary>

--- a/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalDeleteTests.cs
+++ b/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalDeleteTests.cs
@@ -288,6 +288,25 @@ public class ConditionalDeleteTests : CapabilityDrivenTestBase
     }
 
     /// <summary>
+    /// Tests conditional delete criteria carrying a modifier the server does not support.
+    /// Expected: Returns 400 Bad Request rather than silently widening the delete criteria.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case). Conditional delete must reject it too -- dropping the modifier would
+    /// widen the match set, which for a delete means resources the criteria never actually selected.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenConditionalDelete_ThenReturnsBadRequest()
+    {
+        // Act - DELETE /Patient?_id:above=abc (:above is not a supported modifier for _id)
+        var response = await Harness.DeleteWithQueryAsync("Patient", "_id:above=abc");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen delete criteria");
+    }
+
+    /// <summary>
     /// Tests conditional delete on Bundle resource type.
     /// Expected: Returns 400 Bad Request.
     /// </summary>

--- a/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalPatchTests.cs
+++ b/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalPatchTests.cs
@@ -73,6 +73,28 @@ public class ConditionalPatchTests : CapabilityDrivenTestBase
     }
 
     /// <summary>
+    /// Tests conditional patch criteria carrying a modifier the server does not support.
+    /// Expected: Returns 400 Bad Request rather than silently widening the patch criteria.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case). Conditional patch must reject it too -- dropping the modifier would widen
+    /// the match set, which for a patch means the wrong resource could be modified.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenConditionalPatch_ThenReturnsBadRequest()
+    {
+        // Arrange
+        var patchDocument = CreateGenderPatchDocument("female");
+
+        // Act - PATCH /Patient?_id:above=abc (:above is not a supported modifier for _id)
+        var response = await Harness.PatchWithQueryAsync("Patient", "_id:above=abc", patchDocument);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen patch criteria");
+    }
+
+    /// <summary>
     /// Tests conditional patch when exactly one matching resource exists.
     /// Expected: Patches the existing resource and returns 200 OK with the updated resource.
     /// </summary>

--- a/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalUpdateTests.cs
+++ b/test/Ignixa.Api.E2ETests/Operations/Conditional/ConditionalUpdateTests.cs
@@ -88,6 +88,28 @@ public class ConditionalUpdateTests : CapabilityDrivenTestBase
     }
 
     /// <summary>
+    /// Tests conditional update criteria carrying a modifier the server does not support.
+    /// Expected: Returns 400 Bad Request rather than silently widening the update criteria.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case). Conditional update must reject it too -- dropping the modifier would
+    /// widen the match set, which for an update means the wrong resource could be updated.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenConditionalUpdate_ThenReturnsBadRequest()
+    {
+        // Arrange
+        var patient = CreatePatient().WithFamilyName("UnsupportedModifierUpdate").Build();
+
+        // Act - PUT /Patient?_id:above=abc (:above is not a supported modifier for _id)
+        var response = await Harness.PutResourceWithQueryAsync(patient, "_id:above=abc");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen update criteria");
+    }
+
+    /// <summary>
     /// Tests conditional update when no match exists but client provides an ID in the resource body.
     /// Expected: Creates a new resource with the client-provided ID (201 Created).
     /// </summary>

--- a/test/Ignixa.Api.E2ETests/Search/Compartments/PatientCompartmentTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/Compartments/PatientCompartmentTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Net;
 using Shouldly;
 using Ignixa.Api.E2ETests._Infrastructure;
 using Ignixa.Api.E2ETests._Infrastructure.Base;
@@ -119,6 +120,25 @@ public class CompartmentSearchTests : CapabilityDrivenTestBase
             var tags = tagArray?.AsArray().Select(t => t?["code"]?.GetValue<string>());
             tags!.ShouldContain(tag);
         }
+    }
+
+    /// <summary>
+    /// Tests a patient compartment search whose query string carries a modifier the server does not
+    /// support. Expected: Returns 400 Bad Request rather than silently widening the search.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case); compartment search must reject it too. No patient needs to exist for this
+    /// case -- the rejection happens before the compartment query executes.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenPatientCompartmentSearched_ThenReturnsBadRequest()
+    {
+        // Act - GET /Patient/{id}/Observation?_id:above=abc (:above is not a supported modifier for _id)
+        var response = await Client.GetAsync("/Patient/nonexistent-patient-id/Observation?_id:above=abc");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen compartment search");
     }
 
     /// <summary>

--- a/test/Ignixa.Api.E2ETests/Search/IncludeRevinclude/IncludesOperationTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/IncludeRevinclude/IncludesOperationTests.cs
@@ -313,6 +313,24 @@ public class IncludesOperationTests : IncludeTestBase
     }
 
     /// <summary>
+    /// Tests that $includes rejects a query string carrying a modifier the server does not support,
+    /// rather than silently widening the continuation search.
+    /// </summary>
+    /// <remarks>
+    /// FHIR R4 SHALL-rejects an unsupported modifier (see Search.Modifiers.UnsupportedModifierTests for
+    /// the plain-search case); the $includes continuation endpoint must reject it too.
+    /// </remarks>
+    [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenCallingIncludesEndpoint_ThenReturnsBadRequest()
+    {
+        // Act - GET /Location/$includes?_includesContinuationToken=...&_id:above=abc
+        var response = await Client.GetAsync("/Location/$includes?_includesContinuationToken=any-token&_id:above=abc");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, "server should reject rather than silently widen the includes continuation search");
+    }
+
+    /// <summary>
     /// Tests that $includes endpoint returns error for invalid continuation token.
     /// </summary>
     [Fact]

--- a/test/Ignixa.Api.E2ETests/Search/Modifiers/ReferenceTypeModifierTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/Modifiers/ReferenceTypeModifierTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Net;
 using System.Text.Json.Nodes;
 using Shouldly;
 using Ignixa.Api.E2ETests._Infrastructure;
@@ -493,12 +494,15 @@ public class ReferenceTypeModifierTests : CapabilityDrivenTestBase
     #region Edge Cases
 
     /// <summary>
-    /// Tests that invalid type modifier returns no results or OperationOutcome (server should handle gracefully).
-    /// For example, searching performer:InvalidType should return no results.
-    /// Per FHIR spec, servers MAY return OperationOutcome for unsupported search parameters.
+    /// Tests that a type modifier naming something other than a real FHIR resource type is rejected.
+    /// For example, searching performer:InvalidType is a modifier the server does not support for
+    /// that reference parameter, since "InvalidType" is not one of performer's valid target types.
+    /// Per FHIR R4 (https://hl7.org/fhir/R4/search.html#modifiers), a search suffixed by a modifier
+    /// the server does not support for that parameter SHALL be rejected with a 400, not silently
+    /// dropped or ignored -- dropping it would widen the result set instead of narrowing it.
     /// </summary>
     [Fact]
-    public async Task GivenObservationsWithValidPerformerTypes_WhenSearchedWithInvalidTypeModifier_ThenReturnsNoResults()
+    public async Task GivenObservationsWithValidPerformerTypes_WhenSearchedWithInvalidTypeModifier_ThenBadRequestReturned()
     {
         // Capability check
         RequireSearchParameter("Observation", "performer");
@@ -510,22 +514,11 @@ public class ReferenceTypeModifierTests : CapabilityDrivenTestBase
 
         var practitionerId = scenario.Practitioner.Id!;
 
-        // Act - Search with invalid type modifier (not a valid FHIR resource type for performer)
-        var results = await Harness.SearchAsync("Observation", $"performer:InvalidType={practitionerId}&_tag={tag}");
+        // Act - Search with a type modifier that names a nonexistent FHIR resource type.
+        var response = await Client.GetAsync($"/Observation?performer:InvalidType={practitionerId}&_tag={tag}");
 
         // Assert
-        // Servers may handle invalid type modifiers in different ways per FHIR spec:
-        // 1. Return empty results (strict interpretation)
-        // 2. Return OperationOutcome warning
-        // 3. Ignore the invalid modifier and return all matching resources (lenient interpretation)
-        // This test documents the current server behavior without enforcing a specific approach
-        if (results.Any(r => r.ResourceType == "OperationOutcome"))
-        {
-            // If OperationOutcome is present, it should indicate the parameter is not supported
-            results.ShouldContain(r => r.ResourceType == "OperationOutcome", "server returned a warning about unsupported parameter");
-        }
-        // Note: Test passes regardless of whether server returns empty, OperationOutcome, or resources
-        // This flexible assertion allows for different valid FHIR server implementations
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
     /// <summary>

--- a/test/Ignixa.Api.E2ETests/Search/Modifiers/UnsupportedModifierTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/Modifiers/UnsupportedModifierTests.cs
@@ -41,6 +41,32 @@ public class UnsupportedModifierTests : CapabilityDrivenTestBase
     }
 
     [Fact]
+    public async Task GivenAnUnsupportedModifier_WhenSearchedWithNoPreferHeader_ThenTheDiagnosticsNameTheModifierNotTheParameter()
+    {
+        // The SHALL-reject case must read differently from an ignored/unsupported *parameter* (which this
+        // server only rejects when the client opts in via Prefer: handling=strict) -- a client parsing
+        // OperationOutcome.issue[].diagnostics needs to be able to tell "your modifier was rejected" apart
+        // from "your parameter was ignored," even though both currently map to the same severity/code.
+        var response = await Client.GetAsync("/Patient?_id:above=abc");
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.ShouldContain("uses a modifier that is not supported");
+    }
+
+    [Fact]
+    public async Task GivenMultipleUnsupportedModifiers_WhenSearchedWithNoPreferHeader_ThenEveryOneIsReported()
+    {
+        // UnsupportedModifierParams is a list; this pins that the diagnostics loop reports every offending
+        // parameter, not just the first one it finds.
+        var response = await Client.GetAsync("/Patient?_id:above=abc&_lastUpdated:above=2020");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, body);
+        body.ShouldContain("_id:above");
+        body.ShouldContain("_lastUpdated:above");
+    }
+
+    [Fact]
     public async Task GivenASupportedModifierOnTheSameIntrinsicParameter_WhenSearchedWithNoPreferHeader_ThenNotRejected()
     {
         // Control: `_id:not` is a supported modifier on the same intrinsic parameter, so its presence

--- a/test/Ignixa.Api.E2ETests/Search/Modifiers/UnsupportedModifierTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/Modifiers/UnsupportedModifierTests.cs
@@ -1,0 +1,52 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using Shouldly;
+using Ignixa.Api.E2ETests._Infrastructure;
+using Ignixa.Api.E2ETests._Infrastructure.Base;
+using Ignixa.Api.E2ETests._Infrastructure.Collections;
+
+namespace Ignixa.Api.E2ETests.Search.Modifiers;
+
+/// <summary>
+/// E2E tests pinning FHIR R4's SHALL-reject rule for a search parameter suffixed by a modifier the
+/// server does not support (https://hl7.org/fhir/R4/search.html#modifiers).
+/// </summary>
+/// <remarks>
+/// This is distinct from an unsupported/unknown *parameter*, which R4 only says SHOULD be ignored and
+/// which this server only rejects when the client opts in via <c>Prefer: handling=strict</c>
+/// (see <see cref="Sorting.SortTests.GivenPatients_WhenSearchedWithInvalidSortAndHandlingStrict_ThenBadRequestReturned"/>).
+/// An unsupported modifier must be rejected unconditionally -- silently dropping it would widen the
+/// result set instead of narrowing it, which a client reading the entry list cannot detect.
+/// </remarks>
+[Collection(E2ETestCollection.Name)]
+public class UnsupportedModifierTests : CapabilityDrivenTestBase
+{
+    public UnsupportedModifierTests(IgnixaApiFixture fixture) : base(fixture)
+    {
+    }
+
+    [Theory]
+    [InlineData("_id:above=abc")]
+    [InlineData("_id:exact=abc")]
+    [InlineData("_lastUpdated:above=2020")]
+    public async Task GivenAnUnsupportedModifier_WhenSearchedWithNoPreferHeader_ThenBadRequestReturned(string queryString)
+    {
+        var response = await Client.GetAsync($"/Patient?{queryString}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GivenASupportedModifierOnTheSameIntrinsicParameter_WhenSearchedWithNoPreferHeader_ThenNotRejected()
+    {
+        // Control: `_id:not` is a supported modifier on the same intrinsic parameter, so its presence
+        // alone must not trigger the unsupported-modifier rejection.
+        var response = await Client.GetAsync("/Patient?_id:not=abc");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/test/Ignixa.Application.Tests/Features/Experimental/GraphQl/SearchResolverTests.cs
+++ b/test/Ignixa.Application.Tests/Features/Experimental/GraphQl/SearchResolverTests.cs
@@ -671,6 +671,29 @@ public class SearchResolverTests
     }
 
     [Fact]
+    public async Task GivenSearchOptionsWithAnUnsupportedModifier_WhenListSearching_ThenRejectsWithACodedGraphQLExceptionInsteadOfWideningTheSearch()
+    {
+        // Arrange -- GraphQL argument names can't carry a FHIR modifier's ':' today (GraphQL's own Name
+        // grammar forbids it), so this exercises BuildSearchOptions' defensive guard directly via the
+        // builder mock rather than trying to smuggle a modifier through a real IResolverContext argument.
+        var searchOptions = new SearchOptions
+        {
+            ResourceType = "Patient",
+            MaxItemCount = 10,
+            UnsupportedModifierParams = ["identifier:above"],
+        };
+        var (mediator, builderFactory, _, contextAccessor, resolverContext) = CreateMocks(searchOptions);
+
+        var resolver = CreateResolver(mediator, builderFactory, contextAccessor);
+
+        // Act & Assert -- rejected before the mediator is ever called, not executed as a widened search.
+        var ex = await Should.ThrowAsync<GraphQLException>(
+            () => resolver.SearchListAsync("Patient", resolverContext, CancellationToken.None));
+        ex.Errors[0].Code.ShouldBe("INVALID_RESOURCE");
+        await mediator.DidNotReceive().SendAsync(Arg.Any<SearchResourcesQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GivenNonFhirException_WhenSearching_ThenPropagatesUncaught()
     {
         // Arrange — non-FHIR exceptions are left for the error filter to log and mask

--- a/test/Ignixa.Application.Tests/Search/Indexing/SearchModifierNotSupportedExceptionTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Indexing/SearchModifierNotSupportedExceptionTests.cs
@@ -1,0 +1,72 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Models;
+using Shouldly;
+
+namespace Ignixa.Application.Tests.Search.Indexing;
+
+/// <summary>
+/// Covers <see cref="SearchModifierNotSupportedException.ThrowIfAny"/> directly. Every caller that
+/// builds <see cref="SearchOptions"/> from client input is expected to call this immediately -- these
+/// tests pin the guard's own behavior so a regression here doesn't hide behind a call site forgetting
+/// to invoke it.
+/// </summary>
+public class SearchModifierNotSupportedExceptionTests
+{
+    [Fact]
+    public void GivenNoUnsupportedModifiers_WhenThrowIfAnyCalled_ThenNothingIsThrown()
+    {
+        // Arrange
+        var options = new SearchOptions();
+
+        // Act, Assert
+        Should.NotThrow(() => SearchModifierNotSupportedException.ThrowIfAny(options));
+    }
+
+    [Fact]
+    public void GivenUnsupportedModifiers_WhenThrowIfAnyCalled_ThenThrowsNamingEveryOne()
+    {
+        // Arrange
+        var options = new SearchOptions
+        {
+            UnsupportedModifierParams = ["_id:above", "_lastUpdated:above"],
+        };
+
+        // Act
+        var exception = Should.Throw<SearchModifierNotSupportedException>(
+            () => SearchModifierNotSupportedException.ThrowIfAny(options));
+
+        // Assert
+        exception.Message.ShouldContain("_id:above");
+        exception.Message.ShouldContain("_lastUpdated:above");
+    }
+
+    [Fact]
+    public void GivenUnsupportedModifiersAndAResourceType_WhenThrowIfAnyCalled_ThenTheMessageNamesTheResourceType()
+    {
+        // Arrange
+        var options = new SearchOptions
+        {
+            ResourceType = "Patient",
+            UnsupportedModifierParams = ["_id:above"],
+        };
+
+        // Act
+        var exception = Should.Throw<SearchModifierNotSupportedException>(
+            () => SearchModifierNotSupportedException.ThrowIfAny(options));
+
+        // Assert
+        exception.Message.ShouldContain("Patient");
+    }
+
+    [Fact]
+    public void GivenNull_WhenThrowIfAnyCalled_ThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange, Act, Assert
+        Should.Throw<ArgumentNullException>(() => SearchModifierNotSupportedException.ThrowIfAny(null!));
+    }
+}

--- a/test/Ignixa.Application.Tests/Search/Models/SearchOptionsCopyConstructorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Models/SearchOptionsCopyConstructorTests.cs
@@ -138,15 +138,21 @@ public class SearchOptionsCopyConstructorTests
         if (type.IsEnum)
         {
             // Rotated by ordinal so two properties sharing an enum type still get different members and a
-            // transposition between them is caught. The guard in the caller catches the case where the
-            // rotation lands on the property's default.
+            // transposition between them is caught. Index 0 is skipped: this codebase's enums use it for
+            // "unset/none", which is always the default, so landing there would trip the guard below.
             Array values = Enum.GetValues(type);
-            return values.GetValue((values.Length - 1 - ordinal % values.Length + values.Length) % values.Length)!;
+            int index = 1 + (ordinal % (values.Length - 1));
+            return values.GetValue(index)!;
         }
 
         if (type == typeof(Expression))
         {
             return new StringExpression(StringOperator.Equals, FieldName.String, componentIndex: null, "copy-ctor", ignoreCase: false);
+        }
+
+        if (type == typeof(bool))
+        {
+            return true;
         }
 
         // The strategy below assumes every remaining property is a collection; a fresh empty instance is a

--- a/test/Ignixa.Application.Tests/Search/Models/SearchOptionsCopyConstructorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Models/SearchOptionsCopyConstructorTests.cs
@@ -30,7 +30,7 @@ public class SearchOptionsCopyConstructorTests
 
         foreach ((PropertyInfo property, int ordinal) in properties.Select((p, i) => (p, i)))
         {
-            object distinct = DistinctValueFor(property, ordinal);
+            object distinct = DistinctValueFor(property, ordinal, property.GetValue(defaults));
 
             // Without this, a property whose distinct value happened to equal its default would be
             // reported as carried over even when the constructor never assigns it.
@@ -116,7 +116,7 @@ public class SearchOptionsCopyConstructorTests
     /// transposed one (<c>StartSurrogateId = other.EndSurrogateId</c>) does not slip through two properties
     /// that share a type.
     /// </summary>
-    private static object DistinctValueFor(PropertyInfo property, int ordinal)
+    private static object DistinctValueFor(PropertyInfo property, int ordinal, object? defaultValue)
     {
         Type type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
 
@@ -138,11 +138,12 @@ public class SearchOptionsCopyConstructorTests
         if (type.IsEnum)
         {
             // Rotated by ordinal so two properties sharing an enum type still get different members and a
-            // transposition between them is caught. Index 0 is skipped: this codebase's enums use it for
-            // "unset/none", which is always the default, so landing there would trip the guard below.
-            Array values = Enum.GetValues(type);
-            int index = 1 + (ordinal % (values.Length - 1));
-            return values.GetValue(index)!;
+            // transposition between them is caught. The property's actual default is excluded from the
+            // rotation set rather than assuming it's the enum's zero value -- ResourceVersionTypes, for
+            // example, defaults to Latest, not None -- so this can't land on the default no matter which
+            // ordinal a future property change gives it.
+            object[] nonDefaultValues = Enum.GetValues(type).Cast<object>().Where(v => !Equals(v, defaultValue)).ToArray();
+            return nonDefaultValues[ordinal % nonDefaultValues.Length];
         }
 
         if (type == typeof(Expression))

--- a/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
+++ b/test/Ignixa.Application.Tests/Search/Parsing/IrProjectorTests.cs
@@ -207,9 +207,11 @@ public class IrProjectorTests
     }
 
     [Fact]
-    public void GivenAnOfTypeModifier_WhenDescribed_ThenTheUntypedFieldShapesItBindsToStillProject()
+    public void GivenAnOfTypeModifier_WhenDescribed_ThenItProjectsAsASingleTypedPredicateRatherThanFlattenedFields()
     {
-        // Arrange
+        // Arrange -- of-type keeps its typed OfTypeTokenSearchValue instead of flattening into field-level
+        // AND expressions (see SearchExpressionBinder.BindOfType), so it projects like any other predicate
+        // rather than as an "and" of untyped field shapes.
         var ir = ParsePatient(
             ("identifier", SearchParamType.Token),
             ("identifier:of-type", "http://ignixa.test/v2-0203|MR|446053"));
@@ -218,10 +220,8 @@ public class IrProjectorTests
         var rows = IrProjector.Describe(ir);
 
         // Assert
-        rows[0].Kind.ShouldBe("param");
-        rows.ShouldContain(row => row.Kind == "and");
-        rows.Where(row => row.Kind == "stringField").ShouldNotBeEmpty();
-        rows[0].Depth.ShouldBe(0);
+        rows.Select(row => (row.Kind, row.Depth)).ShouldBe([("param", 0), ("predicate", 1)]);
+        rows[0].Text.ShouldBe("Param identifier");
     }
 
     [Fact]

--- a/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
+++ b/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
@@ -89,6 +89,11 @@ public class DdlSchemaParityGuardTests
         decomposed.ShouldNotBeEmpty();
         baseSchema.ShouldNotBeEmpty();
 
+        // TablesNotInBaseSchema only ever suppresses -- FindMismatches never asserts these parsed at all, so
+        // a table dropped or renamed to something DdlTableParser can't parse (e.g. a bracketed identifier)
+        // would silently vanish from `decomposed` and the guard would still pass. Assert presence directly.
+        TablesNotInBaseSchema.ShouldBeSubsetOf(decomposed.Keys);
+
         // Act
         var mismatches = FindMismatches(baseSchema, decomposed, KnownExtensionColumns, TablesNotInBaseSchema);
 

--- a/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
+++ b/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
@@ -23,22 +23,33 @@ namespace Ignixa.RepoGuards.Tests;
 /// arrive only via migrations that were never folded into <c>97.sql</c> (<see
 /// cref="TablesNotInBaseSchema"/>). Both lists are closed sets tied to a specific migration file -- a
 /// table or column showing up in <c>Tables/*.sql</c> outside those lists, unexplained by either baseline,
-/// fails loud here instead of shipping unverified.
+/// fails loud here instead of shipping unverified. <see cref="KnownExtensionColumns"/>' values are the
+/// column shape the migration actually declares, not just a name to suppress -- so a re-widened extension
+/// column is still caught, not silently allowlisted away.
+/// <para>
+/// The comparison itself (<see cref="FindMismatches"/>) is exercised directly against hand-written
+/// fixtures in <see cref="GivenAColumnTypeMismatchNotOnTheAllowlist_WhenCompared_ThenItIsReported"/> and
+/// its siblings, so a bug in the comparison logic (an inverted condition, an allowlist check that never
+/// fires) has a failing test of its own instead of relying solely on the real-file test, which only ever
+/// exercises the current, already-agreeing repo state.
+/// </para>
 /// </remarks>
 public class DdlSchemaParityGuardTests
 {
     /// <summary>
-    /// Columns present in <c>Tables/*.sql</c> for a table that also exists in <c>97.sql</c>, added after
-    /// the base schema by a migration that alters the existing table. See
-    /// <c>Migrations/20251230193724_AddSearchParamExtensionColumns.cs</c>.
+    /// The column shape <c>Tables/*.sql</c> declares for a column that also exists on a table in
+    /// <c>97.sql</c>, added after the base schema by a migration that alters the existing table. Values
+    /// come from the migration's own <c>AddColumn</c> arguments, not just copied from
+    /// <c>Tables/*.sql</c> -- so a column re-widened in the decomposed DDL without a matching migration
+    /// still fails here. See <c>Migrations/20251230193724_AddSearchParamExtensionColumns.cs</c>.
     /// </summary>
-    private static readonly HashSet<(string Table, string Column)> KnownExtensionColumns =
-    [
-        ("UriSearchParam", "Fragment"),
-        ("UriSearchParam", "Version"),
-        ("TokenSearchParam", "IdentifierTypeCode"),
-        ("TokenSearchParam", "IdentifierTypeSystemId"),
-    ];
+    private static readonly Dictionary<(string Table, string Column), DdlColumn> KnownExtensionColumns = new()
+    {
+        [("UriSearchParam", "Fragment")] = Column("Fragment", "nvarchar", 128, isNullable: true),
+        [("UriSearchParam", "Version")] = Column("Version", "nvarchar", 64, isNullable: true),
+        [("TokenSearchParam", "IdentifierTypeCode")] = Column("IdentifierTypeCode", "nvarchar", 256, isNullable: true),
+        [("TokenSearchParam", "IdentifierTypeSystemId")] = Column("IdentifierTypeSystemId", "int", null, isNullable: true),
+    };
 
     /// <summary>
     /// Catalog-filtered tables that exist only in <c>Tables/*.sql</c> because a migration created them
@@ -78,17 +89,200 @@ public class DdlSchemaParityGuardTests
         decomposed.ShouldNotBeEmpty();
         baseSchema.ShouldNotBeEmpty();
 
-        // Act & Assert -- every catalog table not explicitly known to be migration-only must exist in the
-        // base schema, and for those that exist in both, every column not on the known-extensions
-        // allowlist must match exactly (type, width, nullability). A mismatch here means the compiler is
-        // deriving widths from a file that no longer describes the deployed database.
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, KnownExtensionColumns, TablesNotInBaseSchema);
+
+        // Assert -- a mismatch here means the compiler is deriving widths from a file that no longer
+        // describes the deployed database.
+        mismatches.ShouldBeEmpty(string.Join("\n", mismatches));
+    }
+
+    [Fact]
+    public void GivenAColumnTypeMismatchNotOnTheAllowlist_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- Code is varchar(256) in the base schema but nvarchar(256) in the decomposed DDL.
+        var baseSchema = Schema(Table("TokenSearchParam", Column("Code", "varchar", 256, isNullable: false)));
+        var decomposed = Schema(Table("TokenSearchParam", Column("Code", "nvarchar", 256, isNullable: false)));
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("TokenSearchParam.Code");
+    }
+
+    [Fact]
+    public void GivenACollationMismatchNotOnTheAllowlist_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- same type and width, different collation. This is exactly the kind of drift the
+        // guard exists to catch: token/string comparisons are case-sensitive or not depending on
+        // collation, so a silently-changed collation changes search results, not just storage.
+        var baseSchema = Schema(Table(
+            "TokenSearchParam",
+            Column("Code", "varchar", 256, isNullable: false, collation: "Latin1_General_100_CS_AS")));
+        var decomposed = Schema(Table(
+            "TokenSearchParam",
+            Column("Code", "varchar", 256, isNullable: false, collation: "Latin1_General_100_CI_AI")));
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("TokenSearchParam.Code");
+    }
+
+    [Fact]
+    public void GivenAColumnMissingFromTheDecomposedDdl_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- the base schema has SystemId; the decomposed DDL dropped it.
+        var baseSchema = Schema(Table(
+            "TokenSearchParam",
+            Column("Code", "varchar", 256, isNullable: false),
+            Column("SystemId", "int", null, isNullable: true)));
+        var decomposed = Schema(Table("TokenSearchParam", Column("Code", "varchar", 256, isNullable: false)));
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("TokenSearchParam.SystemId");
+        mismatches[0].ShouldContain("missing from Tables");
+    }
+
+    [Fact]
+    public void GivenAnUnlistedExtraColumn_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- the decomposed DDL has a column the base schema doesn't, and it's not on either
+        // allowlist.
+        var baseSchema = Schema(Table("TokenSearchParam", Column("Code", "varchar", 256, isNullable: false)));
+        var decomposed = Schema(Table(
+            "TokenSearchParam",
+            Column("Code", "varchar", 256, isNullable: false),
+            Column("MysteryColumn", "int", null, isNullable: true)));
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("TokenSearchParam.MysteryColumn");
+        mismatches[0].ShouldContain(nameof(KnownExtensionColumns));
+    }
+
+    [Fact]
+    public void GivenAKnownExtensionColumnReWidenedInTheDecomposedDdl_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- Fragment is on the allowlist by name, but its shape here no longer matches what the
+        // migration actually declares. Being on the allowlist must not suppress this.
+        var baseSchema = Schema(Table("UriSearchParam", Column("Uri", "varchar", 256, isNullable: false)));
+        var decomposed = Schema(Table(
+            "UriSearchParam",
+            Column("Uri", "varchar", 256, isNullable: false),
+            Column("Fragment", "nvarchar", 512, isNullable: true)));
+
+        // Act
+        var mismatches = FindMismatches(
+            baseSchema,
+            decomposed,
+            knownExtensionColumns: new Dictionary<(string, string), DdlColumn>
+            {
+                [("UriSearchParam", "Fragment")] = Column("Fragment", "nvarchar", 128, isNullable: true),
+            },
+            tablesNotInBaseSchema: []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("UriSearchParam.Fragment");
+    }
+
+    [Fact]
+    public void GivenAnUnlistedTableOnlyInTheDecomposedDdl_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- a whole table exists only in the decomposed DDL and isn't on the allowlist.
+        var baseSchema = Schema();
+        var decomposed = Schema(Table("MysteryTable", Column("Id", "int", null, isNullable: false)));
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("MysteryTable");
+        mismatches[0].ShouldContain(nameof(TablesNotInBaseSchema));
+    }
+
+    [Fact]
+    public void GivenATableOnlyInTheBaseSchema_WhenCompared_ThenItIsReported()
+    {
+        // Arrange -- a catalog table exists in 97.sql but was dropped from Tables/*.sql. There's no
+        // allowlist for this direction: Tables/*.sql is a superset of 97.sql (base schema plus known
+        // migrations), so a table 97.sql has and Tables/*.sql doesn't is always a real gap -- exactly
+        // what SqlCatalog.Table("...") would fail to look up at runtime.
+        var baseSchema = Schema(Table("ResourceType", Column("Name", "nvarchar", 50, isNullable: false)));
+        var decomposed = Schema();
+
+        // Act
+        var mismatches = FindMismatches(baseSchema, decomposed, [], []);
+
+        // Assert
+        mismatches.ShouldHaveSingleItem();
+        mismatches[0].ShouldContain("ResourceType");
+    }
+
+    [Fact]
+    public void GivenDifferencesCoveredByBothAllowlists_WhenCompared_ThenNothingIsReported()
+    {
+        // Arrange -- mirrors the real Tables/*.sql vs 97.sql relationship: an extension column on a
+        // shared table, plus a whole table that only exists via migration.
+        var baseSchema = Schema(Table("UriSearchParam", Column("Uri", "varchar", 256, isNullable: false)));
+        var decomposed = Schema(
+            Table(
+                "UriSearchParam",
+                Column("Uri", "varchar", 256, isNullable: false),
+                Column("Fragment", "nvarchar", 128, isNullable: true)),
+            Table("SourceEvents", Column("Id", "int", null, isNullable: false)));
+
+        // Act
+        var mismatches = FindMismatches(
+            baseSchema,
+            decomposed,
+            knownExtensionColumns: new Dictionary<(string, string), DdlColumn>
+            {
+                [("UriSearchParam", "Fragment")] = Column("Fragment", "nvarchar", 128, isNullable: true),
+            },
+            tablesNotInBaseSchema: ["SourceEvents"]);
+
+        // Assert
+        mismatches.ShouldBeEmpty(string.Join("\n", mismatches));
+    }
+
+    /// <summary>
+    /// Compares <paramref name="baseSchema"/> (the DB provisioning script) against
+    /// <paramref name="decomposed"/> (the source generator's DDL) table by table, treating both allowlists
+    /// as closed sets -- anything outside them is reported. Pulled out of the real-file test so the
+    /// comparison logic itself has fixture-driven coverage independent of the current repo state.
+    /// </summary>
+    private static List<string> FindMismatches(
+        IReadOnlyDictionary<string, DdlTable> baseSchema,
+        IReadOnlyDictionary<string, DdlTable> decomposed,
+        Dictionary<(string Table, string Column), DdlColumn> knownExtensionColumns,
+        HashSet<string> tablesNotInBaseSchema)
+    {
         var mismatches = new List<string>();
+
+        foreach (var tableName in baseSchema.Keys.Except(decomposed.Keys))
+        {
+            mismatches.Add($"{tableName}: present in 97.sql but missing entirely from Tables/*.sql.");
+        }
 
         foreach (var (tableName, decomposedTable) in decomposed)
         {
             if (!baseSchema.TryGetValue(tableName, out var baseTable))
             {
-                if (!TablesNotInBaseSchema.Contains(tableName))
+                if (!tablesNotInBaseSchema.Contains(tableName))
                 {
                     mismatches.Add(
                         $"{tableName}: present in Tables/*.sql but not in 97.sql, and not on the known " +
@@ -120,17 +314,28 @@ public class DdlSchemaParityGuardTests
 
             foreach (var columnName in decomposedColumns.Keys.Except(baseColumns.Keys))
             {
-                if (!KnownExtensionColumns.Contains((tableName, columnName)))
+                var decomposedColumn = decomposedColumns[columnName];
+
+                if (!knownExtensionColumns.TryGetValue((tableName, columnName), out var expectedColumn))
                 {
                     mismatches.Add(
                         $"{tableName}.{columnName}: in Tables/*.sql but not in 97.sql, and not on the " +
                         $"known-extension-columns allowlist. Add it to {nameof(KnownExtensionColumns)} " +
                         "if a migration genuinely added it, or fix the drift otherwise.");
+                    continue;
+                }
+
+                if (!ColumnsMatch(expectedColumn, decomposedColumn))
+                {
+                    mismatches.Add(
+                        $"{tableName}.{columnName}: known extension column expected to be " +
+                        $"{Describe(expectedColumn)} (per the migration that added it), Tables/*.sql has " +
+                        $"{Describe(decomposedColumn)}.");
                 }
             }
         }
 
-        mismatches.ShouldBeEmpty(string.Join("\n", mismatches));
+        return mismatches;
     }
 
     private static IReadOnlyList<DdlTable> ParseFile(string repoRoot, string relativePath) =>
@@ -141,11 +346,20 @@ public class DdlSchemaParityGuardTests
     private static Dictionary<string, DdlTable> IndexByTable(IReadOnlyList<DdlTable> tables) =>
         tables.ToDictionary(t => t.TableName, StringComparer.Ordinal);
 
+    private static Dictionary<string, DdlTable> Schema(params DdlTable[] tables) => IndexByTable(tables);
+
+    private static DdlTable Table(string name, params DdlColumn[] columns) => new("dbo", name, columns);
+
+    private static DdlColumn Column(string name, string sqlType, int? maxLength, bool isNullable, string? collation = null) =>
+        new(name, sqlType, maxLength, collation, isNullable);
+
     private static bool ColumnsMatch(DdlColumn expected, DdlColumn actual) =>
         expected.SqlType == actual.SqlType
             && expected.MaxLength == actual.MaxLength
-            && expected.IsNullable == actual.IsNullable;
+            && expected.IsNullable == actual.IsNullable
+            && expected.Collation == actual.Collation;
 
     private static string Describe(DdlColumn column) =>
-        $"{column.SqlType}({column.MaxLength?.ToString() ?? "n/a"}), nullable={column.IsNullable}";
+        $"{column.SqlType}({column.MaxLength?.ToString() ?? "n/a"}), nullable={column.IsNullable}, " +
+        $"collation={column.Collation ?? "n/a"}";
 }

--- a/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
+++ b/test/Ignixa.RepoGuards.Tests/DdlSchemaParityGuardTests.cs
@@ -1,0 +1,151 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Ignixa.Search.Sql.Generators;
+using Shouldly;
+
+namespace Ignixa.RepoGuards.Tests;
+
+/// <summary>
+/// Guards against <c>src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/*.sql</c> -- the DDL
+/// <see cref="SqlCatalogGenerator"/> reads to derive column widths the SQL compiler trusts (see
+/// <see cref="Ignixa.Search.Sql.TokenColumnEquality"/> and <c>SearchParamColumnWidths</c>) -- silently
+/// drifting from <c>src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Resources/97.sql</c>, the script
+/// that actually provisions the database. Nothing else checks the two agree: the generator only parses
+/// whichever DDL it is pointed at, so a column renamed or re-widened in one file and not the other would
+/// build clean and silently emit SQL against the wrong shape.
+/// </summary>
+/// <remarks>
+/// <c>97.sql</c> is the base schema; a handful of columns arrive afterward via EF migrations that alter
+/// tables already in <c>97.sql</c> (<see cref="KnownExtensionColumns"/>), and a handful of whole tables
+/// arrive only via migrations that were never folded into <c>97.sql</c> (<see
+/// cref="TablesNotInBaseSchema"/>). Both lists are closed sets tied to a specific migration file -- a
+/// table or column showing up in <c>Tables/*.sql</c> outside those lists, unexplained by either baseline,
+/// fails loud here instead of shipping unverified.
+/// </remarks>
+public class DdlSchemaParityGuardTests
+{
+    /// <summary>
+    /// Columns present in <c>Tables/*.sql</c> for a table that also exists in <c>97.sql</c>, added after
+    /// the base schema by a migration that alters the existing table. See
+    /// <c>Migrations/20251230193724_AddSearchParamExtensionColumns.cs</c>.
+    /// </summary>
+    private static readonly HashSet<(string Table, string Column)> KnownExtensionColumns =
+    [
+        ("UriSearchParam", "Fragment"),
+        ("UriSearchParam", "Version"),
+        ("TokenSearchParam", "IdentifierTypeCode"),
+        ("TokenSearchParam", "IdentifierTypeSystemId"),
+    ];
+
+    /// <summary>
+    /// Catalog-filtered tables that exist only in <c>Tables/*.sql</c> because a migration created them
+    /// outright -- <c>97.sql</c> predates them and was never regenerated. See
+    /// <c>Migrations/20251104055142_AddBackgroundJobs.cs</c>,
+    /// <c>20251108000000_AddPackageResourceAndTerminologyIndexes.cs</c>,
+    /// <c>20251118050351_AddTerminologyImportTracking.cs</c>, and
+    /// <c>20251223154537_AddSourceEventsTable.cs</c>.
+    /// </summary>
+    private static readonly HashSet<string> TablesNotInBaseSchema =
+    [
+        "BackgroundJobs",
+        "PackageResource",
+        "SourceEvents",
+        "TermCodeSystem",
+        "TermConcept",
+        "TermConceptMap",
+        "TermConceptMapElement",
+        "TermValueSet",
+        "TermValueSetExpansion",
+    ];
+
+    [Fact]
+    public void GivenTheDecomposedTableDdl_WhenComparedToTheDatabaseProvisioningScript_ThenSharedTablesAgreeColumnForColumn()
+    {
+        // Arrange
+        var repoRoot = RepoRoot.Find();
+        var baseSchema = IndexByTable(ParseFile(
+            repoRoot, "src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Resources/97.sql"));
+        var catalogTablesDir = Path.Combine(
+            repoRoot, "src", "DataLayer", "Ignixa.DataLayer.SqlServer.Database", "Tables");
+        var decomposedDdl = string.Join(
+            "\n",
+            Directory.GetFiles(catalogTablesDir, "*.sql").Select(File.ReadAllText));
+        var decomposed = IndexByTable(DdlTableParser.ParseTables(decomposedDdl, SqlCatalogTableFilter.IsCatalogTable));
+
+        decomposed.ShouldNotBeEmpty();
+        baseSchema.ShouldNotBeEmpty();
+
+        // Act & Assert -- every catalog table not explicitly known to be migration-only must exist in the
+        // base schema, and for those that exist in both, every column not on the known-extensions
+        // allowlist must match exactly (type, width, nullability). A mismatch here means the compiler is
+        // deriving widths from a file that no longer describes the deployed database.
+        var mismatches = new List<string>();
+
+        foreach (var (tableName, decomposedTable) in decomposed)
+        {
+            if (!baseSchema.TryGetValue(tableName, out var baseTable))
+            {
+                if (!TablesNotInBaseSchema.Contains(tableName))
+                {
+                    mismatches.Add(
+                        $"{tableName}: present in Tables/*.sql but not in 97.sql, and not on the known " +
+                        $"migration-created-table allowlist. Add it to {nameof(TablesNotInBaseSchema)} " +
+                        "if a migration genuinely created it, or fix the drift otherwise.");
+                }
+
+                continue;
+            }
+
+            var baseColumns = baseTable.Columns.ToDictionary(c => c.Name, StringComparer.Ordinal);
+            var decomposedColumns = decomposedTable.Columns.ToDictionary(c => c.Name, StringComparer.Ordinal);
+
+            foreach (var (columnName, baseColumn) in baseColumns)
+            {
+                if (!decomposedColumns.TryGetValue(columnName, out var decomposedColumn))
+                {
+                    mismatches.Add($"{tableName}.{columnName}: in 97.sql but missing from Tables/*.sql.");
+                    continue;
+                }
+
+                if (!ColumnsMatch(baseColumn, decomposedColumn))
+                {
+                    mismatches.Add(
+                        $"{tableName}.{columnName}: 97.sql has {Describe(baseColumn)}, " +
+                        $"Tables/*.sql has {Describe(decomposedColumn)}.");
+                }
+            }
+
+            foreach (var columnName in decomposedColumns.Keys.Except(baseColumns.Keys))
+            {
+                if (!KnownExtensionColumns.Contains((tableName, columnName)))
+                {
+                    mismatches.Add(
+                        $"{tableName}.{columnName}: in Tables/*.sql but not in 97.sql, and not on the " +
+                        $"known-extension-columns allowlist. Add it to {nameof(KnownExtensionColumns)} " +
+                        "if a migration genuinely added it, or fix the drift otherwise.");
+                }
+            }
+        }
+
+        mismatches.ShouldBeEmpty(string.Join("\n", mismatches));
+    }
+
+    private static IReadOnlyList<DdlTable> ParseFile(string repoRoot, string relativePath) =>
+        DdlTableParser.ParseTables(
+            File.ReadAllText(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar))),
+            SqlCatalogTableFilter.IsCatalogTable);
+
+    private static Dictionary<string, DdlTable> IndexByTable(IReadOnlyList<DdlTable> tables) =>
+        tables.ToDictionary(t => t.TableName, StringComparer.Ordinal);
+
+    private static bool ColumnsMatch(DdlColumn expected, DdlColumn actual) =>
+        expected.SqlType == actual.SqlType
+            && expected.MaxLength == actual.MaxLength
+            && expected.IsNullable == actual.IsNullable;
+
+    private static string Describe(DdlColumn column) =>
+        $"{column.SqlType}({column.MaxLength?.ToString() ?? "n/a"}), nullable={column.IsNullable}";
+}

--- a/test/Ignixa.RepoGuards.Tests/Ignixa.RepoGuards.Tests.csproj
+++ b/test/Ignixa.RepoGuards.Tests/Ignixa.RepoGuards.Tests.csproj
@@ -15,10 +15,15 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\Ignixa.Search.Sql.Generators\Ignixa.Search.Sql.Generators.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Ignixa.Search.Sql.Generators.Tests/DdlTableParserRealDdlTests.cs
+++ b/test/Ignixa.Search.Sql.Generators.Tests/DdlTableParserRealDdlTests.cs
@@ -46,7 +46,9 @@ public class DdlTableParserRealDdlTests
     [Fact]
     public void GivenRealTokenSearchParamDdl_WhenParsed_ThenCodeColumnMatchesHandVerifiedCatalog()
     {
-        // Arrange -- copied verbatim from 97.sql lines 883-890
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenSearchParam.sql, plus the two
+        // IdentifierTypeCode/IdentifierTypeSystemId columns :of-type added
         var ddl = """
             CREATE TABLE dbo.TokenSearchParam (
                 ResourceTypeId      SMALLINT      NOT NULL,
@@ -54,7 +56,9 @@ public class DdlTableParserRealDdlTests
                 SearchParamId       SMALLINT      NOT NULL,
                 SystemId            INT           NULL,
                 Code                VARCHAR (256) COLLATE Latin1_General_100_CS_AS NOT NULL,
-                CodeOverflow        VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL
+                CodeOverflow        VARCHAR (MAX) COLLATE Latin1_General_100_CS_AS NULL,
+                IdentifierTypeCode      NVARCHAR (256) NULL,
+                IdentifierTypeSystemId  INT            NULL
             );
             """;
 
@@ -72,12 +76,22 @@ public class DdlTableParserRealDdlTests
         var systemId = table.Columns.Single(c => c.Name == "SystemId");
         systemId.SqlType.ShouldBe("int");
         systemId.IsNullable.ShouldBeTrue();
+
+        var identifierTypeCode = table.Columns.Single(c => c.Name == "IdentifierTypeCode");
+        identifierTypeCode.SqlType.ShouldBe("nvarchar");
+        identifierTypeCode.MaxLength.ShouldBe(256);
+        identifierTypeCode.IsNullable.ShouldBeTrue();
+
+        var identifierTypeSystemId = table.Columns.Single(c => c.Name == "IdentifierTypeSystemId");
+        identifierTypeSystemId.SqlType.ShouldBe("int");
+        identifierTypeSystemId.IsNullable.ShouldBeTrue();
     }
 
     [Fact]
     public void GivenRealTokenQuantityCompositeSearchParamDdl_WhenParsed_ThenDecimalColumnsParseCorrectly()
     {
-        // Arrange -- copied verbatim from 97.sql lines 848-860
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/TokenQuantityCompositeSearchParam.sql
         var ddl = """
             CREATE TABLE dbo.TokenQuantityCompositeSearchParam (
                 ResourceTypeId      SMALLINT         NOT NULL,
@@ -115,7 +129,8 @@ public class DdlTableParserRealDdlTests
     [Fact]
     public void GivenRealReferenceSearchParamDdl_WhenParsed_ThenReferenceResourceIdColumnMatchesHandVerifiedCatalog()
     {
-        // Arrange -- copied verbatim from 97.sql lines 518-526
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ReferenceSearchParam.sql
         var ddl = """
             CREATE TABLE dbo.ReferenceSearchParam (
                 ResourceTypeId           SMALLINT      NOT NULL,
@@ -147,8 +162,10 @@ public class DdlTableParserRealDdlTests
     [Fact]
     public void GivenRealResourceTypeDdl_WhenParsed_ThenNameColumnMatchesHandVerifiedCatalog()
     {
-        // Arrange -- copied verbatim from 97.sql lines 681-686 (includes IDENTITY column and
-        // table-level UNIQUE/PRIMARY KEY CLUSTERED constraints that must be skipped, not parsed as columns)
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/ResourceType.sql (includes IDENTITY
+        // column and table-level UNIQUE/PRIMARY KEY CLUSTERED constraints that must be skipped, not parsed
+        // as columns)
         var ddl = """
             CREATE TABLE dbo.ResourceType (
                 ResourceTypeId SMALLINT      IDENTITY (1, 1) NOT NULL,
@@ -174,7 +191,8 @@ public class DdlTableParserRealDdlTests
     [Fact]
     public void GivenRealSearchParamDdl_WhenParsed_ThenUriAndStatusColumnsMatchHandVerifiedCatalog()
     {
-        // Arrange -- copied verbatim from 97.sql lines 703-711
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/SearchParam.sql
         var ddl = """
             CREATE TABLE dbo.SearchParam (
                 SearchParamId        SMALLINT           IDENTITY (1, 1) NOT NULL,

--- a/test/Ignixa.Search.Sql.Generators.Tests/DdlTableParserRealDdlTests.cs
+++ b/test/Ignixa.Search.Sql.Generators.Tests/DdlTableParserRealDdlTests.cs
@@ -7,7 +7,8 @@ public class DdlTableParserRealDdlTests
     [Fact]
     public void GivenRealStringSearchParamDdl_WhenParsed_ThenTextColumnMatchesHandVerifiedCatalog()
     {
-        // Arrange -- copied verbatim from src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Resources/97.sql lines 713-721
+        // Arrange -- copied verbatim from
+        // src/DataLayer/Ignixa.DataLayer.SqlServer.Database/Tables/StringSearchParam.sql lines 1-9
         var ddl = """
             CREATE TABLE dbo.StringSearchParam (
                 ResourceTypeId      SMALLINT       NOT NULL,

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitProbeRowIncludeSeedTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitProbeRowIncludeSeedTests.cs
@@ -77,7 +77,16 @@ public class EmitProbeRowIncludeSeedTests
     [Fact]
     public void GivenAnUnpagedPlanWithAnInclude_WhenEmitted_ThenTheIncludeStageSeedsFromTheWholeMatchPage()
     {
-        // Arrange -- a Top-capped plan has no OffsetSpec at all and therefore no probe row.
+        // Arrange -- a Top-capped plan has no OffsetSpec at all, so this trim never engages for it.
+        //
+        // KNOWN GAP: this pins today's behavior, not a guarantee it is safe. Some Top callers use the same
+        // "ask for Top+1 to detect hasMore" convention OffsetSpec used to rely on before ProbeExtraRow made it
+        // explicit (see SearchPaging.Keyset's remarks) -- if such a caller combines that convention with
+        // Include stages, the same probe-row-leaks-into-includes bug this PR fixes for OffsetSpec would still
+        // reproduce here, undetected. No caller in this repo drives that combination yet (Ignixa.Search.Sql has
+        // no consumer here besides its own generator/tests until the SqlServer data-layer migration lands), so
+        // extending the trim to Top is deferred rather than speculatively designed against a caller that
+        // doesn't exist yet. See the NOTE in SqlBuilder.EmitIncludesShape.
         var plan = new QueryPlan(
             [new CteDefinition.ResourceSource(103)],
             new CteRef(0),

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitProbeRowIncludeSeedTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitProbeRowIncludeSeedTests.cs
@@ -1,0 +1,289 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+
+namespace Ignixa.Search.Sql.Tests.Ast;
+
+/// <summary>
+/// An over-fetched page returns Limit + 1 rows so the caller can detect a further page, then discards that
+/// last row. These cover the consequence for _include/_revinclude: the discarded probe row must not seed
+/// include stages, or its included resources survive into a bundle its own match row was trimmed out of.
+/// </summary>
+public class EmitProbeRowIncludeSeedTests
+{
+    [Fact]
+    public void GivenAnOverFetchingPageWithAnInclude_WhenEmitted_ThenTheIncludeStageSeedsFromTheProbeFreeMatchSeed()
+    {
+        // Arrange
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldContain(
+            "cteMatchSeed AS (\n" +
+            "    SELECT TOP (10) T1, Sid1\n" +
+            "    FROM cteMatchPage\n" +
+            "    ORDER BY T1 ASC, Sid1 ASC\n" +
+            ")");
+        sql.ShouldContain("SELECT 1 FROM cteMatchSeed m WHERE m.T1 = rsp.ResourceTypeId AND m.Sid1 = rsp.ResourceSurrogateId");
+        sql.ShouldNotContain("SELECT 1 FROM cteMatchPage m WHERE m.T1 = rsp.ResourceTypeId");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWithAnInclude_WhenEmitted_ThenTheMatchPageStillFetchesTheProbeRow()
+    {
+        // Arrange -- the probe row is what hasMore detection reads, so trimming the include seed must not
+        // shrink the match page itself.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain("OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(short)103, 20, 11]);
+    }
+
+    [Fact]
+    public void GivenAPageThatDoesNotOverFetch_WhenEmitted_ThenTheIncludeStageSeedsFromTheWholeMatchPage()
+    {
+        // Arrange -- no probe row means every fetched row is a genuine page member, so narrowing the seed
+        // would drop a legitimate match's includes.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(20, 10));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldNotContain("cteMatchSeed");
+        emitted.Sql.ShouldContain("SELECT 1 FROM cteMatchPage m WHERE m.T1 = rsp.ResourceTypeId AND m.Sid1 = rsp.ResourceSurrogateId");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(short)103, 20, 10]);
+    }
+
+    [Fact]
+    public void GivenAnUnpagedPlanWithAnInclude_WhenEmitted_ThenTheIncludeStageSeedsFromTheWholeMatchPage()
+    {
+        // Arrange -- a Top-capped plan has no OffsetSpec at all and therefore no probe row.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Top: 50,
+            Includes: [ForwardIncludeStage(103, 111)]);
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldNotContain("cteMatchSeed");
+        sql.ShouldContain("SELECT 1 FROM cteMatchPage m WHERE m.T1 = rsp.ResourceTypeId AND m.Sid1 = rsp.ResourceSurrogateId");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWithARevInclude_WhenEmitted_ThenTheRevIncludeStageAlsoSeedsFromTheMatchSeed()
+    {
+        // Arrange -- a reverse stage correlates through r, not rsp, so it reaches the seed by a different
+        // alias and would regress independently of the forward direction.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ReverseIncludeStage(103, 112)],
+            OffsetPage: new OffsetSpec(0, 1, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldContain("SELECT TOP (1) T1, Sid1\n    FROM cteMatchPage");
+        sql.ShouldContain("SELECT 1 FROM cteMatchSeed m WHERE m.T1 = r.ResourceTypeId AND m.Sid1 = r.ResourceSurrogateId");
+        sql.ShouldNotContain("SELECT 1 FROM cteMatchPage m WHERE m.T1 = r.ResourceTypeId");
+    }
+
+    [Fact]
+    public void GivenAnIncludeReachableFromBothAKeptMatchAndTheProbeRow_WhenEmitted_ThenTheSeedIsAnExistentialOverEveryKeptMatch()
+    {
+        // Arrange -- the sharing case cannot be resolved by dropping include rows after the fact: an
+        // included resource reachable from BOTH a kept match and the probe row belongs in the page.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(0, 5, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert -- EXISTS over the seed set, so ONE qualifying kept match is enough to keep the row; and
+        // the stage body is DISTINCT, so reachability from several kept matches still yields one row.
+        sql.ShouldContain(
+            "    WHERE rsp.SearchParamId = 210\n" +
+            "      AND rsp.ResourceTypeId = 103\n" +
+            "      AND r.ResourceTypeId = 111\n" +
+            "      AND rsp.BaseUri IS NULL\n" +
+            "      AND EXISTS (\n" +
+            "        SELECT 1 FROM cteMatchSeed m WHERE m.T1 = rsp.ResourceTypeId AND m.Sid1 = rsp.ResourceSurrogateId\n" +
+            "    )");
+        sql.ShouldContain("SELECT DISTINCT TOP (");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWithAnInclude_WhenEmitted_ThenTheMatchArmAndAntiJoinStillReadTheFullMatchPage()
+    {
+        // Arrange -- only the SEED narrows. The match arm must still emit the probe row (hasMore reads it),
+        // and the anti-join must still exclude every match-page row from the include arm, or the probe row
+        // would surface twice: once as a Match and once as an Include.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(0, 5, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldContain("CAST(1 AS bit) AS IsMatch, CAST(0 AS bit) AS IsPartial FROM cteMatchPage");
+        sql.ShouldContain("WHERE NOT EXISTS (SELECT 1 FROM cteMatchPage m WHERE m.T1 = i.T1 AND m.Sid1 = i.Sid1)");
+        sql.ShouldNotContain("NOT EXISTS (SELECT 1 FROM cteMatchSeed");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingSortedPageWithAnInclude_WhenEmitted_ThenTheMatchSeedRepeatsTheMatchPageOrdering()
+    {
+        // Arrange -- "the first N rows" is only well defined under the match page's own ordering. A custom
+        // sort key drops the T1 tiebreak, so the seed must drop it too or it takes a different N rows.
+        var sort = new SortSpec([new SortKey(202, SortKeyKind.String, SortOrder.Descending)], SortPhase.Valued);
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            Sort: sort,
+            OffsetPage: new OffsetSpec(0, 5, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldContain("    ORDER BY sk0.Text DESC, m.Sid1 ASC\n    OFFSET");
+        sql.ShouldContain(
+            "cteMatchSeed AS (\n" +
+            "    SELECT TOP (5) T1, Sid1\n" +
+            "    FROM cteMatchPage\n" +
+            "    ORDER BY SortValue0 DESC, Sid1 ASC\n" +
+            ")");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWhoseWholeBudgetIsTheProbeRow_WhenEmitted_ThenTheMatchSeedAdmitsNoRows()
+    {
+        // Arrange -- the two-phase sort executor's floor case: the earlier phase already filled the page, so
+        // this phase's only row is the lookahead. It is fetched, but nothing on it may pull includes.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111)],
+            OffsetPage: new OffsetSpec(7, 0, ProbeExtraRow: true));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        SqlGrammar.AssertValid(emitted.Sql);
+        emitted.Sql.ShouldContain("SELECT TOP (0) T1, Sid1\n    FROM cteMatchPage");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(short)103, 7, 1]);
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWhoseOnlyStageSeedsFromAnEarlierStage_WhenEmitted_ThenNoUnreferencedMatchSeedIsEmitted()
+    {
+        // Arrange -- nothing reads the match page, so emitting a seed CTE would be dead SQL.
+        var iterateOnly = ForwardIncludeStage(103, 111) with { SeedFromMatch = false, SeedStages = [], Iterate = false };
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [iterateOnly],
+            OffsetPage: new OffsetSpec(0, 5, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        sql.ShouldNotContain("cteMatchSeed");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWithChainedIncludeStages_WhenEmitted_ThenTheEmittedSqlIsValidAndFullyDefined()
+    {
+        // Arrange -- an :iterate stage seeds from the earlier stage's limit companion, not from the match
+        // page, so the two seed labels coexist in one statement.
+        var stage0 = ForwardIncludeStage(103, 111);
+        var stage1 = ForwardIncludeStage(111, 112) with { SeedStages = [0], Iterate = true };
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [stage0, stage1],
+            OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
+
+        // Act
+        var sql = SqlBuilder.Run(plan).Sql;
+
+        // Assert
+        SqlGrammar.AssertValid(sql);
+        SqlGrammar.AssertEveryReferencedCteIsDefined(sql);
+        sql.ShouldContain("SELECT 1 FROM cteMatchSeed m WHERE");
+        sql.ShouldContain("SELECT 1 FROM inc0lim m WHERE");
+    }
+
+    [Fact]
+    public void GivenAnOverFetchingPageWithNoIncludes_WhenEmitted_ThenTheFetchStillCountsTheProbeRow()
+    {
+        // Arrange -- the no-includes shape has no seed to narrow, but must still fetch the probe row.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain("OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY");
+        emitted.Sql.ShouldNotContain("cteMatchSeed");
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(short)103, 20, 10 + 1]);
+    }
+
+    [Fact]
+    public void GivenAZeroLimitPageWithoutAProbeRow_WhenEmitted_ThenThrowsNotSupportedException()
+    {
+        // Arrange -- a zero fetch is what OFFSET/FETCH rejects; a zero page WITH a probe row still fetches
+        // one and is legal, so the guard has to test the fetch count rather than the limit.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            OffsetPage: new OffsetSpec(0, 0));
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => SqlBuilder.Run(plan));
+    }
+
+    private static IncludeStage ForwardIncludeStage(short seedType, short outputType)
+        => new(IncludeDirection.Forward, ReferenceSearchParamId: 210, SeedTypeIds: [seedType], OutputTypeIds: [outputType],
+               SeedStages: [], SeedFromMatch: true, Iterate: false, Limit: 1000);
+
+    private static IncludeStage ReverseIncludeStage(short seedType, short outputType)
+        => new(IncludeDirection.Reverse, ReferenceSearchParamId: 211, SeedTypeIds: [seedType], OutputTypeIds: [outputType],
+               SeedStages: [], SeedFromMatch: true, Iterate: false, Limit: 1000);
+}

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTableExistsPredicateTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTableExistsPredicateTests.cs
@@ -1,0 +1,46 @@
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+using Ignixa.Search.Sql.Catalog;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Ast;
+
+public class EmitTableExistsPredicateTests
+{
+    [Fact]
+    public void GivenATableExistsPredicateWithNoPredicate_WhenEmitted_ThenSelectsWithNoWhereClause()
+    {
+        // Arrange -- "does this resource have any date-typed search-index row at all"
+        var table = SqlCatalog.Default.Table("DateTimeSearchParam");
+        var plan = new QueryPlan([new CteDefinition.TableExistsPredicate(table)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- no Top specified on the plan, so Emit's own default (no TOP clause) applies (see
+        // EmitTests.cs's CompartmentSource-only case for the same no-Top rendering).
+        emitted.Sql.ShouldBe(
+            ";WITH cte0 AS (\n" +
+            "    SELECT DISTINCT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1\n" +
+            "    FROM dbo.DateTimeSearchParam\n" +
+            ")\n" +
+            "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
+            "ORDER BY m.T1 ASC, m.Sid1 ASC");
+    }
+
+    [Fact]
+    public void GivenATableExistsPredicateWithADateRangePredicate_WhenEmitted_ThenFiltersByIt()
+    {
+        // Arrange -- "does this resource have a date-typed row matching this range"
+        var table = SqlCatalog.Default.Table("DateTimeSearchParam");
+        var predicate = new Predicate.GreaterThanOrEqual(new SqlColumnRef(table.TableName, "StartDateTime"), new SqlParameterRef("2020-01-01T00:00:00.0000000"));
+        var plan = new QueryPlan([new CteDefinition.TableExistsPredicate(table, predicate)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert
+        emitted.Sql.ShouldContain("WHERE StartDateTime >= @p0");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitTests.cs
@@ -2723,6 +2723,49 @@ public class EmitTests
         sql.ShouldNotContain("FETCH");
     }
 
+    [Fact]
+    public void GivenANoIncludesPlanWithOffsetPage_WhenExplained_ThenTheOffsetPageRowNamesTheSameOrdinalsEmitBinds()
+    {
+        // Arrange -- same fixture as GivenANoIncludesPlanWithOffsetPage_WhenEmitted_ThenEmitsOffsetFetchAfterOrderBy,
+        // whose emitted SQL binds OFFSET/FETCH at @p1/@p2 (cte0's own predicate takes @p0). Explain() must
+        // agree, or a plan trace built from it points a caller at the wrong bound value.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            OffsetPage: new OffsetSpec(20, 10));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var explained = plan.Explain();
+
+        // Assert
+        emitted.Sql.ShouldContain("OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY");
+        explained.ShouldContain("offsetPage = OffsetSpec(offset=@p1, fetch=@p2)");
+    }
+
+    [Fact]
+    public void GivenAnIncludesPlanWithOffsetPage_WhenExplained_ThenTheOffsetPageRowStillMatchesEmitsOrdinals()
+    {
+        // Arrange -- same fixture as GivenAnIncludesPlanWithOffsetPage_WhenEmitted_ThenMatchPageCteEmitsOrderByAndOffsetFetch.
+        // WriteMatchPageCte binds OFFSET/FETCH inside cteMatchPage, not the top-level SELECT, but at the same
+        // ordinal position -- Explain()'s row must not drift just because Includes moved the clause.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [ForwardIncludeStage(103, 111, 10)],
+            OffsetPage: new OffsetSpec(20, 10));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var explained = plan.Explain();
+
+        // Assert
+        emitted.Sql.ShouldContain("OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY");
+        explained.ShouldContain("offsetPage = OffsetSpec(offset=@p1, fetch=@p2)");
+    }
+
     // ─── End OffsetPage tests ───────────────────────────────────────────────────────────────────────
 
     // ─── Phase-scoped count tests ───────────────────────────────────────────────────────────────────

--- a/test/Ignixa.Search.Sql.Tests/Ast/EmitVisibleSinceFilterTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/EmitVisibleSinceFilterTests.cs
@@ -1,0 +1,35 @@
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Ast;
+
+public class EmitVisibleSinceFilterTests
+{
+    [Fact]
+    public void GivenAVisibleSinceFilter_WhenEmitted_ThenJoinsTransactionsOnVisibleDate()
+    {
+        // Arrange
+        var since = new SqlParameterRef("2020-01-01T00:00:00.0000000");
+        var plan = new QueryPlan([new CteDefinition.VisibleSinceFilter(since)], new CteRef(0));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- no Top specified on the plan, so Emit's own default (no TOP clause) applies (see
+        // EmitTableExistsPredicateTests's no-predicate case for the same no-Top rendering). The default
+        // visibility clause is part of the expected SQL: this emitter originally emitted no visibility
+        // filter at all, which left one $everything CTE kind outside the contract every other emitter
+        // honours -- a resource deleted or superseded since the cutoff would still have come back.
+        emitted.Sql.ShouldBe(
+            ";WITH cte0 AS (\n" +
+            "    SELECT DISTINCT r.ResourceTypeId AS T1, r.ResourceSurrogateId AS Sid1\n" +
+            "    FROM dbo.Resource r\n" +
+            "    INNER JOIN dbo.Transactions t ON r.TransactionId = t.SurrogateIdRangeFirstValue\n" +
+            "    WHERE t.VisibleDate >= @p0 AND r.IsHistory = 0 AND r.IsDeleted = 0\n" +
+            ")\n" +
+            "SELECT m.T1, m.Sid1 FROM cte0 m\n" +
+            "ORDER BY m.T1 ASC, m.Sid1 ASC");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
@@ -174,6 +174,7 @@ public class PlanExplainerTests
         // Assert
         explained.ShouldBe(
             "root = StringSearchParam[103,202]  Text = @p0\n" +
+            "matchPage = MatchPageCte(top=none, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)");
     }
 
@@ -192,6 +193,7 @@ public class PlanExplainerTests
         // Assert
         explained.ShouldBe(
             "root = StringSearchParam[103,202]  Text = @p0\n" +
+            "matchPage = MatchPageCte(top=none, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=*, seedTypes=*, outputTypes=*, seeds=[match], limit=500 iterate, Reverse)");
     }
 
@@ -463,5 +465,92 @@ public class PlanExplainerTests
             "cte0 = MultiTypeResourceSource[103,104]\n" +
             "cte1 = StringSearchParam[103,202]  Text = @p0\n" +
             "root = Intersect(cte0, cte1)");
+    }
+
+    [Fact]
+    public void GivenASurrogateRangePlan_WhenExplained_ThenTheSurrogateRangeRowNamesTheSameOrdinalsEmitBinds()
+    {
+        // Arrange -- SurrogateRange is how $export shards its read window; BuildMatchWhereClauses binds it
+        // right after the seek/outer predicate and before ORDER BY, so its ordinals land after cte0's own.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            SurrogateRange: new SurrogateIdRange(new SqlParameterRef(5000L), new SqlParameterRef(6000L)));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var explained = plan.Explain();
+
+        // Assert
+        emitted.Parameters.Select(p => p.Value).ShouldBe(["Smith", 5000L, 6000L]);
+        explained.ShouldContain("surrogateRange = SurrogateRange(start=@p1, end=@p2)");
+    }
+
+    [Fact]
+    public void GivenASearchParameterHashPlan_WhenExplained_ThenTheHashRowNamesTheSameOrdinalEmitBinds()
+    {
+        // Arrange -- SearchParameterHash gates reindex eligibility; its ordinal comes right after
+        // SurrogateRange's in BuildMatchWhereClauses, so combining both proves the rows don't collide.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            SurrogateRange: new SurrogateIdRange(new SqlParameterRef(5000L), new SqlParameterRef(6000L)),
+            SearchParameterHash: new SqlParameterRef("abc123"));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var explained = plan.Explain();
+
+        // Assert
+        emitted.Parameters.Select(p => p.Value).ShouldBe(["Smith", 5000L, 6000L, "abc123"]);
+        explained.ShouldContain("surrogateRange = SurrogateRange(start=@p1, end=@p2)");
+        explained.ShouldContain("searchParameterHash = SearchParameterHash(hash=@p3)");
+    }
+
+    [Fact]
+    public void GivenAnIncludesPlanWithSortAndAnOuterPredicate_WhenExplained_ThenTheMatchPageRowReportsBothJoins()
+    {
+        // Arrange -- sortJoins and resourceJoin are false in every other matchPage fixture in this file;
+        // this one forces both true so PrintMatchPageCte's flags are proven on their true path too.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var outer = new Predicate.Equal(new SqlColumnRef("Resource", "ResourceId"), new SqlParameterRef("123"));
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            OuterPredicate: outer,
+            Includes: [new IncludeStage(IncludeDirection.Forward, 55, [103], [105], [], SeedFromMatch: true, Iterate: false, Limit: 10)],
+            Sort: new SortSpec([new SortKey(202, SortKeyKind.String, SortOrder.Ascending)], SortPhase.Valued),
+            Top: 25);
+
+        // Act
+        var explained = plan.Explain();
+
+        // Assert
+        explained.ShouldContain("matchPage = MatchPageCte(top=25, sortJoins=true, resourceJoin=true)");
+    }
+
+    [Fact]
+    public void GivenAProbeTrimmedIncludesPlanWithOffsetPage_WhenExplained_ThenTheMatchSeedRowReportsTheLimitNotTheFetchCount()
+    {
+        // Arrange -- ProbeExtraRow fetches Limit+1 rows so hasMore can be detected; cteMatchSeed trims that
+        // probe row back off before include stages seed from it. The row must show Limit (10), not
+        // FetchCount (11) -- reporting FetchCount here would misrepresent what include stages seed from.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [new IncludeStage(IncludeDirection.Forward, 55, [103], [105], [], SeedFromMatch: true, Iterate: false, Limit: 1000)],
+            OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
+
+        // Act
+        var explained = plan.Explain();
+
+        // Assert
+        explained.ShouldContain("matchSeed = MatchSeedCte(limit=10)");
+        explained.ShouldContain("offsetPage = OffsetSpec(offset=@p1, fetch=@p2)");
     }
 }

--- a/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Ast/PlanExplainerTests.cs
@@ -238,6 +238,49 @@ public class PlanExplainerTests
     }
 
     [Fact]
+    public void GivenAnIncludesOnlyPlanWithAResumeBoundaryAndSurrogateRangeAndHash_WhenExplained_ThenEveryRowNamesTheOrdinalsTheEmitterActuallyBinds()
+    {
+        // Arrange -- exactly the combination SqlBuilder's own RejectUnsupportedCombinations guard message
+        // recommends: bound the match set with SurrogateRange (an $export shard window) and page the include
+        // rows with ResultShape.IncludesPage.Resume. WriteMatchPageCte binds SurrogateRange and
+        // SearchParameterHash INSIDE itself, before the resume boundary is bound after it returns -- a
+        // regression that reorders includeBoundary back ahead of them would make every ordinal here wrong,
+        // and previously did (the boundary row used to render right after the CTE graph, before this pair).
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            Includes: [new IncludeStage(IncludeDirection.Forward, 55, [103], [105], [], SeedFromMatch: true, Iterate: false, Limit: 10)],
+            Shape: new ResultShape.IncludesPage(new IncludeBoundary(111, 5000)),
+            SurrogateRange: new SurrogateIdRange(new SqlParameterRef(7000L), new SqlParameterRef(8000L)),
+            SearchParameterHash: new SqlParameterRef("hashv"));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var rows = PlanExplainer.Describe(plan);
+
+        // Assert -- real bind order: cte0's own predicate, then SurrogateRange, then SearchParameterHash
+        // (both inside WriteMatchPageCte's BuildMatchWhereClauses call), then the resume boundary.
+        emitted.Parameters.Select(p => p.Value).ShouldBe(["Smith", 7000L, 8000L, "hashv", (short)111, 5000L]);
+
+        var surrogateRow = rows.Single(r => r.CanonicalLabel == "surrogateRange");
+        surrogateRow.Body.ShouldBe("SurrogateRange(start=@p1, end=@p2)");
+
+        var hashRow = rows.Single(r => r.CanonicalLabel == "searchParameterHash");
+        hashRow.Body.ShouldBe("SearchParameterHash(hash=@p3)");
+
+        var boundaryRow = rows.Single(r => r.CanonicalLabel == "includeBoundary");
+        boundaryRow.Body.ShouldBe("IncludeBoundary(type=@p4, sid=@p5)");
+
+        // Ordering, not just individual correctness: surrogateRange and searchParameterHash must both
+        // precede includeBoundary.
+        var labels = rows.Select(r => r.CanonicalLabel).ToList();
+        labels.IndexOf("surrogateRange").ShouldBeLessThan(labels.IndexOf("includeBoundary"));
+        labels.IndexOf("searchParameterHash").ShouldBeLessThan(labels.IndexOf("includeBoundary"));
+    }
+
+    [Fact]
     public void GivenACompartmentSourcePlan_WhenExplained_ThenPrintsTheGroupedTypeListAndSearchParamId()
     {
         // Arrange
@@ -535,11 +578,14 @@ public class PlanExplainerTests
     }
 
     [Fact]
-    public void GivenAProbeTrimmedIncludesPlanWithOffsetPage_WhenExplained_ThenTheMatchSeedRowReportsTheLimitNotTheFetchCount()
+    public void GivenAProbeTrimmedIncludesPlanWithOffsetPage_WhenExplained_ThenTheMatchSeedRowReportsTheLimitNotTheFetchCountAndOrdinalsMatchEmit()
     {
         // Arrange -- ProbeExtraRow fetches Limit+1 rows so hasMore can be detected; cteMatchSeed trims that
         // probe row back off before include stages seed from it. The row must show Limit (10), not
         // FetchCount (11) -- reporting FetchCount here would misrepresent what include stages seed from.
+        // Also cross-checks against the real emitted SQL: this is the one combination (ProbeExtraRow: true)
+        // where matchSeed actually appears, and a prior version of this test only ever called plan.Explain(),
+        // never SqlBuilder.Run -- so the ordinal claim was unverified for the one case it exists to cover.
         var plan = new QueryPlan(
             [new CteDefinition.ResourceSource(103)],
             new CteRef(0),
@@ -547,10 +593,74 @@ public class PlanExplainerTests
             OffsetPage: new OffsetSpec(20, 10, ProbeExtraRow: true));
 
         // Act
+        var emitted = SqlBuilder.Run(plan);
         var explained = plan.Explain();
 
-        // Assert
+        // Assert -- @p0 is cte0's own ResourceSource type id; @p1/@p2 are Offset/FetchCount (11 = Limit + probe row).
+        emitted.Parameters.Select(p => p.Value).ShouldBe([(short)103, 20, 11]);
         explained.ShouldContain("matchSeed = MatchSeedCte(limit=10)");
         explained.ShouldContain("offsetPage = OffsetSpec(offset=@p1, fetch=@p2)");
+    }
+
+    [Fact]
+    public void GivenAnIncludesPlanSortedOnlyByLastUpdated_WhenExplained_ThenTheMatchPageRowReportsNoSortJoin()
+    {
+        // Arrange -- EmitSortJoins skips LastUpdated/ResourceType keys entirely: the match set already
+        // projects the surrogate id those sort on, no join needed. Before this test, PrintMatchPageCte
+        // computed sortJoins as `plan.Sort is not null`, which is true here even though WriteMatchPageCte
+        // emits zero JOIN clauses for this exact plan -- a real divergence, not just an unlikely one:
+        // `_sort=_lastUpdated&_include=...` is an ordinary, common query shape.
+        var plan = new QueryPlan(
+            [new CteDefinition.ResourceSource(103)],
+            new CteRef(0),
+            Includes: [new IncludeStage(IncludeDirection.Forward, 55, [103], [105], [], SeedFromMatch: true, Iterate: false, Limit: 10)],
+            Sort: new SortSpec([new SortKey(null, SortKeyKind.LastUpdated, SortOrder.Descending)], SortPhase.Valued));
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+        var explained = plan.Explain();
+
+        // Assert -- "sk0" is EmitSortJoins' own alias for a sort-key join; the include stage still joins
+        // dbo.ReferenceSearchParam for its own reasons, so this checks for the absence of a sort join
+        // specifically, not every join in the emitted SQL.
+        emitted.Sql.ShouldNotContain("sk0");
+        explained.ShouldContain("matchPage = MatchPageCte(top=none, sortJoins=false, resourceJoin=false)");
+    }
+
+    [Fact]
+    public void GivenACountOnlyPlanWithPageAndOffsetPageSet_WhenExplained_ThenNeitherRowAppears()
+    {
+        // Arrange -- EmitCountOnlyShape reads neither Page nor OffsetPage (COUNT_BIG has no page to seek or
+        // window), so a CountOnly plan that still carries either -- constructible directly against QueryPlan,
+        // a public surface -- must not claim ordinals Emit never binds for them. Page and OffsetPage are
+        // mutually exclusive with each other but each independently combinable with CountOnly, so two
+        // separate CountOnly plans, not one plan carrying both.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var pagedCountPlan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            Shape: new ResultShape.Count.AllMatches(),
+            Page: new PageSpec([new SqlParameterRef("Adams")], BoundaryResourceTypeId: null, new SqlParameterRef(5000L)));
+        var offsetCountPlan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)],
+            new CteRef(0),
+            Shape: new ResultShape.Count.AllMatches(),
+            OffsetPage: new OffsetSpec(20, 10));
+
+        // Act
+        var pagedEmitted = SqlBuilder.Run(pagedCountPlan);
+        var offsetEmitted = SqlBuilder.Run(offsetCountPlan);
+        var pagedExplained = pagedCountPlan.Explain();
+        var offsetExplained = offsetCountPlan.Explain();
+
+        // Assert -- Emit binds only cte0's own predicate for both; Describe must claim exactly that, not more.
+        pagedEmitted.Parameters.Select(p => p.Value).ShouldBe(["Smith"]);
+        pagedExplained.ShouldNotContain("page = ");
+        pagedExplained.ShouldContain("countOnly = true");
+
+        offsetEmitted.Parameters.Select(p => p.Value).ShouldBe(["Smith"]);
+        offsetExplained.ShouldNotContain("offsetPage = ");
+        offsetExplained.ShouldContain("countOnly = true");
     }
 }

--- a/test/Ignixa.Search.Sql.Tests/Builders/SqlBuilderCountPhaseScopedTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Builders/SqlBuilderCountPhaseScopedTests.cs
@@ -1,0 +1,56 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+using Ignixa.Search.Sql.Catalog;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Builders;
+
+public class SqlBuilderCountPhaseScopedTests
+{
+    [Fact]
+    public void GivenCountPhaseScopedTrueOnAValuedPhasePlan_WhenEmitted_ThenTheCountQueryJoinsTheSortKey()
+    {
+        // Arrange -- Patient?_sort=name, count-only, phase-scoped to the Valued phase.
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var sort = new SortSpec([new SortKey(202, SortKeyKind.String, SortOrder.Ascending)], SortPhase.Valued);
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)], new CteRef(0),
+            Sort: sort, Shape: new ResultShape.Count.CurrentSortPhase());
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- the count query must join the sort key's table (proving it's phase-scoped, not the
+        // whole match set), matching the same join shape EmitSortJoins renders for the non-count path.
+        emitted.Sql.ShouldContain("SELECT COUNT_BIG(DISTINCT m.Sid1)");
+        emitted.Sql.ShouldContain("JOIN");
+        emitted.Sql.ShouldNotContain("ORDER BY");
+        emitted.Sql.ShouldNotContain("OFFSET");
+    }
+
+    [Fact]
+    public void GivenCountPhaseScopedFalse_WhenEmittedAlongsideASort_ThenTheCountQueryIsUnaffectedByTheSort()
+    {
+        // Regression guard: proves this task did NOT change unscoped CountOnly's existing behavior --
+        // _total=accurate & _sort=X (Phase 9's own tested composition) must still report the TRUE total
+        // match count, ignoring sort entirely, exactly as before this task.
+
+        // Arrange -- same sorted plan as above, but countPhaseScoped left at its default (false).
+        var table = SqlCatalog.Default.Table("StringSearchParam");
+        var predicate = new Predicate.Equal(new SqlColumnRef(table.TableName, "Text"), new SqlParameterRef("Smith"));
+        var sort = new SortSpec([new SortKey(202, SortKeyKind.String, SortOrder.Ascending)], SortPhase.Valued);
+        var plan = new QueryPlan(
+            [new CteDefinition.ParamSource(table, 103, 202, predicate)], new CteRef(0),
+            Sort: sort, Shape: new ResultShape.Count.AllMatches());
+
+        // Act
+        var emitted = SqlBuilder.Run(plan);
+
+        // Assert -- no sort-key join appears; this is the exact rendering CountOnly has always produced.
+        emitted.Sql.ShouldContain("SELECT COUNT_BIG(DISTINCT m.Sid1)");
+        emitted.Sql.ShouldNotContain("JOIN");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Builders/SqlBuilderCountPhaseScopedTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Builders/SqlBuilderCountPhaseScopedTests.cs
@@ -35,8 +35,8 @@ public class SqlBuilderCountPhaseScopedTests
     public void GivenCountPhaseScopedFalse_WhenEmittedAlongsideASort_ThenTheCountQueryIsUnaffectedByTheSort()
     {
         // Regression guard: proves this task did NOT change unscoped CountOnly's existing behavior --
-        // _total=accurate & _sort=X (Phase 9's own tested composition) must still report the TRUE total
-        // match count, ignoring sort entirely, exactly as before this task.
+        // _total=accurate & _sort=X (already covered by ResultShape.Count.AllMatches's own tests) must
+        // still report the TRUE total match count, ignoring sort entirely, exactly as before this task.
 
         // Arrange -- same sorted plan as above, but countPhaseScoped left at its default (false).
         var table = SqlCatalog.Default.Table("StringSearchParam");

--- a/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogDataLayerTablesTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogDataLayerTablesTests.cs
@@ -78,7 +78,7 @@ public class SqlCatalogDataLayerTablesTests
     public void GivenADataLayerTable_WhenLookedUp_ThenItResolves(string tableName)
     {
         // Table() throws KeyNotFoundException on a miss, so resolving at all is the assertion. These are the
-        // remaining tables the Phase F ports write against.
+        // tables the SqlServer data-layer hand-writes SQL against.
         Should.NotThrow(() => SqlCatalog.Default.Table(tableName));
     }
 

--- a/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogDataLayerTablesTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Catalog/SqlCatalogDataLayerTablesTests.cs
@@ -1,0 +1,93 @@
+using Ignixa.Search.Sql.Catalog;
+
+namespace Ignixa.Search.Sql.Tests.Catalog;
+
+/// <summary>
+/// The catalog carries the non-search tables the data layer hand-writes SQL against, so those queries can
+/// source table and column names from the real DDL instead of string literals. The compiler never looks
+/// these up; they exist for <c>Ignixa.DataLayer.SqlServer</c>, which already references this project.
+/// <para>
+/// Each fact below also pins a DDL construct the parser did not originally handle, because the search-index
+/// tables never use it. Deleting these tests would let the parser silently regress on the exact shapes that
+/// made these tables unparseable.
+/// </para>
+/// </summary>
+public class SqlCatalogDataLayerTablesTests
+{
+    [Fact]
+    public void GivenSystem_WhenLookedUp_ThenIdentityDeclaredBeforeNullabilityParses()
+    {
+        // dbo.System declares `SystemId INT IDENTITY (1, 1) NOT NULL` -- IDENTITY *before* the nullability
+        // clause. PackageResource below declares the opposite order; both appear in this schema.
+        var table = SqlCatalog.Default.Table("System");
+
+        var systemId = table.Column("SystemId");
+        var value = table.Column("Value");
+
+        systemId.SqlType.ShouldBe("int");
+        systemId.IsNullable.ShouldBeFalse();
+        value.SqlType.ShouldBe("nvarchar");
+        value.MaxLength.ShouldBe(256);
+        value.IsNullable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenPackageResource_WhenLookedUp_ThenIdentityDeclaredAfterNullabilityParses()
+    {
+        // `PackageResourceId BIGINT NOT NULL IDENTITY (1, 1)` -- IDENTITY *after* nullability, the opposite
+        // of dbo.System's order above.
+        var table = SqlCatalog.Default.Table("PackageResource");
+
+        var id = table.Column("PackageResourceId");
+        var version = table.Column("Version");
+
+        id.SqlType.ShouldBe("bigint");
+        id.IsNullable.ShouldBeFalse();
+
+        // Version is the nullable one -- a real distinction the ports depend on, since "latest by
+        // canonical" has to treat a missing version differently from a present one.
+        version.SqlType.ShouldBe("nvarchar");
+        version.MaxLength.ShouldBe(100);
+        version.IsNullable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSourceEvents_WhenLookedUp_ThenMaxLengthAndDefaultClausesParse()
+    {
+        var table = SqlCatalog.Default.Table("SourceEvents");
+
+        var eventData = table.Column("EventData");
+        var timestamp = table.Column("Timestamp");
+
+        // NVARCHAR (MAX) models as a null MaxLength, matching the existing convention for TextOverflow.
+        eventData.SqlType.ShouldBe("nvarchar");
+        eventData.MaxLength.ShouldBeNull();
+        eventData.IsNullable.ShouldBeFalse();
+
+        // `DATETIMEOFFSET DEFAULT sysutcdatetime() NOT NULL` -- a DEFAULT between type and nullability.
+        timestamp.SqlType.ShouldBe("datetimeoffset");
+        timestamp.IsNullable.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("BackgroundJobs")]
+    [InlineData("TermCodeSystem")]
+    [InlineData("TermConcept")]
+    [InlineData("TermValueSet")]
+    [InlineData("TermConceptMap")]
+    public void GivenADataLayerTable_WhenLookedUp_ThenItResolves(string tableName)
+    {
+        // Table() throws KeyNotFoundException on a miss, so resolving at all is the assertion. These are the
+        // remaining tables the Phase F ports write against.
+        Should.NotThrow(() => SqlCatalog.Default.Table(tableName));
+    }
+
+    [Fact]
+    public void GivenATableOutsideTheDeclaredSet_WhenLookedUp_ThenItStillThrows()
+    {
+        // The catalog is a named set, not the whole schema: the wider schema contains constructs the parser
+        // does not model (EventLog's PERSISTED computed column). A miss must stay loud, so that adding a
+        // table to the set is a deliberate act rather than something a caller discovers at runtime.
+        Should.Throw<KeyNotFoundException>(() => SqlCatalog.Default.Table("EventLog"));
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Compilation/CompilationFixtures.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/CompilationFixtures.cs
@@ -609,6 +609,42 @@ internal static class CompilationFixtures
             "Patient", [new QueryParameter("_id", "123")], FullDiagnostics);
     }
 
+    /// <summary>Patient?_id=abc -- a resource-column parameter with a string value, built directly rather
+    /// than through ISearchOptionsBuilder -- for SearchCompilerCompileFromOptionsTests, which skips Build
+    /// entirely and constructs the SearchOptions it hands to CompileFromOptionsAsync by hand.</summary>
+    public static (SearchOptions Options, ISymbolResolver Resolver) BuildPatientIdAbcOptionsAndResolver()
+    {
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var predicate = new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "abc", text: null))
+        {
+            Span = new SourceSpan(SourceOrigin.Value, 0, 3),
+        };
+        var expression = new SearchParameterExpression(idParam, predicate);
+
+        var resolver = new FakeSymbolResolver();
+        resolver.ResourceTypeIds["Patient"] = 103;
+
+        return (new SearchOptions { ResourceType = "Patient", Expression = expression }, resolver);
+    }
+
+    /// <summary>?status=final with no resource type anywhere in the request -- a genuine system-level
+    /// search, built directly for SearchCompilerCompileFromOptionsTests' null/"" resourceType equivalence
+    /// test. Mirrors EndToEndCompilationTests.GivenABareStatusPredicateWithNoResourceType..., which proves
+    /// this same shape stays typeless all the way through Resolve, Lower, and Emit.</summary>
+    public static (SearchOptions Options, ISymbolResolver Resolver) BuildSystemLevelStatusFinalOptionsAndResolver()
+    {
+        var statusParam = new SearchParameterInfo("status", "status", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        var predicate = new SearchParameterPredicateExpression(statusParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "final", text: null))
+        {
+            Span = new SourceSpan(SourceOrigin.Value, 0, 5),
+        };
+
+        var resolver = new FakeSymbolResolver();
+        resolver.SearchParamIds[statusParam.Url!.ToString()] = 202;
+
+        return (new SearchOptions { ResourceType = null, Expression = predicate }, resolver);
+    }
+
     /// <summary>Patient?organization.name=Acme where the chain's own reference parameter is unregistered -- the
     /// unresolved parameter lives on the ChainedExpression, not on any leaf predicate.</summary>
     public static Task<SearchPlanResult> TraceUnresolvedChainReferenceParameterAsync()

--- a/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
@@ -1,0 +1,135 @@
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Search.Expressions.Parsers;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Tests.Corpus;
+using Ignixa.Serialization.Abstractions;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Compilation;
+
+/// <summary>
+/// Pins <c>identifier:of-type</c> from query string to plan, through the real R4 definitions and the real
+/// parser. The rule-level tests assert the predicate this compiles to; these assert that a request actually
+/// reaches it — the binder used to flatten the typed value into field-level StringExpressions the SQL
+/// compiler has no rule for, so every <c>:of-type</c> request failed compilation and surfaced as a 400.
+/// </summary>
+public class OfTypeCompilationTests
+{
+    private const string V2IdentifierType = "http://terminology.hl7.org/CodeSystem/v2-0203";
+
+    private static readonly R4CoreSchemaProvider Schema = new();
+    private static readonly QueryParameterParser QueryParser = new();
+
+    private static readonly SearchParameterDefinitionManager Definitions =
+        new(Schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+
+    private static readonly SearchOptionsBuilder OptionsBuilder = new(
+        new ExpressionParser(
+            () => Definitions,
+            new SearchParameterExpressionParser(new ReferenceSearchValueParser(Schema, NullFhirBaseUriProvider.Instance), Schema),
+            Schema),
+        Definitions);
+
+    [Fact]
+    public void GivenAnOfTypeQuery_WhenOptionsAreBuilt_ThenTheModifierIsNotClassifiedAsUnsupported()
+    {
+        // Arrange -- :of-type must not land in the bucket that drives a 400 for unsupported modifiers
+
+        // Act
+        var options = OptionsBuilder.Build("Patient", QueryParser.Parse($"identifier:of-type={V2IdentifierType}|MR|12345"));
+
+        // Assert
+        options.UnsupportedModifierParams.ShouldBeEmpty();
+        options.UnsupportedParams.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenAnOfTypeQueryWithATypeSystem_WhenCompiled_ThenOneTokenSourceCarriesAllThreeConditions()
+    {
+        // Act
+        var plan = await CompileAsync($"identifier:of-type={V2IdentifierType}|MR|12345");
+
+        // Assert -- a single ParamSource, not an intersection of one source per condition
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ParamSource>();
+        source.Table.TableName.ShouldBe("TokenSearchParam");
+
+        var outer = source.Predicate.ShouldBeOfType<Predicate.And>();
+        outer.Left.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("IdentifierTypeSystemId");
+
+        var inner = outer.Right.ShouldBeOfType<Predicate.And>();
+        var typeCode = inner.Left.ShouldBeOfType<Predicate.Equal>();
+        typeCode.Column.Column.ShouldBe("IdentifierTypeCode");
+        typeCode.Value.Value.ShouldBe("MR");
+
+        var value = inner.Right.ShouldBeOfType<Predicate.Equal>();
+        value.Column.Column.ShouldBe("Code");
+        value.Value.Value.ShouldBe("12345");
+    }
+
+    [Fact]
+    public async Task GivenAnOfTypeQueryWithoutATypeSystem_WhenCompiled_ThenNoTypeSystemConditionIsEmitted()
+    {
+        // Act
+        var plan = await CompileAsync("identifier:of-type=|MR|12345");
+
+        // Assert
+        var source = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ParamSource>();
+        var and = source.Predicate.ShouldBeOfType<Predicate.And>();
+        and.Left.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("IdentifierTypeCode");
+        and.Right.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("Code");
+    }
+
+    [Fact]
+    public async Task GivenCommaSeparatedOfTypeValues_WhenCompiled_ThenTheyBecomeAUnionOfPerValueSources()
+    {
+        // Arrange -- comma is OR in FHIR, so the alternatives must stay separate sources; folding them into
+        // one source's conjunction would silently require both identifiers on the same row.
+
+        // Act
+        var plan = await CompileAsync($"identifier:of-type={V2IdentifierType}|MR|12345,{V2IdentifierType}|SS|67890");
+
+        // Assert
+        plan.Ctes.OfType<CteDefinition.Union>().ShouldHaveSingleItem().Parts.Count.ShouldBe(2);
+        plan.Ctes.OfType<CteDefinition.ParamSource>().Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenAnOfTypeQuery_WhenCompiled_ThenNoUserValueAppearsInTheSqlText()
+    {
+        // Arrange -- the identifier type system reaches SQL as a resolved integer id, the type code and the
+        // identifier value as parameters. A literal in the text would be both an injection surface and a
+        // plan-cache pollutant.
+
+        // Act
+        var emitted = await EmitAsync($"identifier:of-type={V2IdentifierType}|MR|12345");
+
+        // Assert
+        emitted.Sql.ShouldNotContain(V2IdentifierType);
+        emitted.Sql.ShouldNotContain("12345");
+        emitted.Parameters.Select(p => p.Value).ShouldContain("MR");
+        emitted.Parameters.Select(p => p.Value).ShouldContain("12345");
+    }
+
+    private static async Task<QueryPlan> CompileAsync(string queryString)
+    {
+        var compiler = new SearchSqlCompiler(new CorpusSymbolResolver(), OptionsBuilder, searchParameterDefinitionManager: Definitions);
+        var result = await compiler.TryCreatePlanAsync(
+            "Patient",
+            QueryParser.Parse(queryString),
+            new SearchPlanOptions { DiagnosticsLevel = SearchDiagnosticsLevel.None },
+            CancellationToken.None);
+
+        result.Succeeded.ShouldBeTrue(result.Failure?.Message);
+        return result.Plan!.Query;
+    }
+
+    private static async Task<Sql.Builders.EmittedSql> EmitAsync(string queryString)
+        => Sql.Builders.SqlBuilder.Run(await CompileAsync(queryString));
+}

--- a/test/Ignixa.Search.Sql.Tests/Compilation/PlanExplainDescribeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/PlanExplainDescribeTests.cs
@@ -28,9 +28,9 @@ public class PlanExplainDescribeTests
             "cte1 = TokenSearchParam[103,44]  Code = @p1\n" +
             "root = Intersect(cte0, cte1) WHERE ResourceId = @p2\n" +
             "matchPage = MatchPageCte(top=none, sortJoins=true, resourceJoin=true)\n" +
-            "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)\n" +
             "sort = SortSpec([String:202 ASC], Valued)\n" +
-            "page = PageSpec(boundary=[@p3], type=none, sid=@p4)");
+            "page = PageSpec(boundary=[@p3], type=none, sid=@p4)\n" +
+            "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)");
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class PlanExplainDescribeTests
         var rows = PlanExplainer.Describe(plan);
 
         // Assert
-        rows.Select(row => row.Label).ShouldBe(["cte0", "cte1", "root", "matchPage", "inc0", "sort", "page"]);
+        rows.Select(row => row.Label).ShouldBe(["cte0", "cte1", "root", "matchPage", "sort", "page", "inc0"]);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class PlanExplainDescribeTests
         var rows = PlanExplainer.Describe(plan);
 
         // Assert -- "root" is cosmetic; cte2 is what the SQL and CteProvenance actually use.
-        rows.Select(row => row.CanonicalLabel).ShouldBe(["cte0", "cte1", "cte2", "matchPage", "inc0", "sort", "page"]);
+        rows.Select(row => row.CanonicalLabel).ShouldBe(["cte0", "cte1", "cte2", "matchPage", "sort", "page", "inc0"]);
         rows.Count(row => row.Label != row.CanonicalLabel).ShouldBe(1);
     }
 
@@ -75,9 +75,9 @@ public class PlanExplainDescribeTests
             PlanRowKind.ParamSource,
             PlanRowKind.Intersect,
             PlanRowKind.MatchPageCte,
-            PlanRowKind.IncludeStage,
             PlanRowKind.SortSpec,
             PlanRowKind.PageSpec,
+            PlanRowKind.IncludeStage,
         ]);
     }
 

--- a/test/Ignixa.Search.Sql.Tests/Compilation/PlanExplainDescribeTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/PlanExplainDescribeTests.cs
@@ -27,6 +27,7 @@ public class PlanExplainDescribeTests
             "cte0 = StringSearchParam[103,202]  Text = @p0\n" +
             "cte1 = TokenSearchParam[103,44]  Code = @p1\n" +
             "root = Intersect(cte0, cte1) WHERE ResourceId = @p2\n" +
+            "matchPage = MatchPageCte(top=none, sortJoins=true, resourceJoin=true)\n" +
             "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)\n" +
             "sort = SortSpec([String:202 ASC], Valued)\n" +
             "page = PageSpec(boundary=[@p3], type=none, sid=@p4)");
@@ -42,7 +43,7 @@ public class PlanExplainDescribeTests
         var rows = PlanExplainer.Describe(plan);
 
         // Assert
-        rows.Select(row => row.Label).ShouldBe(["cte0", "cte1", "root", "inc0", "sort", "page"]);
+        rows.Select(row => row.Label).ShouldBe(["cte0", "cte1", "root", "matchPage", "inc0", "sort", "page"]);
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public class PlanExplainDescribeTests
         var rows = PlanExplainer.Describe(plan);
 
         // Assert -- "root" is cosmetic; cte2 is what the SQL and CteProvenance actually use.
-        rows.Select(row => row.CanonicalLabel).ShouldBe(["cte0", "cte1", "cte2", "inc0", "sort", "page"]);
+        rows.Select(row => row.CanonicalLabel).ShouldBe(["cte0", "cte1", "cte2", "matchPage", "inc0", "sort", "page"]);
         rows.Count(row => row.Label != row.CanonicalLabel).ShouldBe(1);
     }
 
@@ -73,6 +74,7 @@ public class PlanExplainDescribeTests
             PlanRowKind.ParamSource,
             PlanRowKind.ParamSource,
             PlanRowKind.Intersect,
+            PlanRowKind.MatchPageCte,
             PlanRowKind.IncludeStage,
             PlanRowKind.SortSpec,
             PlanRowKind.PageSpec,

--- a/test/Ignixa.Search.Sql.Tests/Compilation/ResourceColumnNotModifierTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/ResourceColumnNotModifierTests.cs
@@ -1,0 +1,191 @@
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Expressions.Parsers;
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Search.Sql.Tests.Corpus;
+using Ignixa.Search.Sql.Tests.TestSupport;
+using Ignixa.Serialization.Abstractions;
+using Ignixa.Specification.Generated;
+using Ignixa.Specification.ValueSets.Normative;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Compilation;
+
+/// <summary>
+/// Pins that <c>_id:not</c> and <c>_type:not</c> compile to the same negated outer predicate whether the
+/// query names one value or several.
+/// <para>
+/// The two spellings do not reach Lower as the same expression. SearchExpressionBinder.BindAlternatives
+/// lifts the <c>:not</c> off a comma list and wraps the resulting Or in a NotExpression; BindAtomic, which
+/// handles a lone value, has no Or to lift onto and leaves the modifier sitting on the predicate. Lower's
+/// resource-column extraction only understood the first shape, so <c>_id:not=a</c> reached
+/// ResourceColumnLoweringRule with a modifier still attached and was rejected outright (HTTP 400) while
+/// <c>_id:not=a,b</c> compiled fine.
+/// </para>
+/// <para>
+/// The tests that go through <see cref="SearchSqlCompiler"/> and the real R4 definitions are the ones that
+/// establish which shape each spelling actually produces; a hand-built expression tree can assert a shape
+/// the binder never emits, which is how the gap survived earlier unit coverage.
+/// </para>
+/// </summary>
+public class ResourceColumnNotModifierTests
+{
+    private static readonly R4CoreSchemaProvider Schema = new();
+    private static readonly QueryParameterParser QueryParser = new();
+
+    private static readonly SearchParameterDefinitionManager Definitions =
+        new(Schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+
+    private static readonly SearchOptionsBuilder OptionsBuilder = new(
+        new ExpressionParser(
+            () => Definitions,
+            new SearchParameterExpressionParser(new ReferenceSearchValueParser(Schema, NullFhirBaseUriProvider.Instance), Schema),
+            Schema),
+        Definitions);
+
+    [Fact]
+    public async Task GivenASingleValuedIdNotModifier_WhenCompiled_ThenTheOuterWhereNegatesTheResourceIdEquality()
+    {
+        // Act
+        var plan = await CompileAsync("Observation", "_id:not=abc");
+
+        // Assert -- Not(ResourceId = @p), and no search-param CTE: _id never leaves dbo.Resource.
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        var equal = not.Operand.ShouldBeOfType<Predicate.Equal>();
+        equal.Column.Column.ShouldBe("ResourceId");
+        equal.Value.Value.ShouldBe("abc");
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
+
+    [Fact]
+    public async Task GivenAMultiValuedIdNotModifier_WhenCompiled_ThenTheOuterWhereNegatesTheOrOfResourceIdEqualities()
+    {
+        // Act
+        var plan = await CompileAsync("Observation", "_id:not=abc,def");
+
+        // Assert
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        var or = not.Operand.ShouldBeOfType<Predicate.Or>();
+        or.Left.ShouldBeOfType<Predicate.Equal>().Value.Value.ShouldBe("abc");
+        or.Right.ShouldBeOfType<Predicate.Equal>().Value.Value.ShouldBe("def");
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
+
+    [Fact]
+    public async Task GivenASingleValuedTypeNotModifier_WhenCompiledAtSystemLevel_ThenTheOuterWhereNegatesTheResourceTypeIdEquality()
+    {
+        // Act -- GET /?_type:not=Patient, the system-level sibling of the _id case above.
+        var plan = await CompileAsync(resourceType: null, "_type:not=Patient");
+
+        // Assert
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        not.Operand.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceTypeId");
+    }
+
+    [Fact]
+    public async Task GivenAMultiValuedTypeNotModifier_WhenCompiledAtSystemLevel_ThenTheOuterWhereNegatesTheOrOfResourceTypeIdEqualities()
+    {
+        // Act
+        var plan = await CompileAsync(resourceType: null, "_type:not=Patient,Organization");
+
+        // Assert
+        var not = plan.OuterPredicate.ShouldBeOfType<Predicate.Not>();
+        var or = not.Operand.ShouldBeOfType<Predicate.Or>();
+        or.Left.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceTypeId");
+        or.Right.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceTypeId");
+    }
+
+    [Fact]
+    public void GivenTheTwoNegationShapesTheBinderProduces_WhenLowered_ThenTheyProduceTheSamePlan()
+    {
+        // Arrange -- the same query, _id:not=abc, in the two forms the binder can hand to Lower: the
+        // modifier left on the predicate (what BindAtomic emits for a lone value) and the modifier lifted
+        // into a NotExpression around a one-element Or (what BindAlternatives would emit if the value list
+        // were reached that way). Equivalence has to be asserted here rather than through the binder,
+        // because no query string makes the binder produce a one-element Or.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var value = new TokenSearchValue(system: null, code: "abc", text: null);
+
+        var modifierOnPredicate = new SearchParameterExpression(
+            idParam,
+            new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, new SearchModifier(SearchModifierCode.Not), value));
+
+        var modifierLiftedIntoNot = new SearchParameterExpression(
+            idParam,
+            new NotExpression(Expression.Or(
+            [
+                new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, value),
+            ])));
+
+        // Act
+        var fromPredicate = LowerSingleType(modifierOnPredicate);
+        var fromNotExpression = LowerSingleType(modifierLiftedIntoNot);
+
+        // Assert
+        fromPredicate.Explain().ShouldBe(fromNotExpression.Explain());
+        fromPredicate.OuterPredicate.ShouldBeOfType<Predicate.Not>()
+            .Operand.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceId");
+    }
+
+    [Fact]
+    public void GivenAnIdModifierOtherThanNot_WhenLowered_ThenLoweringStillRefusesIt()
+    {
+        // Arrange -- stripping :not must not have opened the door for every other modifier. _id:above is
+        // meaningless on a resource id, and lowering it as though the modifier were absent would return a
+        // positive _id match. Asserted at the Lower boundary because SearchOptionsBuilder rejects an
+        // unsupported modifier at parse time and never hands it to the compiler (see
+        // UnsupportedModifierClassificationTests), so a query-string test would prove nothing about this
+        // guard -- it exists for a caller that builds the expression tree directly.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var tree = new SearchParameterExpression(
+            idParam,
+            new SearchParameterPredicateExpression(
+                idParam, SearchComparator.Eq, new SearchModifier(SearchModifierCode.Above), new TokenSearchValue(system: null, code: "abc", text: null)));
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => LowerSingleType(tree));
+    }
+
+    private static QueryPlan LowerSingleType(Expression expression)
+    {
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Observation"] = 96 });
+
+        return LowerHarness.Run(
+            expression,
+            symbols,
+            targetResourceType: "Observation",
+            includes: [],
+            revIncludes: [],
+            includeLimit: 0,
+            sort: [],
+            sortPhase: SortPhase.Valued,
+            page: null).Plan;
+    }
+
+    private static async Task<QueryPlan> CompileAsync(string? resourceType, string queryString)
+    {
+        var result = await TryCompileAsync(resourceType, queryString);
+        result.Succeeded.ShouldBeTrue(result.Failure?.Message);
+        return result.Plan!.Query;
+    }
+
+    private static Task<SearchPlanResult> TryCompileAsync(string? resourceType, string queryString)
+    {
+        var compiler = new SearchSqlCompiler(new CorpusSymbolResolver(), OptionsBuilder, searchParameterDefinitionManager: Definitions);
+        return compiler.TryCreatePlanAsync(
+            resourceType,
+            QueryParser.Parse(queryString),
+            new SearchPlanOptions { DiagnosticsLevel = SearchDiagnosticsLevel.None },
+            CancellationToken.None);
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Compilation/SearchCompilerCompileFromOptionsTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/SearchCompilerCompileFromOptionsTests.cs
@@ -1,0 +1,54 @@
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Compilation;
+
+/// <summary>
+/// Covers <see cref="SearchSqlCompiler.TryCreatePlanFromOptionsAsync"/> for <see cref="SearchOptions"/> built
+/// directly rather than through <see cref="Ignixa.Search.Parsing.ISearchOptionsBuilder"/> -- the same
+/// bypass-the-builder shape <see cref="CompileFromOptionsTests"/> already covers for access constraints,
+/// resource types, and surrogate bounds, extended here to the resource-column (<c>_id</c>) and null-
+/// resourceType (system-level) cases <see cref="CompilationFixtures.BuildPatientIdAbcOptionsAndResolver"/> and
+/// <see cref="CompilationFixtures.BuildSystemLevelStatusFinalOptionsAndResolver"/> were built for.
+/// </summary>
+public class SearchCompilerCompileFromOptionsTests
+{
+    [Fact]
+    public async Task GivenPatientIdAbc_WhenCompiledFromOptions_ThenTheResourceColumnPredicateCompilesToTheOuterJoin()
+    {
+        // Arrange -- Patient?_id=abc, built by hand (no ISearchOptionsBuilder in the loop).
+        var (options, resolver) = CompilationFixtures.BuildPatientIdAbcOptionsAndResolver();
+
+        // Act
+        var result = await new SearchSqlCompiler(resolver).TryCreatePlanFromOptionsAsync(options, "Patient");
+
+        // Assert -- _id is a resource-column parameter: it must lift onto OuterPredicate, not become a CTE
+        // that gets intersected in. Ctes.Count == 1 is the base ResourceSource with nothing joined to it.
+        result.Succeeded.ShouldBeTrue(result.Failure?.Message);
+        var plan = result.Plan!.Query;
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+        plan.OuterPredicate.ShouldBeOfType<Predicate.Equal>().Column.Column.ShouldBe("ResourceId");
+    }
+
+    [Fact]
+    public async Task GivenSystemLevelStatusFinal_WhenCompiledFromOptions_ThenItCompilesWithNoResourceTypeAnywhere()
+    {
+        // Arrange -- ?status=final with no resource type anywhere in the request, built by hand.
+        var (options, resolver) = CompilationFixtures.BuildSystemLevelStatusFinalOptionsAndResolver();
+
+        // Act -- resourceType: null all the way through, the genuine system-level-search entry point.
+        var result = await new SearchSqlCompiler(resolver).TryCreatePlanFromOptionsAsync(options, resourceType: null);
+
+        // Assert -- the leaf lowers to a ParamSource with no ResourceTypeId of its own, mirroring
+        // EndToEndCompilationTests.GivenABareStatusPredicateWithNoResourceType... for the query-string entry
+        // point: this proves CreatePlanFromOptionsAsync's own resourceType normalization does not silently
+        // invent a type for a request that named none.
+        result.Succeeded.ShouldBeTrue(result.Failure?.Message);
+        var plan = result.Plan!.Query;
+        var cte = plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ParamSource>();
+        cte.ResourceTypeId.ShouldBeNull();
+        cte.SearchParamId.ShouldBe((short)202);
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Compilation/UnsupportedModifierClassificationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/UnsupportedModifierClassificationTests.cs
@@ -1,0 +1,142 @@
+using Ignixa.Abstractions;
+using Ignixa.Search.Definition;
+using Ignixa.Search.Expressions.Parsers;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Parsing;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Search.Sql.Tests.Corpus;
+using Ignixa.Search.Sql.Tests.TestSupport;
+using Ignixa.Serialization.Abstractions;
+using Ignixa.Specification.Generated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Compilation;
+
+/// <summary>
+/// Pins that a modifier the server does not support for a parameter is recorded in
+/// <see cref="SearchOptions.UnsupportedModifierParams"/>, not merely dropped into the same bucket as an
+/// unknown parameter.
+/// <para>
+/// The two look identical downstream — both leave <see cref="SearchOptions.Expression"/> without the
+/// parameter, so <c>Observation?_id:above=abc</c> compiles to a bare ResourceSource with no outer
+/// predicate and matches every Observation. FHIR R4 does not treat them the same: an unknown or
+/// unsupported parameter SHOULD be ignored, while a request "suffixed by a modifier that the server does
+/// not support for that parameter" SHALL be rejected with a 400. Dropping the former narrows nothing;
+/// dropping the latter widens the result set to everything, which a client reading the entry list cannot
+/// distinguish from a filter that matched everything.
+/// </para>
+/// <para>
+/// The classification is asserted here, on real R4 definitions through the real
+/// <see cref="SearchOptionsBuilder"/>, because that is where the two cases are told apart. Whether the
+/// classification then produces a 400 is the HTTP boundary's decision and is pinned separately.
+/// </para>
+/// </summary>
+public class UnsupportedModifierClassificationTests
+{
+    private static readonly R4CoreSchemaProvider Schema = new();
+    private static readonly QueryParameterParser QueryParser = new();
+
+    private static readonly SearchParameterDefinitionManager Definitions =
+        new(Schema, NullLogger<SearchParameterDefinitionManager>.Instance);
+
+    private static readonly SearchOptionsBuilder OptionsBuilder = new(
+        new ExpressionParser(
+            () => Definitions,
+            new SearchParameterExpressionParser(new ReferenceSearchValueParser(Schema, NullFhirBaseUriProvider.Instance), Schema),
+            Schema),
+        Definitions);
+
+    [Theory]
+    [InlineData("_id:above=abc")]
+    [InlineData("_id:exact=abc")]
+    [InlineData("_lastUpdated:above=2020")]
+    public void GivenAnUnsupportedModifierOnAnIntrinsicParameter_WhenBuilt_ThenItIsRecordedAsAnUnsupportedModifier(string queryString)
+    {
+        // Arrange
+        var expectedKey = queryString.Split('=')[0];
+
+        // Act
+        var options = OptionsBuilder.Build("Observation", QueryParser.Parse(queryString));
+
+        // Assert
+        options.UnsupportedModifierParams.ShouldHaveSingleItem().ShouldBe(expectedKey);
+        options.UnsupportedParams.ShouldContain(expectedKey);
+    }
+
+    [Theory]
+    [InlineData("status:above=final")]
+    [InlineData("subject:above=Patient/1")]
+    [InlineData("code:exact=x")]
+    public void GivenAnUnsupportedModifierOnAnIndexedParameter_WhenBuilt_ThenItIsClassifiedTheSameWayAsOnAnIntrinsic(string queryString)
+    {
+        // Arrange -- the intrinsic/indexed split is a storage detail; R4's modifier rule does not know
+        // about it, so the classification must not diverge across it.
+        var expectedKey = queryString.Split('=')[0];
+
+        // Act
+        var options = OptionsBuilder.Build("Observation", QueryParser.Parse(queryString));
+
+        // Assert
+        options.UnsupportedModifierParams.ShouldHaveSingleItem().ShouldBe(expectedKey);
+    }
+
+    [Fact]
+    public void GivenAnUnknownParameter_WhenBuilt_ThenItIsUnsupportedButNotAnUnsupportedModifier()
+    {
+        // Arrange -- the control for the classification: an unknown parameter is the case R4 says SHOULD
+        // be ignored, so it must stay out of the list that drives rejection.
+        // Act
+        var options = OptionsBuilder.Build("Observation", QueryParser.Parse("nosuchparameter=x"));
+
+        // Assert
+        options.UnsupportedParams.ShouldContain("nosuchparameter");
+        options.UnsupportedModifierParams.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenASupportedModifierOnTheSameIntrinsicParameter_WhenCompiled_ThenItStillCompilesToItsPredicate()
+    {
+        // Arrange -- without this control, "_id:above is rejected" would pass just as well if _id had been
+        // broken outright. _id:not is the supported modifier on the same parameter.
+        // Act
+        var options = OptionsBuilder.Build("Observation", QueryParser.Parse("_id:not=abc"));
+        var plan = await CompileAsync("Observation", "_id:not=abc");
+
+        // Assert
+        options.UnsupportedModifierParams.ShouldBeEmpty();
+        options.UnsupportedParams.ShouldBeEmpty();
+        plan.OuterPredicate.ShouldBeOfType<Predicate.Not>()
+            .Operand.ShouldBeOfType<Predicate.Equal>()
+            .Column.Column.ShouldBe("ResourceId");
+    }
+
+    [Fact]
+    public async Task GivenAnUnsupportedModifierOnAnIntrinsicParameter_WhenCompiled_ThenThePlanCarriesNoPredicateAtAll()
+    {
+        // Arrange -- the reason the classification has to exist. Nothing in the plan records that a filter
+        // was requested, so no downstream stage can recover the fact.
+        // Act
+        var plan = await CompileAsync("Observation", "_id:above=abc");
+
+        // Assert
+        plan.OuterPredicate.ShouldBeNull();
+        plan.Ctes.ShouldHaveSingleItem().ShouldBeOfType<CteDefinition.ResourceSource>();
+    }
+
+    private static async Task<QueryPlan> CompileAsync(string? resourceType, string queryString)
+    {
+        var compiler = new SearchSqlCompiler(new CorpusSymbolResolver(), OptionsBuilder, searchParameterDefinitionManager: Definitions);
+        var result = await compiler.TryCreatePlanAsync(
+            resourceType,
+            QueryParser.Parse(queryString),
+            new SearchPlanOptions { DiagnosticsLevel = SearchDiagnosticsLevel.None },
+            CancellationToken.None);
+
+        result.Succeeded.ShouldBeTrue(result.Failure?.Message);
+        return result.Plan!.Query;
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/EndToEndCompilationTests.cs
@@ -992,6 +992,7 @@ public class EndToEndCompilationTests
         // unmodified `name` predicate in this file (e.g. GivenAForwardChainQuery above) -- not a plain Equal.
         plan.Explain().ShouldBe(
             "root = StringSearchParam[103,202]  Text LIKE @p0 (StartsWith) collate CI_AI top 50\n" +
+            "matchPage = MatchPageCte(top=50, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)");
 
         var emitted = SqlBuilder.Run(plan);
@@ -1025,6 +1026,7 @@ public class EndToEndCompilationTests
         // Assert -- same StringLoweringRule default-arm shape as the forward-include test above.
         plan.Explain().ShouldBe(
             "root = StringSearchParam[103,202]  Text LIKE @p0 (StartsWith) collate CI_AI\n" +
+            "matchPage = MatchPageCte(top=none, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=77, seedTypes=[103], outputTypes=[104], seeds=[match], limit=1000, Reverse)");
 
         var emitted = SqlBuilder.Run(plan);
@@ -1053,6 +1055,7 @@ public class EndToEndCompilationTests
         // Assert
         plan.Explain().ShouldBe(
             "root = ResourceSource[103] top 50\n" +
+            "matchPage = MatchPageCte(top=50, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)");
 
         var emitted = SqlBuilder.Run(plan);
@@ -1138,6 +1141,7 @@ public class EndToEndCompilationTests
         // Assert -- non-iterate always sorts first regardless of its position in the input list.
         plan.Explain().ShouldBe(
             "root = ResourceSource[103]\n" +
+            "matchPage = MatchPageCte(top=none, sortJoins=false, resourceJoin=false)\n" +
             "inc0 = IncludeStage(ref=55, seedTypes=[103], outputTypes=[105], seeds=[match], limit=1000, Forward)\n" +
             "inc1 = IncludeStage(ref=66, seedTypes=[105], outputTypes=[105], seeds=[inc0], limit=1000 iterate, Forward)");
 

--- a/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
@@ -24,7 +24,7 @@ public class CompositeTokenCodeOverflowTests
     /// token slot declares the same width as TokenSearchParam.Code, so one catalog lookup covers all the
     /// slots exercised here. That the row generators really split here — rather than at a literal that
     /// happens to agree — is pinned from the writers' side by TokenCodeOverflowSplitPointTests in
-    /// Ignixa.DataLayer.SqlServer.Tests.
+    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
     private static readonly int SplitWidth =
         Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;

--- a/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/CompositeTokenCodeOverflowTests.cs
@@ -24,7 +24,7 @@ public class CompositeTokenCodeOverflowTests
     /// token slot declares the same width as TokenSearchParam.Code, so one catalog lookup covers all the
     /// slots exercised here. That the row generators really split here — rather than at a literal that
     /// happens to agree — is pinned from the writers' side by TokenCodeOverflowSplitPointTests in
-    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
+    /// Ignixa.DataLayer.SqlServer.Tests.
     /// </summary>
     private static readonly int SplitWidth =
         Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerOptionsTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerOptionsTests.cs
@@ -164,6 +164,25 @@ public class LowerOptionsTests
     }
 
     [Fact]
+    public void GivenAZeroLimitOffsetSpecWithAProbeRow_WhenLowering_ThenItIsAcceptedBecauseTheFetchIsStillPositive()
+    {
+        // Arrange -- the two-phase sort executor's floor case: an earlier phase already filled the page, so
+        // this phase's entire budget is the has-more lookahead row. It fetches one row, which OFFSET/FETCH
+        // accepts; rejecting it on Limit alone would 400 an ordinary paged sort.
+        var (predicate, symbols) = NameQuery();
+
+        // Act
+        var plan = LowerHarness.Run(
+            predicate, symbols, targetResourceType: "Patient", includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null,
+            options: new LowerOptions { OffsetPage = new OffsetSpec(40, 0, ProbeExtraRow: true) }).Plan;
+
+        // Assert
+        plan.OffsetPage!.Limit.ShouldBe(0);
+        plan.OffsetPage!.FetchCount.ShouldBe(1);
+    }
+
+    [Fact]
     public void GivenANullOffsetSpec_WhenLowering_ThenThrowsRatherThanSilentlyUnpaging()
     {
         // Arrange -- a positional record parameter cannot enforce non-nullness against a caller who ignores the

--- a/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/LowerTests.cs
@@ -935,10 +935,15 @@ public class LowerTests
     [Fact]
     public void GivenASingleValuedNegatedIdParameter_WhenLowered_ThenLiftsABarePredicateUnderNotIntoTheOuterWhere()
     {
-        // Arrange -- Patient?_id:not=a. The binder still wraps a single value as NotExpression(Or([_id=a])),
-        // so the outer predicate is Not(Equal) directly (a bare predicate under Not), a distinct shape from
-        // the multi-value Not(Or(...)) case. Pins that the one-element Or collapses to the equality without
-        // a spurious Or wrapper.
+        // Arrange -- a one-element NotExpression(Or([_id=a])), which lowers to Not(Equal) directly (a bare
+        // predicate under Not), a distinct shape from the multi-value Not(Or(...)) case. Pins that the
+        // one-element Or collapses to the equality without a spurious Or wrapper.
+        //
+        // This is NOT the shape the binder emits for Patient?_id:not=a, despite what this comment used to
+        // claim: BindAlternatives only lifts the modifier into a NotExpression when it has a comma list to
+        // wrap, and a lone value goes through BindAtomic, which leaves the modifier on the predicate. That
+        // false premise is why _id:not=a returned 400 while this test passed. See
+        // ResourceColumnNotModifierTests for the binder-driven coverage of both spellings.
         var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
         var tree = new SearchParameterExpression(
             idParam,

--- a/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
@@ -1,0 +1,286 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Lowering.Leaf;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Specification.ValueSets.Normative;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Lowering;
+
+/// <summary>
+/// Pins <c>identifier:of-type=[system]|[code]|[value]</c> down to one TokenSearchParam source whose
+/// predicates are conjoined, which is what makes the three conditions describe the same Identifier. The
+/// row-evaluation tests below are the ones that actually prove it: a shape assertion alone would pass just
+/// as well for three independent sources intersected, the shape that returns wrong rows.
+/// </summary>
+public class OfTypeLoweringRuleTests
+{
+    private const string V2IdentifierType = "http://terminology.hl7.org/CodeSystem/v2-0203";
+
+    /// <summary>
+    /// Read from the catalog, not written as a literal, for the reason
+    /// <see cref="TokenLoweringRuleTests"/> spells out: the split point is the Code column's declared width,
+    /// and a literal that drifted from the DDL would search for a prefix no row stores.
+    /// </summary>
+    private static readonly int InlineCodeWidth =
+        Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;
+
+    private static SearchParameterInfo IdentifierParameter()
+        => new("identifier", "identifier", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-identifier"));
+
+    private static LeafContext ContextResolving(
+        SearchParameterInfo parameter,
+        short searchParamId,
+        IReadOnlyDictionary<string, int?>? systemIds = null)
+        => new(new SymbolTable(
+            new Dictionary<string, short> { [parameter.Url.ToString()] = searchParamId },
+            new Dictionary<string, short>(),
+            compartmentMembership: null,
+            systemIds: systemIds));
+
+    private static CteDefinition.ParamSource Lower(
+        string? typeSystem,
+        string typeCode,
+        string identifierValue,
+        IReadOnlyDictionary<string, int?>? systemIds = null)
+    {
+        var parameter = IdentifierParameter();
+        var predicate = new SearchParameterPredicateExpression(
+            parameter,
+            SearchComparator.Eq,
+            modifier: null,
+            new OfTypeTokenSearchValue(identifierValue, typeSystem, typeCode));
+
+        return OfTypeLoweringRule.Lower(predicate, (OfTypeTokenSearchValue)predicate.Value, ContextResolving(parameter, 55, systemIds), 103);
+    }
+
+    [Fact]
+    public void GivenAnOfTypeSearchWithATypeSystem_WhenLowered_ThenOneSourceConjoinsSystemTypeCodeAndValue()
+    {
+        // Arrange
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", "12345", systemIds);
+
+        // Assert -- And(IdentifierTypeSystemId, And(IdentifierTypeCode, Code)) over a single ParamSource
+        cte.Table.TableName.ShouldBe("TokenSearchParam");
+        cte.SearchParamId.ShouldBe((short)55);
+        cte.ResourceTypeId.ShouldBe((short)103);
+
+        var outer = cte.Predicate.ShouldBeOfType<Predicate.And>();
+        var systemEqual = outer.Left.ShouldBeOfType<Predicate.Equal>();
+        systemEqual.Column.Table.ShouldBe("TokenSearchParam");
+        systemEqual.Column.Column.ShouldBe("IdentifierTypeSystemId");
+        systemEqual.Value.Value.ShouldBe(77);
+
+        var inner = outer.Right.ShouldBeOfType<Predicate.And>();
+        var typeCodeEqual = inner.Left.ShouldBeOfType<Predicate.Equal>();
+        typeCodeEqual.Column.Column.ShouldBe("IdentifierTypeCode");
+        typeCodeEqual.Value.Value.ShouldBe("MR");
+
+        var valueEqual = inner.Right.ShouldBeOfType<Predicate.Equal>();
+        valueEqual.Column.Column.ShouldBe("Code");
+        valueEqual.Value.Value.ShouldBe("12345");
+    }
+
+    [Fact]
+    public void GivenAnOfTypeSearchWithoutATypeSystem_WhenLowered_ThenConstrainsTypeCodeAndValueOnly()
+    {
+        // Arrange -- the |MR|12345 form. FHIR allows the type system to be omitted.
+
+        // Act
+        var cte = Lower(typeSystem: null, "MR", "12345");
+
+        // Assert -- no IdentifierTypeSystemId arm at all
+        var and = cte.Predicate.ShouldBeOfType<Predicate.And>();
+        var typeCodeEqual = and.Left.ShouldBeOfType<Predicate.Equal>();
+        typeCodeEqual.Column.Column.ShouldBe("IdentifierTypeCode");
+        typeCodeEqual.Value.Value.ShouldBe("MR");
+
+        var valueEqual = and.Right.ShouldBeOfType<Predicate.Equal>();
+        valueEqual.Column.Column.ShouldBe("Code");
+        valueEqual.Value.Value.ShouldBe("12345");
+    }
+
+    [Fact]
+    public void GivenAnOfTypeSearchWithoutATypeSystem_WhenEvaluatedAgainstRowsFromAnySystem_ThenTheSystemIsUnconstrained()
+    {
+        // Arrange -- two rows with the same type code and value but different (and absent) type systems.
+        // Shape assertions cannot tell "no system arm" from "an arm that happens to match"; this can.
+        var matchingRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 999,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = "12345",
+        };
+        var otherSystemRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 4,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = "12345",
+        };
+
+        // Act
+        var cte = Lower(typeSystem: null, "MR", "12345");
+
+        // Assert
+        PredicateRowEvaluator.Matches(cte.Predicate!, matchingRow).ShouldBeTrue();
+        PredicateRowEvaluator.Matches(cte.Predicate!, otherSystemRow).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenAnUnknownTypeSystem_WhenLowered_ThenReturnsFalsePredicate()
+    {
+        // Arrange -- the resolver knows the string but no row uses it, the same three-state miss
+        // TokenColumnEquality.Build turns into Predicate.False rather than an id comparison against null.
+        var systemIds = new Dictionary<string, int?> { ["http://unknown.example/id-types"] = null };
+
+        // Act
+        var cte = Lower("http://unknown.example/id-types", "MR", "12345", systemIds);
+
+        // Assert
+        cte.Predicate.ShouldBeOfType<Predicate.False>();
+        PredicateRowEvaluator.Matches(
+            cte.Predicate!,
+            new Dictionary<string, object> { ["IdentifierTypeCode"] = "MR", ["Code"] = "12345" }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenAnIdentifierValueLongerThanTheInlineWidth_WhenLowered_ThenComparesBothHalvesOfTheSplit()
+    {
+        // Arrange -- an overflowing value exists only as (prefix, remainder) across Code + CodeOverflow;
+        // comparing the whole value against Code alone could never match the row the writer produced.
+        var longValue = new string('A', InlineCodeWidth) + new string('B', 40);
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", longValue, systemIds);
+
+        // Assert
+        var outer = cte.Predicate.ShouldBeOfType<Predicate.And>();
+        var inner = outer.Right.ShouldBeOfType<Predicate.And>();
+        var valueAnd = inner.Right.ShouldBeOfType<Predicate.And>();
+
+        var codeEqual = valueAnd.Left.ShouldBeOfType<Predicate.Equal>();
+        codeEqual.Column.Column.ShouldBe("Code");
+        codeEqual.Value.Value.ShouldBe(longValue[..InlineCodeWidth]);
+
+        var overflowEqual = valueAnd.Right.ShouldBeOfType<Predicate.Equal>();
+        overflowEqual.Column.Column.ShouldBe("CodeOverflow");
+        overflowEqual.Value.Value.ShouldBe(longValue[InlineCodeWidth..]);
+    }
+
+    [Fact]
+    public void GivenAnOverflowingIdentifierValue_WhenEvaluatedAgainstTheRowTheWriterWouldProduce_ThenItMatchesButASharedPrefixDoesNot()
+    {
+        // Arrange
+        var longValue = new string('A', InlineCodeWidth) + new string('B', 40);
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+        var storedRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 77,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = longValue[..InlineCodeWidth],
+            ["CodeOverflow"] = longValue[InlineCodeWidth..],
+        };
+        var sharedPrefixRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 77,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = longValue[..InlineCodeWidth],
+            ["CodeOverflow"] = new string('C', 40),
+        };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", longValue, systemIds);
+
+        // Assert
+        PredicateRowEvaluator.Matches(cte.Predicate!, storedRow).ShouldBeTrue();
+        PredicateRowEvaluator.Matches(cte.Predicate!, sharedPrefixRow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenARowWithTheRightValueButTheWrongTypeCode_WhenEvaluated_ThenItDoesNotMatch()
+    {
+        // Arrange -- the case :of-type exists for. Without the IdentifierTypeCode conjunct this row
+        // matches, and identifier:of-type degrades into a plain identifier search.
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+        var wrongTypeRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 77,
+            ["IdentifierTypeCode"] = "SS",
+            ["Code"] = "12345",
+        };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", "12345", systemIds);
+
+        // Assert
+        PredicateRowEvaluator.Matches(cte.Predicate!, wrongTypeRow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenARowWithTheRightTypeCodeButTheWrongValue_WhenEvaluated_ThenItDoesNotMatch()
+    {
+        // Arrange
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+        var wrongValueRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 77,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = "67890",
+        };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", "12345", systemIds);
+
+        // Assert
+        PredicateRowEvaluator.Matches(cte.Predicate!, wrongValueRow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenARowFromADifferentTypeSystem_WhenEvaluated_ThenItDoesNotMatch()
+    {
+        // Arrange -- same type code "MR" in a local code system is not the v2-0203 "MR"
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+        var otherSystemRow = new Dictionary<string, object>
+        {
+            ["IdentifierTypeSystemId"] = 4,
+            ["IdentifierTypeCode"] = "MR",
+            ["Code"] = "12345",
+        };
+
+        // Act
+        var cte = Lower(V2IdentifierType, "MR", "12345", systemIds);
+
+        // Assert
+        PredicateRowEvaluator.Matches(cte.Predicate!, otherSystemRow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenAnOfTypePredicate_WhenDispatched_ThenItReachesTheOfTypeRuleRatherThanTheUnsupportedArm()
+    {
+        // Arrange -- the dispatcher's default arm used to swallow OfTypeTokenSearchValue into a
+        // NotSupportedException, which the API surfaced as a 400.
+        var parameter = IdentifierParameter();
+        var predicate = new SearchParameterPredicateExpression(
+            parameter,
+            SearchComparator.Eq,
+            modifier: null,
+            new OfTypeTokenSearchValue("12345", V2IdentifierType, "MR"));
+        var systemIds = new Dictionary<string, int?> { [V2IdentifierType] = 77 };
+
+        // Act
+        var cte = LeafLoweringDispatcher.Lower(predicate, ContextResolving(parameter, 55, systemIds), 103);
+
+        // Assert
+        cte.Table.TableName.ShouldBe("TokenSearchParam");
+        cte.Predicate.ShouldBeOfType<Predicate.And>();
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/StructuralContextExceptTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/StructuralContextExceptTests.cs
@@ -1,0 +1,34 @@
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Symbols;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Lowering;
+
+public class StructuralContextExceptTests
+{
+    [Fact]
+    public void GivenTwoCteRefs_WhenExcepted_ThenAddsAnExceptCteAndReturnsItsRef()
+    {
+        // Arrange -- mirrors LowerTests.cs's "GivenAMissingTrueOnAStringParameter..." pattern (the only
+        // established pattern for asserting a CteDefinition.Except shape), but drives StructuralContext's
+        // own Except method directly rather than going through Lower.Run/:missing.
+        var symbols = new SymbolTable(
+            new Dictionary<string, short>(),
+            new Dictionary<string, short> { ["Patient"] = 103 });
+        var context = new StructuralContext(symbols);
+        var left = context.LowerResourceSource("Patient");
+        var right = context.LowerResourceSource("Patient");
+
+        // Act
+        var result = context.Except(left, right);
+
+        // Assert
+        var plan = new QueryPlan(context.Ctes, result);
+        plan.Ctes[result.Index].ShouldBeOfType<CteDefinition.Except>();
+        var exceptCte = (CteDefinition.Except)plan.Ctes[result.Index];
+        exceptCte.Left.ShouldBe(left);
+        exceptCte.Right.ShouldBe(right);
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/StructuralContextTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/StructuralContextTests.cs
@@ -1,0 +1,52 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Search.Sql.Tests.TestSupport;
+using Ignixa.Specification.ValueSets.Normative;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Lowering;
+
+public class StructuralContextTests
+{
+    [Fact]
+    public void GivenAResourceColumnPredicateNestedInsideAnUnflattenedAnd_WhenLowered_ThenTheExceptionNamesTheLikelyCause()
+    {
+        // Arrange -- mirrors the bug found and fixed in SearchCompartmentHandler (Task 2 of this sub-project):
+        // composing And(otherExpression, existingAnd) instead of splicing into existingAnd's own children
+        // leaves a resource-column predicate (_id) nested one level inside an And that Lower's top-level
+        // ExtractResourceColumnPredicates pass never scans into, so it survives to StructuralContext's
+        // leaf/composite dispatch choke point instead of being pulled into the outer WHERE.
+        var idParam = new SearchParameterInfo("_id", "_id", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+        var categoryParam = new SearchParameterInfo("category", "category", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-category"));
+        var activeParam = new SearchParameterInfo("active", "active", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-active"));
+
+        var idExpression = new SearchParameterExpression(
+            idParam,
+            new SearchParameterPredicateExpression(idParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "obs-1", text: null)));
+        var categoryExpression = new SearchParameterPredicateExpression(
+            categoryParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "laboratory", text: null));
+        var existingAnd = new MultiaryExpression(MultiaryOperator.And, [idExpression, categoryExpression]);
+
+        var activePredicate = new SearchParameterPredicateExpression(
+            activeParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "true", text: null));
+
+        var tree = new MultiaryExpression(MultiaryOperator.And, [activePredicate, existingAnd]);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [categoryParam.Url.ToString()] = 55, [activeParam.Url.ToString()] = 44 },
+            new Dictionary<string, short> { ["Observation"] = 104 });
+
+        // Act & Assert
+        var ex = Should.Throw<NotSupportedException>(() =>
+            LowerHarness.Run(tree, symbols, targetResourceType: "Observation", includes: [], revIncludes: [], includeLimit: 0, sort: [], sortPhase: SortPhase.Valued, page: null));
+        ex.Message.ShouldContain(
+            "This commonly happens when a resource-column predicate arrives nested inside an And/Or that " +
+            "wasn't flattened before reaching Lower.Run -- e.g. a caller composing And(otherExpression, " +
+            "existingAnd) instead of splicing into existingAnd's own children. Flatten the composed " +
+            "expression before calling Lower.");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/SystemLevelSearchTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/SystemLevelSearchTests.cs
@@ -1,0 +1,169 @@
+using Ignixa.Search.Expressions;
+using Ignixa.Search.Indexing.SearchValues;
+using Ignixa.Search.Models;
+using Ignixa.Search.Sql.Ast;
+using Ignixa.Search.Sql.Builders;
+using Ignixa.Search.Sql.Lowering;
+using Ignixa.Search.Sql.Symbols;
+using Ignixa.Search.Sql.Tests.TestSupport;
+using Ignixa.Specification.ValueSets.Normative;
+using Shouldly;
+using Xunit;
+
+namespace Ignixa.Search.Sql.Tests.Lowering;
+
+public class SystemLevelSearchTests
+{
+    [Fact]
+    public void GivenAnOrdinaryPredicateWithNoResourceType_WhenLowered_ThenParamSourceHasANullResourceTypeId()
+    {
+        // Arrange -- GET /?status=final (a Token predicate, no resource type constraint at all).
+        var parameter = new SearchParameterInfo("status", "status", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        var predicate = new SearchParameterPredicateExpression(parameter, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "final", text: null));
+        var symbols = new SymbolTable(new Dictionary<string, short> { [parameter.Url!.ToString()] = 202 }, new Dictionary<string, short>());
+
+        // Act
+        var lowered = LowerHarness.Run(
+            predicate, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null, new LowerOptions { SystemLevelSearch = true });
+
+        // Assert
+        lowered.Plan.Ctes.Count.ShouldBe(1);
+        var cte = lowered.Plan.Ctes[0].ShouldBeOfType<CteDefinition.ParamSource>();
+        cte.ResourceTypeId.ShouldBeNull();
+        cte.SearchParamId.ShouldBe((short)202);
+    }
+
+    [Fact]
+    public void GivenABareRequestWithNoPredicatesAtAll_WhenLowered_ThenTheBaseSetScansEveryType()
+    {
+        // Arrange -- GET /?_lastUpdated=gt2020-01-01 (a resource-column-only query). The _lastUpdated
+        // predicate is a resource-column predicate, so it must be wrapped in a SearchParameterExpression
+        // for ExtractResourceColumnPredicates to pull it into the outer WHERE, leaving no CTE-lowerable
+        // remainder -- which drops through to the base case: MultiTypeResourceSource.AllTypes(), whose
+        // empty type list is the deliberate every-type contract.
+        var lastUpdatedParam = new SearchParameterInfo("_lastUpdated", "_lastUpdated", SearchParamType.Date, new Uri("http://hl7.org/fhir/SearchParameter/Resource-lastUpdated"));
+        var predicate = new SearchParameterPredicateExpression(lastUpdatedParam, SearchComparator.Gt, modifier: null, new DateTimeSearchValue(DateTime.Parse("2020-01-01")));
+        var expression = new SearchParameterExpression(lastUpdatedParam, predicate);
+        var symbols = new SymbolTable(new Dictionary<string, short>(), new Dictionary<string, short>());
+
+        // Act
+        var lowered = LowerHarness.Run(
+            expression, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null, new LowerOptions { SystemLevelSearch = true });
+
+        // Assert
+        lowered.Plan.Ctes.OfType<CteDefinition.MultiTypeResourceSource>().ShouldContain(rs => rs.ResourceTypeIds.Count == 0);
+        lowered.Plan.OuterPredicate.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GivenAnOrdinaryPredicateSortedByAStringKeyWithNoResourceType_WhenLowered_ThenSortComposesNormally()
+    {
+        // Arrange -- GET /?status=final&_sort=name -- Section 4 requires sort to compose with system-level
+        // search. Without the sort guard being gated on the discriminator this would throw unconditionally.
+        var statusParam = new SearchParameterInfo("status", "status", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        var nameParam = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));
+        var predicate = new SearchParameterPredicateExpression(statusParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "final", text: null));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [statusParam.Url!.ToString()] = 202, [nameParam.Url!.ToString()] = 77 },
+            new Dictionary<string, short>());
+
+        // Act -- must NOT throw.
+        var lowered = LowerHarness.Run(
+            predicate, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [new SortExpression(nameParam, Ignixa.Search.Expressions.SortOrder.Ascending)],
+            sortPhase: SortPhase.Valued, page: null, new LowerOptions { SystemLevelSearch = true });
+
+        // Assert -- a type-less ParamSource plus a working sort join that emits without error.
+        var cte = lowered.Plan.Ctes[0].ShouldBeOfType<CteDefinition.ParamSource>();
+        cte.ResourceTypeId.ShouldBeNull();
+        lowered.Plan.Sort.ShouldNotBeNull();
+        lowered.Plan.Sort!.Keys.Count.ShouldBe(1);
+        lowered.Plan.Sort.Keys[0].SearchParamId.ShouldBe((short)77);
+
+        var emitted = SqlBuilder.Run(lowered.Plan);
+        emitted.Sql.ShouldContain("ORDER BY");
+        emitted.Sql.ShouldContain("StringSearchParam");
+    }
+
+    [Fact]
+    public void GivenAChainedExpressionWithNoResourceType_WhenLowered_ThenItUsesTheChainsOwnTypes()
+    {
+        // Arrange -- ?organization.name=Acme with no target type. A chain names its own referencing and
+        // target types, so a null ambient scope is unused rather than missing, and the plan it lowers to is
+        // the one the typed Patient?organization.name=Acme produces (see
+        // EndToEndCompilationTests.GivenAForwardChainQuery_..., whose golden Explain this matches exactly).
+        // This case was refused at the chain dispatch choke point until LowerChain was shown to read only
+        // the chain's own types; asserting the plan, not just the absence of a throw, is what keeps the
+        // relaxation from degenerating into a cross-type chain that silently ignores its scope.
+        var orgParam = new SearchParameterInfo("organization", "organization", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Patient-organization"));
+        var nameParam = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Organization-name"));
+        var innerPredicate = new SearchParameterPredicateExpression(nameParam, SearchComparator.Eq, modifier: null, new StringSearchValue("Acme"));
+        var chain = new ChainedExpression(["Patient"], orgParam, ["Organization"], reversed: false, new SearchParameterExpression(nameParam, innerPredicate));
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [orgParam.Url!.ToString()] = 55, [nameParam.Url!.ToString()] = 202 },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Organization"] = 105 });
+
+        // Act
+        var lowered = LowerHarness.Run(
+            chain, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+            sort: [], sortPhase: SortPhase.Valued, page: null, new LowerOptions { SystemLevelSearch = true });
+
+        // Assert
+        lowered.Plan.Explain().ShouldBe(
+            "cte0 = StringSearchParam[105,202]  Text LIKE @p0 (StartsWith) collate CI_AI\n" +
+            "root = ChainJoin(cte0, ref=55, inner=105, output=[103], Forward)");
+    }
+
+    [Fact]
+    public void GivenAnIncludeWithNoResourceType_WhenLowered_ThenThrowsNotSupportedException()
+    {
+        // Arrange -- ?status=final&_include=Observation:encounter under system-level search. _include does
+        // not combine with a null target type: BuildIncludeStages needs a concrete match type for SeedFromMatch.
+        var statusParam = new SearchParameterInfo("status", "status", SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        var encounterParam = new SearchParameterInfo(
+            "encounter", "encounter", SearchParamType.Reference,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-encounter"), targetResourceTypes: ["Encounter"]);
+        var predicate = new SearchParameterPredicateExpression(statusParam, SearchComparator.Eq, modifier: null, new TokenSearchValue(system: null, code: "final", text: null));
+        var include = new IncludeExpression(["Observation"], encounterParam, "Observation", "Encounter", null, wildCard: false, reversed: false, iterate: false);
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [statusParam.Url!.ToString()] = 202, [encounterParam.Url!.ToString()] = 88 },
+            new Dictionary<string, short> { ["Observation"] = 104, ["Encounter"] = 105 });
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() =>
+            LowerHarness.Run(
+                predicate, symbols, targetResourceType: null, includes: [include], revIncludes: [], includeLimit: 1000,
+                sort: [], sortPhase: SortPhase.Valued, page: null, new LowerOptions { SystemLevelSearch = true }))
+            .Message.ShouldContain("SeedFromMatch");
+    }
+
+    [Fact]
+    public void GivenAWildcardCompartmentSearchWithASortKey_WhenLowered_ThenStillThrowsNotSupportedException()
+    {
+        // Arrange -- THE critical regression guard: a wildcard compartment search (systemLevelSearch
+        // defaults to false) is a DIFFERENT null-resourceType case and must STILL throw for combinations
+        // it never supported. If this breaks, the discriminator isn't discriminating and system-level
+        // search's relaxation leaked into wildcard compartment too. Mirrors LowerTests'
+        // GivenAWildcardCompartmentSearchWithASortKey exactly.
+        var subjectParam = new SearchParameterInfo("subject", "subject", SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/clinical-subject"));
+        var nameParam = new SearchParameterInfo("name", "name", SearchParamType.String, new Uri("http://hl7.org/fhir/SearchParameter/Patient-name"));
+        var compartment = new CompartmentSearchExpression("Patient", "123");
+        var symbols = new SymbolTable(
+            new Dictionary<string, short> { [subjectParam.Url!.ToString()] = 77, [nameParam.Url!.ToString()] = 202 },
+            new Dictionary<string, short> { ["Patient"] = 103, ["Observation"] = 104 },
+            new Dictionary<string, IReadOnlyList<(SearchParameterInfo, IReadOnlyList<string>)>>
+            {
+                ["Patient"] = [(subjectParam, ["Observation"])],
+            });
+
+        // Act & Assert -- note: NO systemLevelSearch argument (defaults false), so this stays a genuine
+        // wildcard compartment search, not a system-level search.
+        Should.Throw<NotSupportedException>(() =>
+            LowerHarness.Run(
+                compartment, symbols, targetResourceType: null, includes: [], revIncludes: [], includeLimit: 0,
+                sort: [new SortExpression(nameParam, Ignixa.Search.Expressions.SortOrder.Ascending)], sortPhase: SortPhase.Valued, page: null))
+            .Message.ShouldContain("wildcard compartment search");
+    }
+}

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
@@ -19,7 +19,7 @@ public class TokenLoweringRuleTests
     /// these tests pin the relationship to the schema rather than one schema's current number. That the row
     /// generators really split here — rather than at a literal that happens to agree — is pinned from the
     /// writers' side by TokenCodeOverflowSplitPointTests in
-    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
+    /// Ignixa.DataLayer.SqlServer.Tests.
     /// </summary>
     private static readonly int InlineCodeWidth =
         Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;

--- a/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/TokenLoweringRuleTests.cs
@@ -19,7 +19,7 @@ public class TokenLoweringRuleTests
     /// these tests pin the relationship to the schema rather than one schema's current number. That the row
     /// generators really split here — rather than at a literal that happens to agree — is pinned from the
     /// writers' side by TokenCodeOverflowSplitPointTests in
-    /// Ignixa.DataLayer.SqlServer.Tests.
+    /// Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.
     /// </summary>
     private static readonly int InlineCodeWidth =
         Sql.Catalog.SqlCatalog.Default.Table("TokenSearchParam").Column("Code").MaxLength!.Value;

--- a/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Symbols/ResolveTests.cs
@@ -459,6 +459,54 @@ public class ResolveTests
     }
 
     [Fact]
+    public async Task GivenAnOfTypePredicate_WhenResolved_ThenItsIdentifierTypeSystemIsCollected()
+    {
+        // Arrange -- OfTypeTokenSearchValue is not a TokenSearchValue, so the collector's TokenSearchValue
+        // arm does not see its TypeSystem. Left uncollected, SymbolTable.SystemId throws KeyNotFoundException
+        // during Lower and the whole search fails -- the failure mode a missing collector arm always has here.
+        var parameter = new SearchParameterInfo(
+            "identifier", "identifier", SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Patient-identifier"));
+        var predicate = new SearchParameterPredicateExpression(
+            parameter, SearchComparator.Eq, modifier: null,
+            new OfTypeTokenSearchValue("12345", "http://terminology.hl7.org/CodeSystem/v2-0203", "MR"));
+        var expression = new SearchParameterExpression(parameter, predicate);
+
+        var resolver = new FakeSymbolResolver();
+        resolver.SearchParamIds["http://hl7.org/fhir/SearchParameter/Patient-identifier"] = 55;
+        resolver.SystemIds["http://terminology.hl7.org/CodeSystem/v2-0203"] = 77;
+
+        // Act
+        var symbolTable = (await ResolveHarness.RunAsync(expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None)).Symbols;
+
+        // Assert
+        symbolTable.SystemId("http://terminology.hl7.org/CodeSystem/v2-0203").ShouldBe(77);
+    }
+
+    [Fact]
+    public async Task GivenAnOfTypePredicateWithNoTypeSystem_WhenResolved_ThenNoSystemIsCollected()
+    {
+        // Arrange -- the |MR|12345 form has nothing to look up; collecting an empty string would ask the
+        // resolver for a system that cannot exist.
+        var parameter = new SearchParameterInfo(
+            "identifier", "identifier", SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Patient-identifier"));
+        var predicate = new SearchParameterPredicateExpression(
+            parameter, SearchComparator.Eq, modifier: null,
+            new OfTypeTokenSearchValue("12345", typeSystem: null, "MR"));
+        var expression = new SearchParameterExpression(parameter, predicate);
+
+        var resolver = new FakeSymbolResolver();
+        resolver.SearchParamIds["http://hl7.org/fhir/SearchParameter/Patient-identifier"] = 55;
+
+        // Act
+        var symbolTable = (await ResolveHarness.RunAsync(expression, includes: [], revIncludes: [], sort: [], resolver, "Patient", CancellationToken.None)).Symbols;
+
+        // Assert
+        Should.Throw<KeyNotFoundException>(() => symbolTable.SystemId(string.Empty));
+    }
+
+    [Fact]
     public async Task GivenANotReferencedPath_WhenResolved_ThenTheReferenceParameterIsResolvedAndStored()
     {
         // Arrange -- Patient?_not-referenced=Observation:subject. Resolve must look the (Observation,


### PR DESCRIPTION
## Context

This PR extracts a self-contained subset of the in-progress SqlServer data-layer migration branch (`brendankowitz-solid-succotash`, commit `a5056475`) — specifically the accumulated `Ignixa.Search.Sql` / `Ignixa.Search.Sql.Generators` / `Ignixa.Search` fixes and features. This library has no project reference into the SqlServer data-layer migration (`DataLayer.SqlServer` depends on it, not vice versa), so it can land independently of that in-progress migration. The goal is to get a solid version of the Search.Sql library merged first; **the SqlServer data-layer migration PR will rebase on top of this once it merges.**

## Includes

- `SortKeyKind.Aggregated`: MIN/MAX-aggregating derived-table joins for Token/Number/Quantity/Reference/Uri sort
- `SortKeyKind.ResourceId` so `_sort=_id` compiles correctly
- Offset-based paging (`OffsetSpec`) and phase-scoped `CountOnly`, alongside keyset `PageSpec`
- `KeysetContinuationToken` for `PageSpec`'s keyset boundary
- System-level search via nullable `ParamSource`/`ResourceSource.ResourceTypeId`
- Comma-separated `_type` value list support
- `$everything` orchestration: Patient-itself, compartment, conditional date, since-scoped, referenced-type expansion (`VisibleSinceFilter`, `TableExistsPredicate`, `StructuralContext.Except`)
- `SearchCompiler.CompileFromOptionsAsync`, carrying `EmittedSqlTrace.Parameters` and `SearchTrace.CompiledPlan`
- `OuterPredicate` surrogate-ID range filter
- `SqlCatalog` generator repointed at the decomposed per-table DDL under `Ignixa.DataLayer.SqlServer.Database/Tables` (included here as inert DDL-only input to the source generator; no runtime SqlServer driver code is included)
- Fixes: `:of-type` compiled against one `TokenSearchParam` row; single-value `:not` on intrinsics; `$everything` expansion types resolved only when requested; `resourceType` normalized once in `CompileFromOptionsAsync`; `Explain()` parameter ordinal sync for typeless `ResourceSource`
- `SearchOptions` gains `ProbeExtraRow` and `UnsupportedModifierParams` (additive, default false/null — inert until a follow-up PR wires up callers)

## Not included

The two cross-layer fixes for the `_include` probe-row bug (`b5d730f3`, `fe418174`), which also touch `Application`/`FileBasedSearchService`/`DataLayer.SqlServer` and will follow once this lands. The native SqlServer data-layer runtime code stays on the feature branch.

## Verification

- `dotnet build All.sln` → 0 warnings, 0 errors
- `dotnet test test\Ignixa.Search.Sql.Tests\Ignixa.Search.Sql.Tests.csproj` → 1142 passing (net9.0) + 1142 passing (net10.0)
- `dotnet test test\Ignixa.Search.Sql.Generators.Tests\Ignixa.Search.Sql.Generators.Tests.csproj` → 11 passing (net9.0) + 11 passing (net10.0)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>