### PR TITLE
fix(search-sql): enforce case-sensitive of-type codes

### DIFF
--- a/src/Core/Ignixa.Search.Sql/Lowering/Leaf/OfTypeLoweringRule.cs
+++ b/src/Core/Ignixa.Search.Sql/Lowering/Leaf/OfTypeLoweringRule.cs
@@ -18,6 +18,8 @@ namespace Ignixa.Search.Sql.Lowering.Leaf;
 /// </summary>
 internal static class OfTypeLoweringRule
 {
+    private const string CaseSensitiveCollation = "Latin1_General_100_CS_AS";
+
     public static CteDefinition.ParamSource Lower(SearchParameterPredicateExpression predicate, OfTypeTokenSearchValue value, LeafContext context, short? resourceTypeId)
     {
         ArgumentNullException.ThrowIfNull(predicate);
@@ -40,7 +42,7 @@ internal static class OfTypeLoweringRule
                 "An :of-type search carried no identifier value -- a type alone selects every identifier of that type, which is not what the modifier means.");
 
         Predicate typed = new Predicate.And(
-            new Predicate.Equal(new SqlColumnRef(table.TableName, "IdentifierTypeCode"), context.Parameter(value.TypeCode)),
+            new Predicate.Equal(new SqlColumnRef(table.TableName, "IdentifierTypeCode"), context.Parameter(value.TypeCode), CaseSensitiveCollation),
             valueEquality);
 
         // The |code|value form omits the type system deliberately (FHIR allows it), so IdentifierTypeSystemId

--- a/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
+++ b/src/DataLayer/Ignixa.DataLayer.SqlEntityFramework/Search/SearchParameterQueryGenerator.cs
@@ -1496,7 +1496,7 @@ public class SearchParameterQueryGenerator
 
         if (!string.IsNullOrEmpty(identifierTypeCode))
         {
-            query = query.Where(sp => EF.Functions.Collate(sp.IdentifierTypeCode, "Latin1_General_100_CI_AS") == identifierTypeCode);
+            query = query.Where(sp => EF.Functions.Collate(sp.IdentifierTypeCode, "Latin1_General_100_CS_AS") == identifierTypeCode);
         }
 
         _logger.LogDebug(

--- a/test/Ignixa.Api.E2ETests/Search/Modifiers/IdentifierOfTypeTests.cs
+++ b/test/Ignixa.Api.E2ETests/Search/Modifiers/IdentifierOfTypeTests.cs
@@ -533,16 +533,14 @@ public class IdentifierOfTypeTests : CapabilityDrivenTestBase
     }
 
     /// <summary>
-    /// Tests case sensitivity of identifier value matching.
-    /// Per FHIR spec, token values are case-sensitive.
+    /// Tests case sensitivity of identifier type code matching.
+    /// Per FHIR spec, token codes are case-sensitive.
     /// </summary>
     /// <remarks>
-    /// KNOWN DEVIATION: The current implementation uses case-insensitive collation
-    /// (Latin1_General_100_CI_AS) for token matching, which is a server-wide behavior.
-    /// This test is skipped until case-sensitive token matching is implemented.
+    /// Uses the SQL-backed runtime path because collation behavior is database-specific.
     /// </remarks>
-    [Fact(Skip = "Token matching is currently case-insensitive - known deviation from FHIR spec")]
-    public async Task GivenIdentifierWithDifferentCase_WhenSearchingByOfType_ThenSearchIsCaseSensitive()
+    [Fact]
+    public async Task GivenIdentifiersWithCaseVariantTypeCodes_WhenSearchingByOfType_ThenReturnsOnlyExactTypeCode()
     {
         // Capability check
         RequireSearchParameter("Patient", "identifier");
@@ -550,37 +548,86 @@ public class IdentifierOfTypeTests : CapabilityDrivenTestBase
         // Arrange
         var tag = Guid.NewGuid().ToString();
 
-        // Patient with lowercase identifier
-        var patientLower = CreatePatient()
+        // Patient with lowercase type code
+        var patientLowerType = CreatePatient()
+            .FromSeattle()
+            .WithTypedIdentifier("12345", IdentifierTypeSystem, "mr", "Lowercase medical record")
+            .WithTag(tag)
+            .Build();
+
+        // Patient with uppercase type code
+        var patientUpperType = CreatePatient()
+            .FromSeattle()
+            .WithTypedIdentifier("12345", IdentifierTypeSystem, "MR", "Medical Record")
+            .WithTag(tag)
+            .Build();
+
+        await Harness.CreateResourcesAsync([patientLowerType, patientUpperType]);
+
+        // Act
+        var lowercaseResults = await Harness.SearchAsync("Patient",
+            $"identifier:of-type={IdentifierTypeSystem}|mr|12345&_tag={tag}");
+
+        // Assert
+        lowercaseResults.Length.ShouldBe(1, "identifier type code matching should be case-sensitive");
+        lowercaseResults[0].Id.ShouldBe(patientLowerType.Id);
+        lowercaseResults.ShouldNotContain(r => r.Id == patientUpperType.Id);
+
+        // Act
+        var uppercaseResults = await Harness.SearchAsync("Patient",
+            $"identifier:of-type={IdentifierTypeSystem}|MR|12345&_tag={tag}");
+
+        // Assert
+        uppercaseResults.Length.ShouldBe(1, "identifier type code matching should preserve query casing");
+        uppercaseResults[0].Id.ShouldBe(patientUpperType.Id);
+        uppercaseResults.ShouldNotContain(r => r.Id == patientLowerType.Id);
+    }
+
+    /// <summary>
+    /// Tests case sensitivity of identifier value matching.
+    /// Per FHIR spec, token values are case-sensitive.
+    /// </summary>
+    /// <remarks>
+    /// KNOWN DEVIATION: The current implementation uses case-insensitive collation
+    /// (Latin1_General_100_CI_AS) for identifier value matching. This test remains
+    /// skipped until identifier value matching is corrected.
+    /// </remarks>
+    [Fact(Skip = "Identifier value matching is currently case-insensitive - known deviation from FHIR spec")]
+    public async Task GivenIdentifierValueWithDifferentCase_WhenSearchingByOfType_ThenSearchIsCaseSensitive()
+    {
+        // Capability check
+        RequireSearchParameter("Patient", "identifier");
+
+        // Arrange
+        var tag = Guid.NewGuid().ToString();
+        var patientLowerValue = CreatePatient()
             .FromSeattle()
             .WithTypedIdentifier("abc123", IdentifierTypeSystem, "MR", "Medical Record")
             .WithTag(tag)
             .Build();
-
-        // Patient with uppercase identifier
-        var patientUpper = CreatePatient()
+        var patientUpperValue = CreatePatient()
             .FromSeattle()
             .WithTypedIdentifier("ABC123", IdentifierTypeSystem, "MR", "Medical Record")
             .WithTag(tag)
             .Build();
 
-        await Harness.CreateResourcesAsync([patientLower, patientUpper]);
+        await Harness.CreateResourcesAsync([patientLowerValue, patientUpperValue]);
 
-        // Act - Search for lowercase
-        var lowerResults = await Harness.SearchAsync("Patient",
+        // Act
+        var lowercaseResults = await Harness.SearchAsync("Patient",
             $"identifier:of-type={IdentifierTypeSystem}|MR|abc123&_tag={tag}");
 
-        // Assert - Only lowercase should match
-        lowerResults.Length.ShouldBe(1, "search should be case-sensitive");
-        lowerResults[0].Id.ShouldBe(patientLower.Id);
+        // Assert
+        lowercaseResults.Length.ShouldBe(1, "identifier value matching should be case-sensitive");
+        lowercaseResults[0].Id.ShouldBe(patientLowerValue.Id);
 
-        // Act - Search for uppercase
-        var upperResults = await Harness.SearchAsync("Patient",
+        // Act
+        var uppercaseResults = await Harness.SearchAsync("Patient",
             $"identifier:of-type={IdentifierTypeSystem}|MR|ABC123&_tag={tag}");
 
-        // Assert - Only uppercase should match
-        upperResults.Length.ShouldBe(1, "search should be case-sensitive");
-        upperResults[0].Id.ShouldBe(patientUpper.Id);
+        // Assert
+        uppercaseResults.Length.ShouldBe(1, "identifier value matching should be case-sensitive");
+        uppercaseResults[0].Id.ShouldBe(patientUpperValue.Id);
     }
 
     #endregion

--- a/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
@@ -117,6 +117,16 @@ public class OfTypeCompilationTests
         emitted.Parameters.Select(p => p.Value).ShouldContain("12345");
     }
 
+    [Fact]
+    public async Task GivenAnOfTypeQuery_WhenEmitted_ThenTypeCodeUsesCaseSensitiveCollation()
+    {
+        // Act
+        var emitted = await EmitAsync("identifier:of-type=|MR|12345");
+
+        // Assert
+        emitted.Sql.ShouldContain("IdentifierTypeCode = @p0 COLLATE Latin1_General_100_CS_AS");
+    }
+
     private static async Task<QueryPlan> CompileAsync(string queryString)
     {
         var compiler = new SearchSqlCompiler(new CorpusSymbolResolver(), OptionsBuilder, searchParameterDefinitionManager: Definitions);

--- a/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Compilation/OfTypeCompilationTests.cs
@@ -127,6 +127,17 @@ public class OfTypeCompilationTests
         emitted.Sql.ShouldContain("IdentifierTypeCode = @p0 COLLATE Latin1_General_100_CS_AS");
     }
 
+    [Fact]
+    public async Task GivenLowercaseOfTypeCode_WhenEmitted_ThenCodeRemainsLowercaseAndUsesCaseSensitiveCollation()
+    {
+        // Act
+        var emitted = await EmitAsync("identifier:of-type=|mr|12345");
+
+        // Assert - guard that no future normalization upcases the code while still emitting the collation
+        emitted.Parameters.Select(p => p.Value).ShouldContain("mr");
+        emitted.Sql.ShouldContain("IdentifierTypeCode = @p0 COLLATE Latin1_General_100_CS_AS");
+    }
+
     private static async Task<QueryPlan> CompileAsync(string queryString)
     {
         var compiler = new SearchSqlCompiler(new CorpusSymbolResolver(), OptionsBuilder, searchParameterDefinitionManager: Definitions);

--- a/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
@@ -83,6 +83,7 @@ public class OfTypeLoweringRuleTests
         var typeCodeEqual = inner.Left.ShouldBeOfType<Predicate.Equal>();
         typeCodeEqual.Column.Column.ShouldBe("IdentifierTypeCode");
         typeCodeEqual.Value.Value.ShouldBe("MR");
+        typeCodeEqual.Collation.ShouldBe("Latin1_General_100_CS_AS");
 
         var valueEqual = inner.Right.ShouldBeOfType<Predicate.Equal>();
         valueEqual.Column.Column.ShouldBe("Code");

--- a/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
+++ b/test/Ignixa.Search.Sql.Tests/Lowering/OfTypeLoweringRuleTests.cs
@@ -109,6 +109,20 @@ public class OfTypeLoweringRuleTests
     }
 
     [Fact]
+    public void GivenAnOfTypeSearch_WhenLowered_ThenTypeCodeUsesCaseSensitiveCollation()
+    {
+        // Arrange
+        var cte = Lower(typeSystem: null, "MR", "12345");
+
+        // Act
+        var typeCodeEqual = cte.Predicate.ShouldBeOfType<Predicate.And>().Left.ShouldBeOfType<Predicate.Equal>();
+
+        // Assert
+        typeCodeEqual.Column.Column.ShouldBe("IdentifierTypeCode");
+        typeCodeEqual.Collation.ShouldBe("Latin1_General_100_CS_AS");
+    }
+
+    [Fact]
     public void GivenAnOfTypeSearchWithoutATypeSystem_WhenEvaluatedAgainstRowsFromAnySystem_ThenTheSystemIsUnconstrained()
     {
         // Arrange -- two rows with the same type code and value but different (and absent) type systems.


### PR DESCRIPTION
## Purpose
Enforce FHIR-required case-sensitive matching for `identifier:of-type` identifier type codes in both the SQL compiler and active Entity Framework runtime path.

## Scope
- Apply `Latin1_General_100_CS_AS` only to `TokenSearchParam.IdentifierTypeCode`.
- Add AST and emitted-SQL compiler regression coverage.
- Add SQL-backed E2E coverage proving `mr` and `MR` type codes match only their exact case in both query directions.
- Preserve the skipped identifier-value casing test as a separately tracked known deviation.

## Risk
Low. Both paths now specify the intended collation instead of inheriting or forcing case-insensitive behavior; schema, API, query parameterization, and identifier value matching are unchanged.

## Tests
- `dotnet test test\Ignixa.Search.Sql.Tests\Ignixa.Search.Sql.Tests.csproj --no-restore`
- `dotnet test test\Ignixa.Api.E2ETests\Ignixa.Api.E2ETests.csproj --no-restore --filter "FullyQualifiedName~IdentifierOfTypeTests"`
- `dotnet test test\Ignixa.DataLayer.SqlEntityFramework.IntegrationTests\Ignixa.DataLayer.SqlEntityFramework.IntegrationTests.csproj --no-restore`

Part of #390.