### PR TITLE
chore(deps): resolve docs-site Dependabot alerts

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -7270,9 +7270,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9658,9 +9658,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -14287,9 +14287,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -14943,9 +14943,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha1-MWoTnaeUhM5Vlp+nu28vGrzBQGA=",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14962,7 +14962,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -52,10 +52,10 @@
     "body-parser": "^1.20.6",
     "webpack-dev-server": "^5.2.6",
     "http-proxy-middleware": "^2.0.10",
-      "brace-expansion": "^5.0.9",
+    "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.0",
-      "fast-uri": "^3.1.5",
-      "svgo": "^3.3.4",
-      "postcss": "^8.5.23"
-    }
+    "fast-uri": "^3.1.5",
+    "svgo": "^3.3.4",
+    "postcss": "^8.5.23"
+  }
 }

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -52,9 +52,10 @@
     "body-parser": "^1.20.6",
     "webpack-dev-server": "^5.2.6",
     "http-proxy-middleware": "^2.0.10",
-    "brace-expansion": "^5.0.0",
+      "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.0",
-    "fast-uri": "^3.1.4",
-    "svgo": "^3.3.4"
-  }
+      "fast-uri": "^3.1.5",
+      "svgo": "^3.3.4",
+      "postcss": "^8.5.23"
+    }
 }


### PR DESCRIPTION
## Purpose
Resolve open Dependabot security alerts in `docs/site`.

## Changes
Tightened npm overrides and refreshed the lockfile:

| Package | From | To | Alert |
|---------|------|----|-------|
| `postcss` | 8.5.20 | 8.5.26 | #57 medium (CVE-2026-69153) |
| `fast-uri` | 3.1.4 | 3.1.5 | #54 high (CVE-2026-18446) |
| `brace-expansion` | 5.0.8 | 5.0.9 | #53 high (CVE-2026-69152) |

Overrides pin the patched *floor* (`^8.5.23`, `^3.1.5`, `^5.0.9`) rather than an exact version, matching the existing style of the block and staying open to future patches.

### Transitive change
`nanoid` 3.3.16 → 3.3.18. Not a security bump — mechanically forced because `postcss@8.5.26` widened its own dependency range from `^3.3.16` to `^3.3.17`.

That is the complete set of lockfile changes: 4 entries out of 1382. No adds, no removals, no other version moves.

## Remaining open alerts
`image-size@2.0.2` (#55, #56 — high) still has **no upstream patched release**. It is pulled in by `@docusaurus/mdx-loader` for docs build-time image dimension probing, so exposure is limited to trusted repo content at build time. `npm audit` reports `fixAvailable: true` for the dependent `@docusaurus/*` entries, but that would mean forcing major-version Docusaurus churn without actually fixing the root package. Deferred until upstream ships a real fix.

## Verification
- `npm ci` + `npm run build` in `docs/site` — success
- Exactly one install of each bumped package in the tree; no nested vulnerable copies
- `npm audit`: 0 moderate (postcss alert cleared)
- CI `validate-docs` (`pr-build.yml`) covers `docs/site/**` and runs the same install + build

## Risks
Low — docs-site transitive dependencies only. No runtime FHIR server impact.