### PR TITLE
Translate primitive values across the Firely adapter boundary

### DIFF
--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk5/Ignixa.Extensions.FirelySdk5.csproj
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk5/Ignixa.Extensions.FirelySdk5.csproj
@@ -19,6 +19,7 @@
 
   <!-- Link all source files from FirelySdk6 project (zero duplication) -->
   <ItemGroup>
+    <Compile Include="..\Ignixa.Extensions.FirelySdk6\FirelyPrimitiveValues.cs" Link="FirelyPrimitiveValues.cs" />
     <Compile Include="..\Ignixa.Extensions.FirelySdk6\FirelySdkExtensions.cs" Link="FirelySdkExtensions.cs" />
     <Compile Include="..\Ignixa.Extensions.FirelySdk6\IgnixaElementAdapter.cs" Link="IgnixaElementAdapter.cs" />
     <Compile Include="..\Ignixa.Extensions.FirelySdk6\IgnixaExtensions.cs" Link="IgnixaExtensions.cs" />

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using P = Hl7.Fhir.ElementModel.Types;
+
+namespace Ignixa.Extensions.FirelySdk;
+
+/// <summary>
+/// Translates primitive values across the adapter boundary so that each adapter presents the
+/// value contract its own SDK expects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two SDKs disagree on how a primitive value is represented. Firely surfaces the temporal
+/// primitives as <c>Hl7.Fhir.ElementModel.Types</c> instances — <c>date</c> becomes a
+/// <see cref="P.Date"/>, <c>dateTime</c>/<c>instant</c> a <see cref="P.DateTime"/>, and
+/// <c>time</c> a <see cref="P.Time"/>. Ignixa carries the same values as FHIR wire-format
+/// strings (see <c>SchemaAwareElement.Value</c>). Both agree on <c>boolean</c>, the integer
+/// family, <c>decimal</c>, and the string-backed types.
+/// </para>
+/// <para>
+/// Passing a value straight through therefore hands the receiving engine a type it does not
+/// recognise. That is not merely untidy: Ignixa's FHIRPath comparison helpers narrow their
+/// operands through a <c>string</c>/<c>DateTime</c>/<c>DateTimeOffset</c> switch that falls
+/// through to <c>null</c> for anything else, so a Firely <see cref="P.DateTime"/> makes every
+/// date comparison yield an empty collection instead of a boolean — silently, and in a position
+/// where FHIRPath's empty-propagation hides it.
+/// </para>
+/// </remarks>
+internal static class FirelyPrimitiveValues
+{
+    /// <summary>
+    /// Converts a value read from a Firely <c>ITypedElement</c> into the representation Ignixa uses.
+    /// </summary>
+    /// <param name="value">The value as Firely reports it.</param>
+    /// <returns>The equivalent value in Ignixa's representation.</returns>
+    /// <remarks>
+    /// The temporal types round-trip through their FHIR wire format, which is what
+    /// <c>ToString()</c> returns: Firely preserves the originally parsed string when it has one,
+    /// and otherwise renders at the precision the value actually carries, so a year-only
+    /// <c>dateTime</c> stays year-only rather than being widened to a full timestamp.
+    /// </remarks>
+    public static object? ToIgnixa(object? value) => value switch
+    {
+        P.DateTime dateTime => dateTime.ToString(),
+        P.Date date => date.ToString(),
+        P.Time time => time.ToString(),
+        _ => value,
+    };
+
+    /// <summary>
+    /// Converts a value read from an Ignixa <c>IElement</c> into the representation Firely uses.
+    /// </summary>
+    /// <param name="value">The value as Ignixa reports it.</param>
+    /// <param name="instanceType">The FHIR type name of the element the value came from.</param>
+    /// <returns>The equivalent value in Firely's representation.</returns>
+    /// <remarks>
+    /// Ignixa reports the temporal primitives as strings, so the FHIR type name is what tells us
+    /// which of them to build. An unparseable value is surfaced as its raw text rather than
+    /// throwing, matching how Firely's own <c>PocoElementNode</c> degrades on malformed input —
+    /// navigation over a bad resource should stay possible.
+    /// </remarks>
+    public static object? ToFirely(object? value, string? instanceType)
+    {
+        if (value is null || instanceType is null)
+        {
+            return value;
+        }
+
+        try
+        {
+            return (instanceType, value) switch
+            {
+                ("date", string text) => P.Date.Parse(text),
+                ("dateTime" or "instant", string text) => P.DateTime.Parse(text),
+                ("time", string text) => P.Time.Parse(text),
+                ("integer64", string text) => long.Parse(text, CultureInfo.InvariantCulture),
+
+                // IElement.Value also permits DateTimeOffset for the temporal types.
+                ("date", DateTimeOffset dto) => P.Date.FromDateTimeOffset(dto),
+                ("dateTime" or "instant", DateTimeOffset dto) => P.DateTime.FromDateTimeOffset(dto),
+
+                _ => value,
+            };
+        }
+        catch (FormatException)
+        {
+            return value;
+        }
+        catch (OverflowException)
+        {
+            return value;
+        }
+    }
+}

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
@@ -1,9 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Ignixa Contributors. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Frozen;
+using System.Diagnostics;
 using System.Globalization;
 using Ignixa.Abstractions;
 using P = Hl7.Fhir.ElementModel.Types;
@@ -107,9 +108,10 @@ internal static class FirelyPrimitiveValues
     /// Ignixa reports the temporal primitives as strings, so the FHIR type name is what tells us
     /// which of them to build. A value that does not parse is returned unchanged, which is what
     /// the adapter did before any translation existed: navigation over a malformed resource stays
-    /// possible, and the malformed text reaches Firely exactly as it would have. Firely then
-    /// applies its own handling, which for a bad temporal is to throw when the value is consumed -
-    /// this method neither introduces nor suppresses that.
+    /// possible, and the malformed text reaches Firely exactly as it would have. What Firely then
+    /// does with it depends on the consumer - one that coerces it to a temporal throws, while
+    /// navigation, <c>toString()</c> and serialization see the raw string. This method neither
+    /// introduces nor suppresses either outcome.
     /// </remarks>
     public static object? ToFirely(object? value, string? instanceType)
     {
@@ -124,7 +126,7 @@ internal static class FirelyPrimitiveValues
             PrimitiveKind.DateTime => ToFirelyDateTime(value),
             PrimitiveKind.Time => ToFirelyTime(value),
             PrimitiveKind.Integer64 => ToFirelyInteger64(value),
-            _ => value,
+            _ => throw new UnreachableException($"Unhandled {nameof(PrimitiveKind)}: {kind}."),
         };
     }
 
@@ -142,10 +144,12 @@ internal static class FirelyPrimitiveValues
 
     /// <remarks>
     /// The offset is part of a FHIR <c>dateTime</c>, so a bare <see cref="DateTime"/> is rendered
-    /// through its round-trip format rather than being given a fabricated one: that emits no
+    /// through its round-trip format rather than being given an arbitrary one: that emits no
     /// offset for <see cref="DateTimeKind.Unspecified"/>, <c>Z</c> for
-    /// <see cref="DateTimeKind.Utc"/>, and the host offset for <see cref="DateTimeKind.Local"/>,
-    /// matching how Ignixa's own evaluator normalises the same value.
+    /// <see cref="DateTimeKind.Utc"/>, and the host machine's offset for
+    /// <see cref="DateTimeKind.Local"/>, matching how Ignixa's own evaluator normalises the same
+    /// value. The <see cref="DateTimeKind.Local"/> result is therefore host-dependent, which is
+    /// inherent to the input: a local <see cref="DateTime"/> has no meaning without one.
     /// </remarks>
     private static object ToFirelyDateTime(object value) => value switch
     {
@@ -158,8 +162,11 @@ internal static class FirelyPrimitiveValues
     };
 
     /// <remarks>
-    /// A FHIR <c>time</c> is a wall-clock time with no offset, so the offset of a supplied instant
-    /// is deliberately dropped rather than folded into the result.
+    /// A FHIR <c>time</c> is a wall-clock time, so where an offset has to be discarded to build
+    /// one - the instant-shaped arms below - it is dropped rather than folded into the result.
+    /// The string arm does not strip one: FHIR's <c>time</c> grammar forbids an offset, so a
+    /// string carrying one is already non-conformant, and preserving what was actually written is
+    /// more useful to a validator than silently normalising it away.
     /// </remarks>
     private static object ToFirelyTime(object value) => value switch
     {
@@ -170,10 +177,14 @@ internal static class FirelyPrimitiveValues
     };
 
     /// <remarks>
-    /// <see cref="NumberStyles.AllowLeadingSign"/> rather than the default
-    /// <see cref="NumberStyles.Integer"/>, which also accepts surrounding whitespace that FHIR's
-    /// <c>integer64</c> grammar does not permit. A value outside <see cref="long"/>'s range fails
-    /// the parse and is returned unchanged, same as any other unparseable input.
+    /// <c>AllowLeadingSign</c> rather than the default <see cref="NumberStyles.Integer"/>, which
+    /// also accepts surrounding whitespace that FHIR's <c>integer64</c> grammar does not permit.
+    /// This is not a grammar check: FHIR's <c>[0]|[-+]?[1-9][0-9]*</c> also forbids leading zeros,
+    /// which <see cref="long.TryParse(string, NumberStyles, IFormatProvider, out long)"/> accepts
+    /// and canonicalises away, so <c>"007"</c> crosses as <c>7</c>. That matches how
+    /// <c>SchemaAwareElement</c> already parses the narrower integer types; validating the literal
+    /// belongs in the validator, not here. A value outside <see cref="long"/>'s range fails the
+    /// parse and is returned unchanged, same as any other unparseable input.
     /// </remarks>
     private static object ToFirelyInteger64(object value) => value switch
     {

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/FirelyPrimitiveValues.cs
@@ -1,9 +1,11 @@
-// -------------------------------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------------------------------
 // Copyright (c) Ignixa Contributors. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Frozen;
 using System.Globalization;
+using Ignixa.Abstractions;
 using P = Hl7.Fhir.ElementModel.Types;
 
 namespace Ignixa.Extensions.FirelySdk;
@@ -15,23 +17,67 @@ namespace Ignixa.Extensions.FirelySdk;
 /// <remarks>
 /// <para>
 /// The two SDKs disagree on how a primitive value is represented. Firely surfaces the temporal
-/// primitives as <c>Hl7.Fhir.ElementModel.Types</c> instances — <c>date</c> becomes a
+/// primitives as <c>Hl7.Fhir.ElementModel.Types</c> instances - <c>date</c> becomes a
 /// <see cref="P.Date"/>, <c>dateTime</c>/<c>instant</c> a <see cref="P.DateTime"/>, and
-/// <c>time</c> a <see cref="P.Time"/>. Ignixa carries the same values as FHIR wire-format
-/// strings (see <c>SchemaAwareElement.Value</c>). Both agree on <c>boolean</c>, the integer
-/// family, <c>decimal</c>, and the string-backed types.
+/// <c>time</c> a <see cref="P.Time"/>. Ignixa carries those as FHIR wire-format strings
+/// (see <c>SchemaAwareElement.Value</c>). Both agree on <c>boolean</c>, <c>integer</c>,
+/// <c>decimal</c>, and the string-backed types.
 /// </para>
 /// <para>
 /// Passing a value straight through therefore hands the receiving engine a type it does not
 /// recognise. That is not merely untidy: Ignixa's FHIRPath comparison helpers narrow their
 /// operands through a <c>string</c>/<c>DateTime</c>/<c>DateTimeOffset</c> switch that falls
-/// through to <c>null</c> for anything else, so a Firely <see cref="P.DateTime"/> makes every
-/// date comparison yield an empty collection instead of a boolean — silently, and in a position
-/// where FHIRPath's empty-propagation hides it.
+/// through to <c>null</c> for anything else, so a Firely <see cref="P.DateTime"/> makes any
+/// <c>date</c>/<c>dateTime</c> comparison yield an empty collection instead of a boolean -
+/// silently, and in a position where FHIRPath's empty-propagation hides it.
+/// </para>
+/// <para>
+/// <c>integer64</c> is translated in the Ignixa-to-Firely direction only. Firely reports it as a
+/// <see cref="long"/>, which Ignixa's evaluator already treats as a first-class numeric type
+/// alongside <c>int</c> and <c>decimal</c>, so converting it to a string on the way in would
+/// downgrade numeric comparisons to lexical ones. Note that this leaves Ignixa's own two element
+/// implementations disagreeing - <c>SchemaAwareElement</c> has no <c>integer64</c> arm and yields
+/// a string - which is a pre-existing gap in <c>Ignixa.Serialization</c>, not one this shim can
+/// close.
+/// </para>
+/// <para>
+/// Only the primitives the two SDKs disagree about are translated. The FHIRPath system types
+/// Firely's own evaluator can surface - <c>P.Quantity</c>, <c>P.Code</c>, <c>P.Concept</c> - are
+/// not, because their Ignixa counterparts live in <c>Ignixa.FhirPath</c>, which this interop shim
+/// deliberately does not reference. Such a value reaching Ignixa hits the same silent-empty
+/// behaviour described above; the cases are pinned in <c>FirelyPrimitiveValueContractTests</c>.
 /// </para>
 /// </remarks>
 internal static class FirelyPrimitiveValues
 {
+    /// <summary>
+    /// The FHIR primitive types whose representation differs between the two SDKs, mapped to the
+    /// conversion each needs.
+    /// </summary>
+    /// <remarks>
+    /// Keyed case-insensitively because <c>IElement.InstanceType</c> is populated from several
+    /// sources - schema lookups, FHIRPath-synthesised elements, third-party implementations - and
+    /// Ignixa's own evaluator lower-cases it before comparing. A casing mismatch here would not
+    /// fail loudly; it would silently skip the translation.
+    /// </remarks>
+    private static readonly FrozenDictionary<string, PrimitiveKind> TranslatedTypes =
+        new Dictionary<string, PrimitiveKind>(StringComparer.OrdinalIgnoreCase)
+        {
+            [FhirTypeConstants.Date] = PrimitiveKind.Date,
+            [FhirTypeConstants.DateTime] = PrimitiveKind.DateTime,
+            [FhirTypeConstants.Instant] = PrimitiveKind.DateTime,
+            [FhirTypeConstants.Time] = PrimitiveKind.Time,
+            [FhirTypeConstants.Integer64] = PrimitiveKind.Integer64,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    private enum PrimitiveKind
+    {
+        Date,
+        DateTime,
+        Time,
+        Integer64,
+    }
+
     /// <summary>
     /// Converts a value read from a Firely <c>ITypedElement</c> into the representation Ignixa uses.
     /// </summary>
@@ -59,40 +105,88 @@ internal static class FirelyPrimitiveValues
     /// <returns>The equivalent value in Firely's representation.</returns>
     /// <remarks>
     /// Ignixa reports the temporal primitives as strings, so the FHIR type name is what tells us
-    /// which of them to build. An unparseable value is surfaced as its raw text rather than
-    /// throwing, matching how Firely's own <c>PocoElementNode</c> degrades on malformed input —
-    /// navigation over a bad resource should stay possible.
+    /// which of them to build. A value that does not parse is returned unchanged, which is what
+    /// the adapter did before any translation existed: navigation over a malformed resource stays
+    /// possible, and the malformed text reaches Firely exactly as it would have. Firely then
+    /// applies its own handling, which for a bad temporal is to throw when the value is consumed -
+    /// this method neither introduces nor suppresses that.
     /// </remarks>
     public static object? ToFirely(object? value, string? instanceType)
     {
-        if (value is null || instanceType is null)
+        if (value is null || instanceType is null || !TranslatedTypes.TryGetValue(instanceType, out var kind))
         {
             return value;
         }
 
-        try
+        return kind switch
         {
-            return (instanceType, value) switch
-            {
-                ("date", string text) => P.Date.Parse(text),
-                ("dateTime" or "instant", string text) => P.DateTime.Parse(text),
-                ("time", string text) => P.Time.Parse(text),
-                ("integer64", string text) => long.Parse(text, CultureInfo.InvariantCulture),
-
-                // IElement.Value also permits DateTimeOffset for the temporal types.
-                ("date", DateTimeOffset dto) => P.Date.FromDateTimeOffset(dto),
-                ("dateTime" or "instant", DateTimeOffset dto) => P.DateTime.FromDateTimeOffset(dto),
-
-                _ => value,
-            };
-        }
-        catch (FormatException)
-        {
-            return value;
-        }
-        catch (OverflowException)
-        {
-            return value;
-        }
+            PrimitiveKind.Date => ToFirelyDate(value),
+            PrimitiveKind.DateTime => ToFirelyDateTime(value),
+            PrimitiveKind.Time => ToFirelyTime(value),
+            PrimitiveKind.Integer64 => ToFirelyInteger64(value),
+            _ => value,
+        };
     }
+
+    /// <remarks>
+    /// A FHIR <c>date</c> has no time and no offset, so the offset of a supplied instant is
+    /// deliberately dropped rather than folded into the result.
+    /// </remarks>
+    private static object ToFirelyDate(object value) => value switch
+    {
+        string text => P.Date.TryParse(text, out var parsedText) ? parsedText : value,
+        DateTimeOffset dto => P.Date.FromDateTimeOffset(dto, P.DateTimePrecision.Day, includeOffset: false),
+        DateTime dt => P.Date.FromDateTimeOffset(AsOffset(dt), P.DateTimePrecision.Day, includeOffset: false),
+        _ => value,
+    };
+
+    /// <remarks>
+    /// The offset is part of a FHIR <c>dateTime</c>, so a bare <see cref="DateTime"/> is rendered
+    /// through its round-trip format rather than being given a fabricated one: that emits no
+    /// offset for <see cref="DateTimeKind.Unspecified"/>, <c>Z</c> for
+    /// <see cref="DateTimeKind.Utc"/>, and the host offset for <see cref="DateTimeKind.Local"/>,
+    /// matching how Ignixa's own evaluator normalises the same value.
+    /// </remarks>
+    private static object ToFirelyDateTime(object value) => value switch
+    {
+        string text => P.DateTime.TryParse(text, out var parsedText) ? parsedText : value,
+        DateTimeOffset dto => P.DateTime.FromDateTimeOffset(dto, P.DateTimePrecision.Fraction, includeOffset: true),
+        DateTime dt => P.DateTime.TryParse(dt.ToString("o", CultureInfo.InvariantCulture), out var parsedDateTime)
+            ? parsedDateTime
+            : value,
+        _ => value,
+    };
+
+    /// <remarks>
+    /// A FHIR <c>time</c> is a wall-clock time with no offset, so the offset of a supplied instant
+    /// is deliberately dropped rather than folded into the result.
+    /// </remarks>
+    private static object ToFirelyTime(object value) => value switch
+    {
+        string text => P.Time.TryParse(text, out var parsedText) ? parsedText : value,
+        DateTimeOffset dto => P.Time.FromDateTimeOffset(dto, P.DateTimePrecision.Fraction, includeOffset: false),
+        DateTime dt => P.Time.FromDateTimeOffset(AsOffset(dt), P.DateTimePrecision.Fraction, includeOffset: false),
+        _ => value,
+    };
+
+    /// <remarks>
+    /// <see cref="NumberStyles.AllowLeadingSign"/> rather than the default
+    /// <see cref="NumberStyles.Integer"/>, which also accepts surrounding whitespace that FHIR's
+    /// <c>integer64</c> grammar does not permit. A value outside <see cref="long"/>'s range fails
+    /// the parse and is returned unchanged, same as any other unparseable input.
+    /// </remarks>
+    private static object ToFirelyInteger64(object value) => value switch
+    {
+        string text => long.TryParse(text, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var parsedText)
+            ? parsedText
+            : value,
+        _ => value,
+    };
+
+    /// <summary>
+    /// Widens a <see cref="DateTime"/> to a <see cref="DateTimeOffset"/> without consulting the
+    /// host's time zone, for the cases where the offset is discarded anyway.
+    /// </summary>
+    private static DateTimeOffset AsOffset(DateTime value) =>
+        new(DateTime.SpecifyKind(value, DateTimeKind.Unspecified), TimeSpan.Zero);
 }

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
@@ -38,7 +38,11 @@ public class IgnixaElementAdapter : IElement
     public string Name => _firelyElement.Name;
 
     /// <inheritdoc/>
-    public object? Value => _firelyElement.Value;
+    /// <remarks>
+    /// Translated into Ignixa's representation — Firely surfaces the temporal primitives as
+    /// <c>Hl7.Fhir.ElementModel.Types</c> instances, which Ignixa's evaluators do not recognise.
+    /// </remarks>
+    public object? Value => FirelyPrimitiveValues.ToIgnixa(_firelyElement.Value);
 
     /// <inheritdoc/>
     public string InstanceType => _firelyElement.InstanceType ?? string.Empty;

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
@@ -24,6 +24,8 @@ public class IgnixaElementAdapter : IElement
     private readonly Hl7.Fhir.ElementModel.ITypedElement _firelyElement;
     private IReadOnlyList<IElement>? _cachedAllChildren;
     private Dictionary<string, IReadOnlyList<IElement>>? _childrenByName;
+    private object? _translatedValue;
+    private bool _translatedValueResolved;
 
     /// <summary>
     /// Creates a new adapter wrapping a Firely SDK ITypedElement.
@@ -39,10 +41,27 @@ public class IgnixaElementAdapter : IElement
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Translated into Ignixa's representation — Firely surfaces the temporal primitives as
+    /// <inheritdoc path="/remarks/node()"/>
+    /// <para>
+    /// Translated into Ignixa's representation - Firely surfaces the temporal primitives as
     /// <c>Hl7.Fhir.ElementModel.Types</c> instances, which Ignixa's evaluators do not recognise.
+    /// Memoized so that repeated reads return the same instance rather than re-rendering the
+    /// wire-format string each time.
+    /// </para>
     /// </remarks>
-    public object? Value => FirelyPrimitiveValues.ToIgnixa(_firelyElement.Value);
+    public object? Value
+    {
+        get
+        {
+            if (!_translatedValueResolved)
+            {
+                _translatedValue = FirelyPrimitiveValues.ToIgnixa(_firelyElement.Value);
+                _translatedValueResolved = true;
+            }
+
+            return _translatedValue;
+        }
+    }
 
     /// <inheritdoc/>
     public string InstanceType => _firelyElement.InstanceType ?? string.Empty;

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/IgnixaElementAdapter.cs
@@ -25,7 +25,7 @@ public class IgnixaElementAdapter : IElement
     private IReadOnlyList<IElement>? _cachedAllChildren;
     private Dictionary<string, IReadOnlyList<IElement>>? _childrenByName;
     private object? _translatedValue;
-    private bool _translatedValueResolved;
+    private volatile bool _translatedValueResolved;
 
     /// <summary>
     /// Creates a new adapter wrapping a Firely SDK ITypedElement.
@@ -46,7 +46,10 @@ public class IgnixaElementAdapter : IElement
     /// Translated into Ignixa's representation - Firely surfaces the temporal primitives as
     /// <c>Hl7.Fhir.ElementModel.Types</c> instances, which Ignixa's evaluators do not recognise.
     /// Memoized so that repeated reads return the same instance rather than re-rendering the
-    /// wire-format string each time.
+    /// wire-format string each time. The value is captured on first read: this adapter is a
+    /// snapshot of the wrapped element, not a live view of it, so re-create it after mutating the
+    /// element underneath. The resolved flag is <c>volatile</c> so a concurrent reader cannot see
+    /// it set before the value it guards.
     /// </para>
     /// </remarks>
     public object? Value
@@ -70,7 +73,12 @@ public class IgnixaElementAdapter : IElement
     public string Location => _firelyElement.Location;
 
     /// <inheritdoc/>
-    public bool HasPrimitiveValue => _firelyElement.Value != null;
+    /// <remarks>
+    /// Derived from <see cref="Value"/> rather than read live off the wrapped element, so the two
+    /// cannot disagree once the value has been snapshotted. Translation never maps a non-null
+    /// value to null, so this is the same answer the wrapped element would give.
+    /// </remarks>
+    public bool HasPrimitiveValue => Value is not null;
 
     /// <inheritdoc/>
     public IType? Type => _firelyElement.Definition != null

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
@@ -55,7 +55,11 @@ public class TypedElementAdapter : ITypedElement
     }
 
     /// <inheritdoc/>
-    public object? Value => _coreElement.Value;
+    /// <remarks>
+    /// Translated into Firely's representation — Ignixa carries the temporal primitives as FHIR
+    /// wire-format strings, where Firely expects <c>Hl7.Fhir.ElementModel.Types</c> instances.
+    /// </remarks>
+    public object? Value => FirelyPrimitiveValues.ToFirely(_coreElement.Value, _coreElement.InstanceType);
 
     /// <inheritdoc/>
     public string InstanceType => _coreElement.InstanceType;

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
@@ -25,6 +25,8 @@ namespace Ignixa.Extensions.FirelySdk;
 public class TypedElementAdapter : ITypedElement
 {
     private readonly IElement _coreElement;
+    private object? _translatedValue;
+    private bool _translatedValueResolved;
 
     /// <summary>
     /// Creates a new adapter wrapping an Ignixa IElement.
@@ -56,10 +58,30 @@ public class TypedElementAdapter : ITypedElement
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Translated into Firely's representation — Ignixa carries the temporal primitives as FHIR
+    /// <inheritdoc path="/remarks/node()"/>
+    /// <para>
+    /// Translated into Firely's representation - Ignixa carries the temporal primitives as FHIR
     /// wire-format strings, where Firely expects <c>Hl7.Fhir.ElementModel.Types</c> instances.
+    /// </para>
+    /// <para>
+    /// Memoized because the translation parses, and Firely's engines read <c>Value</c> repeatedly
+    /// on the same element - and because <see cref="Children"/> hands out a fresh adapter per call,
+    /// so nothing upstream would amortise it.
+    /// </para>
     /// </remarks>
-    public object? Value => FirelyPrimitiveValues.ToFirely(_coreElement.Value, _coreElement.InstanceType);
+    public object? Value
+    {
+        get
+        {
+            if (!_translatedValueResolved)
+            {
+                _translatedValue = FirelyPrimitiveValues.ToFirely(_coreElement.Value, _coreElement.InstanceType);
+                _translatedValueResolved = true;
+            }
+
+            return _translatedValue;
+        }
+    }
 
     /// <inheritdoc/>
     public string InstanceType => _coreElement.InstanceType;

--- a/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
+++ b/src/Core/Extensions/Ignixa.Extensions.FirelySdk6/TypedElementAdapter.cs
@@ -26,7 +26,7 @@ public class TypedElementAdapter : ITypedElement
 {
     private readonly IElement _coreElement;
     private object? _translatedValue;
-    private bool _translatedValueResolved;
+    private volatile bool _translatedValueResolved;
 
     /// <summary>
     /// Creates a new adapter wrapping an Ignixa IElement.
@@ -66,7 +66,11 @@ public class TypedElementAdapter : ITypedElement
     /// <para>
     /// Memoized because the translation parses, and Firely's engines read <c>Value</c> repeatedly
     /// on the same element - and because <see cref="Children"/> hands out a fresh adapter per call,
-    /// so nothing upstream would amortise it.
+    /// so nothing upstream would amortise it. The value and the instance type are both captured on
+    /// first read: this adapter is a snapshot of the wrapped element, not a live view of it, so
+    /// re-create it after mutating the element underneath. The resolved flag is
+    /// <c>volatile</c> so a concurrent reader cannot see it set before the value it guards; the
+    /// translation is pure, so racing readers at worst repeat the work.
     /// </para>
     /// </remarks>
     public object? Value

--- a/src/Core/Ignixa.Abstractions/Structure/IElement.cs
+++ b/src/Core/Ignixa.Abstractions/Structure/IElement.cs
@@ -30,13 +30,29 @@ public interface IElement
     /// Primitive value for primitive types, null for complex types.
     /// </summary>
     /// <remarks>
-    /// Type mapping:
-    /// - boolean → bool
-    /// - integer → int
-    /// - string/code/id/markdown/url/canonical/uuid → string
-    /// - decimal → decimal
-    /// - dateTime/date/instant → DateTimeOffset or string
-    /// - base64Binary → byte[] or string
+    /// <para>
+    /// Canonical mapping, as produced by <c>SchemaAwareElement</c>:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>boolean → bool</description></item>
+    /// <item><description>integer/unsignedInt/positiveInt → int</description></item>
+    /// <item><description>decimal → decimal</description></item>
+    /// <item><description>every other primitive, including date/dateTime/instant/time,
+    /// integer64, and base64Binary → its FHIR wire-format string</description></item>
+    /// </list>
+    /// <para>
+    /// Consumers must additionally tolerate these alternatives, which other implementations do
+    /// produce: <c>DateTimeOffset</c> or <c>DateTime</c> for date/dateTime/instant/time,
+    /// <c>byte[]</c> for base64Binary, and <c>long</c> for integer64. Note that
+    /// <c>SchemaAwareElement</c> does not yet emit <c>long</c> for integer64 even though the
+    /// FHIRPath evaluator treats it as a first-class numeric, so the two differ for that type.
+    /// </para>
+    /// <para>
+    /// This is a real contract, not documentation: <c>Ignixa.Extensions.FirelySdk</c> translates
+    /// against it when crossing into the Firely SDK, and the FHIRPath comparison helpers narrow
+    /// their operands to exactly these types. A value outside the list is not rejected - it falls
+    /// through to an empty collection, which FHIRPath's empty-propagation then hides.
+    /// </para>
     /// </remarks>
     object? Value { get; }
 

--- a/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
+++ b/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
@@ -116,7 +116,7 @@ public class FirelyPrimitiveValueContractTests
         var value = new TypedElementAdapter(element).Value;
 
         // Assert
-        Assert.Same(text, value);
+        Assert.Equal(text, value);
     }
 
     [Fact]
@@ -130,20 +130,96 @@ public class FirelyPrimitiveValueContractTests
         Assert.Equal(1.5m, new TypedElementAdapter(new StubElement { InstanceType = "decimal", Value = 1.5m }).Value);
     }
 
-    [Fact]
-    public void GivenUnparseableIgnixaDateTime_WhenReadThroughTypedElementAdapter_ThenReturnsRawTextWithoutThrowing()
+    [Theory]
+    [InlineData("dateTime", "not-a-date")]
+    [InlineData("date", "2013-13-45")]
+    [InlineData("time", "99:99")]
+    [InlineData("integer64", "9223372036854775808")]
+    [InlineData("integer64", "12.0")]
+    [InlineData("integer64", " 12 ")]
+    public void GivenUnparseableIgnixaPrimitive_WhenReadThroughTypedElementAdapter_ThenReturnsRawTextWithoutThrowing(string instanceType, string text)
     {
-        // Firely's own PocoElementNode degrades this way, so navigation over a malformed
-        // resource stays possible instead of throwing mid-traversal.
+        // Degrading to the raw text keeps navigation over a malformed resource possible instead of
+        // throwing mid-traversal. It is NOT a repair: the raw string reaches Firely exactly as it
+        // did before this translation existed, so downstream behaviour on bad data is unchanged.
+        // Note " 12 " is rejected deliberately - FHIR's integer64 regex forbids surrounding
+        // whitespace, which long.TryParse would otherwise accept under NumberStyles.Integer.
 
         // Arrange
-        var element = new StubElement { InstanceType = "dateTime", Value = "not-a-date" };
+        var element = new StubElement { InstanceType = instanceType, Value = text };
 
         // Act
         var value = new TypedElementAdapter(element).Value;
 
         // Assert
-        Assert.Equal("not-a-date", value);
+        Assert.Equal(text, value);
+    }
+
+    [Theory]
+    [InlineData("DateTime", "2013-01-01T11:22:33+10:00")]
+    [InlineData("DATE", "2013-01-01")]
+    [InlineData("Time", "11:22:33")]
+    [InlineData("Integer64", "42")]
+    public void GivenInstanceTypeInUnexpectedCasing_WhenReadThroughTypedElementAdapter_ThenStillTranslates(string instanceType, string text)
+    {
+        // The FHIRPath evaluator lower-cases instanceType before dispatching on it, so a source
+        // that reports non-canonical casing works there. Translation must not be the odd one out.
+
+        // Arrange
+        var element = new StubElement { InstanceType = instanceType, Value = text };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.IsNotType<string>(value);
+    }
+
+    [Theory]
+    [InlineData("date", "2024-03-05")]
+    [InlineData("dateTime", "2024-03-05T13:45:30.123+10:00")]
+    [InlineData("time", "13:45:30.123")]
+    public void GivenIgnixaDateTimeOffsetValue_WhenReadThroughTypedElementAdapter_ThenTranslatesAtTheTypesOwnPrecision(string instanceType, string expected)
+    {
+        // IElement.Value permits DateTimeOffset as well as the wire string. Each FHIR type has to
+        // land at its own precision: date drops the time and offset, time drops the offset, and
+        // only dateTime keeps both.
+
+        // Arrange
+        var element = new StubElement
+        {
+            InstanceType = instanceType,
+            Value = new DateTimeOffset(2024, 3, 5, 13, 45, 30, 123, TimeSpan.FromHours(10)),
+        };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(expected, value?.ToString());
+    }
+
+    [Fact]
+    public void GivenIgnixaDateTimeValue_WhenReadThroughTypedElementAdapter_ThenTranslatesWithoutFabricatingAnOffset()
+    {
+        // A bare DateTime carries no offset. Translating it must not invent one, because "+00:00"
+        // and "no offset stated" are different instants in FHIR.
+
+        // Arrange
+        var element = new StubElement
+        {
+            InstanceType = "dateTime",
+            Value = new DateTime(2024, 3, 5, 13, 45, 30, DateTimeKind.Unspecified),
+        };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        var dateTime = Assert.IsType<P.DateTime>(value);
+        Assert.DoesNotContain("+", dateTime.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Z", dateTime.ToString(), StringComparison.Ordinal);
+        Assert.StartsWith("2024-03-05T13:45:30", dateTime.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -211,6 +287,33 @@ public class FirelyPrimitiveValueContractTests
         Assert.Equal(1.5m, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "decimal", Value = 1.5m }).Value);
     }
 
+    [Fact]
+    public void GivenFirelyQuantityValue_WhenReadThroughIgnixaElementAdapter_ThenPassesThroughUntranslated()
+    {
+        // Pins a known gap rather than asserting desired behaviour.
+        //
+        // Firely surfaces Quantity as Hl7.Fhir.ElementModel.Types.Quantity. Ignixa's evaluator
+        // tests `element.Value is Ignixa.FhirPath.Types.Quantity` (FhirPathEvaluator.cs:649), a
+        // different type, so it never matches. The consequence is silent: on an adapted Firely
+        // element, `value.toQuantity() = 5 'mg'` and `value.toQuantity() > 1 'mg'` both yield an
+        // empty collection instead of a boolean.
+        //
+        // This shim cannot fix it. Ignixa.FhirPath.Types.Quantity lives in Ignixa.FhirPath, which
+        // Ignixa.Extensions.FirelySdk6 deliberately does not reference - translating here would
+        // invert the layering. The fix belongs either in Ignixa.FhirPath (accept P.Quantity) or in
+        // moving Quantity down to Ignixa.Abstractions. Update this test when that lands.
+
+        // Arrange
+        var quantity = new P.Quantity(5m, "mg");
+        var element = new StubTypedElement { InstanceType = "Quantity", Value = quantity };
+
+        // Act
+        var value = new IgnixaElementAdapter(element).Value;
+
+        // Assert
+        Assert.Same(quantity, value);
+    }
+
     #endregion
 
     #region Round trip
@@ -220,19 +323,47 @@ public class FirelyPrimitiveValueContractTests
     [InlineData("dateTime", "2013")]
     [InlineData("date", "2013-01-01")]
     [InlineData("time", "11:22:33")]
-    public void GivenIgnixaTemporal_WhenRoundTrippedThroughBothAdapters_ThenPrecisionIsPreserved(string instanceType, string text)
+    public void GivenIgnixaTemporalString_WhenRoundTrippedThroughBothAdapters_ThenPrecisionIsPreserved(string instanceType, string text)
     {
         // Precision matters: a year-only dateTime must not be widened into a full timestamp.
+        // Note this case is weak on its own - a pass-through adapter satisfies it too, because the
+        // identity function trivially round-trips. The DateTimeOffset theory below is the one with
+        // mutation-detection power; this one guards against a lossy parse/render pair.
 
         // Arrange
         var element = new StubElement { InstanceType = instanceType, Value = text };
 
-        // Act — deliberately re-wrap rather than relying on the unwrapping fast path.
+        // Act - deliberately re-wrap rather than relying on the unwrapping fast path.
         var firelyValue = new TypedElementAdapter(element).Value;
         var backToIgnixa = new IgnixaElementAdapter(new StubTypedElement { InstanceType = instanceType, Value = firelyValue }).Value;
 
         // Assert
         Assert.Equal(text, backToIgnixa);
+    }
+
+    [Theory]
+    [InlineData("date", "2024-03-05")]
+    [InlineData("dateTime", "2024-03-05T13:45:30.123+10:00")]
+    [InlineData("time", "13:45:30.123")]
+    public void GivenIgnixaDateTimeOffset_WhenRoundTrippedThroughBothAdapters_ThenNarrowsToTheTypesWireFormat(string instanceType, string expected)
+    {
+        // Unlike the string theory above, this one fails against a pass-through adapter: a raw
+        // DateTimeOffset would come back as its own ToString(), never as the FHIR wire format,
+        // and a date would arrive carrying a time and offset it is not allowed to have.
+
+        // Arrange
+        var element = new StubElement
+        {
+            InstanceType = instanceType,
+            Value = new DateTimeOffset(2024, 3, 5, 13, 45, 30, 123, TimeSpan.FromHours(10)),
+        };
+
+        // Act
+        var firelyValue = new TypedElementAdapter(element).Value;
+        var backToIgnixa = new IgnixaElementAdapter(new StubTypedElement { InstanceType = instanceType, Value = firelyValue }).Value;
+
+        // Assert
+        Assert.Equal(expected, Assert.IsType<string>(backToIgnixa));
     }
 
     #endregion
@@ -270,6 +401,114 @@ public class FirelyPrimitiveValueContractTests
 
     #endregion
 
+    #region Memoization
+
+    [Fact]
+    public void GivenRepeatedValueReads_WhenReadThroughTypedElementAdapter_ThenTranslatesOnlyOnce()
+    {
+        // Translation parses, which costs roughly 20x what Firely's own ITypedElement.Value costs.
+        // Firely's engines read Value several times per element, and Children() hands out a fresh
+        // adapter per call, so nothing upstream would amortise a per-read parse.
+
+        // Arrange
+        var element = new CountingStubElement { InstanceType = "dateTime", Value = "2013-01-01T11:22:33+10:00" };
+        var adapter = new TypedElementAdapter(element);
+
+        // Act
+        _ = adapter.Value;
+        _ = adapter.Value;
+        _ = adapter.Value;
+
+        // Assert
+        Assert.Equal(1, element.ValueReadCount);
+    }
+
+    [Fact]
+    public void GivenRepeatedValueReads_WhenReadThroughIgnixaElementAdapter_ThenTranslatesOnlyOnce()
+    {
+        // Arrange
+        var element = new CountingStubTypedElement { InstanceType = "date", Value = P.Date.Parse("2013-01-01") };
+        var adapter = new IgnixaElementAdapter(element);
+
+        // Act
+        _ = adapter.Value;
+        _ = adapter.Value;
+        _ = adapter.Value;
+
+        // Assert
+        Assert.Equal(1, element.ValueReadCount);
+    }
+
+    [Fact]
+    public void GivenNullValue_WhenReadRepeatedlyThroughTypedElementAdapter_ThenStillTranslatesOnlyOnce()
+    {
+        // Guards the classic memoization bug of using a null field as the "not yet resolved"
+        // sentinel, which would re-translate forever whenever the real answer is null.
+
+        // Arrange
+        var element = new CountingStubElement { InstanceType = "dateTime", Value = null };
+        var adapter = new TypedElementAdapter(element);
+
+        // Act
+        _ = adapter.Value;
+        _ = adapter.Value;
+
+        // Assert
+        Assert.Equal(1, element.ValueReadCount);
+    }
+
+    #endregion
+
+    #region Extension method entry points
+
+    [Fact]
+    public void GivenIgnixaElement_WhenConvertedViaToTypedElement_ThenValueIsTranslated()
+    {
+        // Most callers reach the adapters through the extension methods rather than constructing
+        // them directly, so the translation has to be live on that path too.
+
+        // Arrange
+        var element = new StubElement { InstanceType = "date", Value = "2013-01-01" };
+
+        // Act
+        var value = element.ToTypedElement().Value;
+
+        // Assert
+        Assert.IsType<P.Date>(value);
+    }
+
+    [Fact]
+    public void GivenFirelyElement_WhenConvertedViaToIgnixaElement_ThenValueIsTranslated()
+    {
+        // Arrange
+        var element = new StubTypedElement { InstanceType = "date", Value = P.Date.Parse("2013-01-01") };
+
+        // Act
+        var value = element.ToIgnixaElement().Value;
+
+        // Assert
+        Assert.Equal("2013-01-01", Assert.IsType<string>(value));
+    }
+
+    [Fact]
+    public void GivenAdaptedFirelyElement_WhenConvertedBackViaToTypedElement_ThenUnwrapsRatherThanDoubleTranslating()
+    {
+        // The unwrap fast path returns the original Firely element, whose Value was never
+        // translated. If it ever stopped unwrapping, the value would be rendered to a string on the
+        // way in and re-parsed on the way out - lossy for anything the string form cannot carry.
+
+        // Arrange
+        var original = new StubTypedElement { InstanceType = "date", Value = P.Date.Parse("2013-01-01") };
+
+        // Act
+        var roundTripped = original.ToIgnixaElement().ToTypedElement();
+
+        // Assert
+        Assert.Same(original, roundTripped);
+    }
+
+    #endregion
+
     #region Stubs
 
     private sealed class StubElement : IElement
@@ -286,10 +525,43 @@ public class FirelyPrimitiveValueContractTests
 
         public bool HasPrimitiveValue => Value != null;
 
-        public List<IElement> ChildElements { get; init; } = new();
+        public List<IElement> ChildElements { get; init; } = [];
 
         public IReadOnlyList<IElement> Children(string? name = null) =>
             name == null ? ChildElements : ChildElements.Where(c => c.Name == name).ToArray();
+
+        public T? Meta<T>()
+            where T : class => null;
+    }
+
+    private sealed class CountingStubElement : IElement
+    {
+        private object? _value;
+
+        public int ValueReadCount { get; private set; }
+
+        public string Name { get; init; } = string.Empty;
+
+        public object? Value
+        {
+            get
+            {
+                ValueReadCount++;
+                return _value;
+            }
+
+            init => _value = value;
+        }
+
+        public string InstanceType { get; init; } = string.Empty;
+
+        public string Location { get; init; } = string.Empty;
+
+        public IType? Type { get; init; }
+
+        public bool HasPrimitiveValue => _value != null;
+
+        public IReadOnlyList<IElement> Children(string? name = null) => [];
 
         public T? Meta<T>()
             where T : class => null;
@@ -307,10 +579,41 @@ public class FirelyPrimitiveValueContractTests
 
         public IElementDefinitionSummary? Definition { get; init; }
 
-        public List<ITypedElement> ChildElements { get; init; } = new();
+        public List<ITypedElement> ChildElements { get; init; } = [];
 
         public IEnumerable<ITypedElement> Children(string? name = null) =>
             name == null ? ChildElements : ChildElements.Where(c => c.Name == name);
+
+        public T? Annotation<T>()
+            where T : class => null;
+    }
+
+    private sealed class CountingStubTypedElement : ITypedElement
+    {
+        private object? _value;
+
+        public int ValueReadCount { get; private set; }
+
+        public string Name { get; init; } = string.Empty;
+
+        public object? Value
+        {
+            get
+            {
+                ValueReadCount++;
+                return _value;
+            }
+
+            init => _value = value;
+        }
+
+        public string? InstanceType { get; init; }
+
+        public string Location { get; init; } = string.Empty;
+
+        public IElementDefinitionSummary? Definition { get; init; }
+
+        public IEnumerable<ITypedElement> Children(string? name = null) => [];
 
         public T? Annotation<T>()
             where T : class => null;

--- a/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
+++ b/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
@@ -1,0 +1,320 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Ignixa Contributors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Specification;
+using Ignixa.Abstractions;
+using Ignixa.Extensions.FirelySdk;
+using Ignixa.FhirPath.Evaluation;
+using Ignixa.FhirPath.Parser;
+using Xunit;
+using P = Hl7.Fhir.ElementModel.Types;
+
+namespace Ignixa.Extensions.Tests.FirelySdk;
+
+/// <summary>
+/// Tests that each adapter presents the primitive value contract its own SDK expects, rather than
+/// passing the other SDK's representation straight through.
+/// </summary>
+public class FirelyPrimitiveValueContractTests
+{
+    #region Ignixa -> Firely
+
+    [Theory]
+    [InlineData("dateTime", "2013-01-01T11:22:33+10:00")]
+    [InlineData("dateTime", "2013")]
+    [InlineData("instant", "2013-01-01T11:22:33.123Z")]
+    public void GivenIgnixaDateTimeString_WhenReadThroughTypedElementAdapter_ThenReturnsFirelyDateTime(string instanceType, string text)
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = instanceType, Value = text };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        var dateTime = Assert.IsType<P.DateTime>(value);
+        Assert.Equal(text, dateTime.ToString());
+    }
+
+    [Fact]
+    public void GivenIgnixaDateString_WhenReadThroughTypedElementAdapter_ThenReturnsFirelyDate()
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = "date", Value = "2013-01-01" };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        var date = Assert.IsType<P.Date>(value);
+        Assert.Equal("2013-01-01", date.ToString());
+    }
+
+    [Fact]
+    public void GivenIgnixaTimeString_WhenReadThroughTypedElementAdapter_ThenReturnsFirelyTime()
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = "time", Value = "11:22:33" };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        var time = Assert.IsType<P.Time>(value);
+        Assert.Equal("11:22:33", time.ToString());
+    }
+
+    [Fact]
+    public void GivenIgnixaDateTimeOffset_WhenReadThroughTypedElementAdapter_ThenReturnsFirelyDateTime()
+    {
+        // IElement.Value permits DateTimeOffset for the temporal types as well as a string.
+
+        // Arrange
+        var instant = new DateTimeOffset(2013, 1, 1, 11, 22, 33, TimeSpan.Zero);
+        var element = new StubElement { InstanceType = "instant", Value = instant };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        var dateTime = Assert.IsType<P.DateTime>(value);
+        Assert.Equal(instant, dateTime.ToDateTimeOffset(TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void GivenIgnixaInteger64String_WhenReadThroughTypedElementAdapter_ThenReturnsLong()
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = "integer64", Value = "9007199254740993" };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(9007199254740993L, Assert.IsType<long>(value));
+    }
+
+    [Theory]
+    [InlineData("string", "hello")]
+    [InlineData("code", "official")]
+    [InlineData("uri", "http://example.org")]
+    [InlineData("base64Binary", "SGVsbG8=")]
+    public void GivenIgnixaStringBackedPrimitive_WhenReadThroughTypedElementAdapter_ThenPassesThroughUnchanged(string instanceType, string text)
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = instanceType, Value = text };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Same(text, value);
+    }
+
+    [Fact]
+    public void GivenIgnixaNonStringPrimitives_WhenReadThroughTypedElementAdapter_ThenPassesThroughUnchanged()
+    {
+        // The two SDKs already agree on these, so they must not be disturbed.
+
+        // Arrange & Act & Assert
+        Assert.Equal(true, new TypedElementAdapter(new StubElement { InstanceType = "boolean", Value = true }).Value);
+        Assert.Equal(42, new TypedElementAdapter(new StubElement { InstanceType = "integer", Value = 42 }).Value);
+        Assert.Equal(1.5m, new TypedElementAdapter(new StubElement { InstanceType = "decimal", Value = 1.5m }).Value);
+    }
+
+    [Fact]
+    public void GivenUnparseableIgnixaDateTime_WhenReadThroughTypedElementAdapter_ThenReturnsRawTextWithoutThrowing()
+    {
+        // Firely's own PocoElementNode degrades this way, so navigation over a malformed
+        // resource stays possible instead of throwing mid-traversal.
+
+        // Arrange
+        var element = new StubElement { InstanceType = "dateTime", Value = "not-a-date" };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal("not-a-date", value);
+    }
+
+    [Fact]
+    public void GivenNullIgnixaValue_WhenReadThroughTypedElementAdapter_ThenReturnsNull()
+    {
+        // Arrange
+        var element = new StubElement { InstanceType = "dateTime", Value = null };
+
+        // Act & Assert
+        Assert.Null(new TypedElementAdapter(element).Value);
+    }
+
+    #endregion
+
+    #region Firely -> Ignixa
+
+    [Theory]
+    [InlineData("2013-01-01T11:22:33+10:00")]
+    [InlineData("2013")]
+    public void GivenFirelyDateTime_WhenReadThroughIgnixaElementAdapter_ThenReturnsWireFormatString(string text)
+    {
+        // Arrange
+        var element = new StubTypedElement { InstanceType = "dateTime", Value = P.DateTime.Parse(text) };
+
+        // Act
+        var value = new IgnixaElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(text, Assert.IsType<string>(value));
+    }
+
+    [Fact]
+    public void GivenFirelyDate_WhenReadThroughIgnixaElementAdapter_ThenReturnsWireFormatString()
+    {
+        // Arrange
+        var element = new StubTypedElement { InstanceType = "date", Value = P.Date.Parse("2013-01-01") };
+
+        // Act
+        var value = new IgnixaElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal("2013-01-01", Assert.IsType<string>(value));
+    }
+
+    [Fact]
+    public void GivenFirelyTime_WhenReadThroughIgnixaElementAdapter_ThenReturnsWireFormatString()
+    {
+        // Arrange
+        var element = new StubTypedElement { InstanceType = "time", Value = P.Time.Parse("11:22:33") };
+
+        // Act
+        var value = new IgnixaElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal("11:22:33", Assert.IsType<string>(value));
+    }
+
+    [Fact]
+    public void GivenFirelyNonTemporalPrimitives_WhenReadThroughIgnixaElementAdapter_ThenPassesThroughUnchanged()
+    {
+        // Arrange & Act & Assert
+        Assert.Equal("hello", new IgnixaElementAdapter(new StubTypedElement { InstanceType = "string", Value = "hello" }).Value);
+        Assert.Equal(true, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "boolean", Value = true }).Value);
+        Assert.Equal(42, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "integer", Value = 42 }).Value);
+        Assert.Equal(1.5m, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "decimal", Value = 1.5m }).Value);
+    }
+
+    #endregion
+
+    #region Round trip
+
+    [Theory]
+    [InlineData("dateTime", "2013-01-01T11:22:33+10:00")]
+    [InlineData("dateTime", "2013")]
+    [InlineData("date", "2013-01-01")]
+    [InlineData("time", "11:22:33")]
+    public void GivenIgnixaTemporal_WhenRoundTrippedThroughBothAdapters_ThenPrecisionIsPreserved(string instanceType, string text)
+    {
+        // Precision matters: a year-only dateTime must not be widened into a full timestamp.
+
+        // Arrange
+        var element = new StubElement { InstanceType = instanceType, Value = text };
+
+        // Act — deliberately re-wrap rather than relying on the unwrapping fast path.
+        var firelyValue = new TypedElementAdapter(element).Value;
+        var backToIgnixa = new IgnixaElementAdapter(new StubTypedElement { InstanceType = instanceType, Value = firelyValue }).Value;
+
+        // Assert
+        Assert.Equal(text, backToIgnixa);
+    }
+
+    #endregion
+
+    #region FHIRPath regression
+
+    [Fact]
+    public void GivenFirelyBackedElement_WhenComparingDatesInFhirPath_ThenYieldsBooleanRatherThanEmpty()
+    {
+        // This is the defect the translation exists to prevent. Ignixa's comparison helpers narrow
+        // their operands through a string/DateTime/DateTimeOffset switch; an untranslated Firely
+        // P.DateTime falls through to null, the comparison returns empty instead of a boolean, and
+        // FHIRPath's empty-propagation carries that all the way out without an error.
+
+        // Arrange
+        var birthDate = new StubTypedElement { Name = "birthDate", InstanceType = "date", Value = P.Date.Parse("1990-05-04") };
+        var patient = new StubTypedElement
+        {
+            Name = "Patient",
+            InstanceType = "Patient",
+            ChildElements = { birthDate },
+        };
+
+        var ast = new FhirPathParser().Parse("birthDate > @1980-01-01");
+
+        // Act
+        var results = new FhirPathEvaluator()
+            .Evaluate(new IgnixaElementAdapter(patient), ast)
+            .ToList();
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal(true, result.Value);
+    }
+
+    #endregion
+
+    #region Stubs
+
+    private sealed class StubElement : IElement
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public object? Value { get; init; }
+
+        public string InstanceType { get; init; } = string.Empty;
+
+        public string Location { get; init; } = string.Empty;
+
+        public IType? Type { get; init; }
+
+        public bool HasPrimitiveValue => Value != null;
+
+        public List<IElement> ChildElements { get; init; } = new();
+
+        public IReadOnlyList<IElement> Children(string? name = null) =>
+            name == null ? ChildElements : ChildElements.Where(c => c.Name == name).ToArray();
+
+        public T? Meta<T>()
+            where T : class => null;
+    }
+
+    private sealed class StubTypedElement : ITypedElement
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public object? Value { get; init; }
+
+        public string? InstanceType { get; init; }
+
+        public string Location { get; init; } = string.Empty;
+
+        public IElementDefinitionSummary? Definition { get; init; }
+
+        public List<ITypedElement> ChildElements { get; init; } = new();
+
+        public IEnumerable<ITypedElement> Children(string? name = null) =>
+            name == null ? ChildElements : ChildElements.Where(c => c.Name == name);
+
+        public T? Annotation<T>()
+            where T : class => null;
+    }
+
+    #endregion
+}

--- a/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
+++ b/test/Ignixa.Extensions.Tests/FirelySdk/FirelyPrimitiveValueContractTests.cs
@@ -115,8 +115,8 @@ public class FirelyPrimitiveValueContractTests
         // Act
         var value = new TypedElementAdapter(element).Value;
 
-        // Assert
-        Assert.Equal(text, value);
+        // Assert - reference equality, so a translation that rebuilt an equal string would fail.
+        Assert.Same(text, value);
     }
 
     [Fact]
@@ -142,6 +142,9 @@ public class FirelyPrimitiveValueContractTests
         // Degrading to the raw text keeps navigation over a malformed resource possible instead of
         // throwing mid-traversal. It is NOT a repair: the raw string reaches Firely exactly as it
         // did before this translation existed, so downstream behaviour on bad data is unchanged.
+        // Concretely, that behaviour is deferred and consumer-dependent - navigation, toString()
+        // and serialization see a plain string, while a consumer that coerces it to a temporal
+        // throws, reported as a type mismatch far from the element that is actually malformed.
         // Note " 12 " is rejected deliberately - FHIR's integer64 regex forbids surrounding
         // whitespace, which long.TryParse would otherwise accept under NumberStyles.Integer.
 
@@ -156,11 +159,11 @@ public class FirelyPrimitiveValueContractTests
     }
 
     [Theory]
-    [InlineData("DateTime", "2013-01-01T11:22:33+10:00")]
-    [InlineData("DATE", "2013-01-01")]
-    [InlineData("Time", "11:22:33")]
-    [InlineData("Integer64", "42")]
-    public void GivenInstanceTypeInUnexpectedCasing_WhenReadThroughTypedElementAdapter_ThenStillTranslates(string instanceType, string text)
+    [InlineData("DateTime", "2013-01-01T11:22:33+10:00", typeof(P.DateTime))]
+    [InlineData("DATE", "2013-01-01", typeof(P.Date))]
+    [InlineData("Time", "11:22:33", typeof(P.Time))]
+    [InlineData("Integer64", "42", typeof(long))]
+    public void GivenInstanceTypeInUnexpectedCasing_WhenReadThroughTypedElementAdapter_ThenStillTranslates(string instanceType, string text, Type expected)
     {
         // The FHIRPath evaluator lower-cases instanceType before dispatching on it, so a source
         // that reports non-canonical casing works there. Translation must not be the odd one out.
@@ -172,18 +175,20 @@ public class FirelyPrimitiveValueContractTests
         var value = new TypedElementAdapter(element).Value;
 
         // Assert
-        Assert.IsNotType<string>(value);
+        Assert.IsType(expected, value);
     }
 
     [Theory]
-    [InlineData("date", "2024-03-05")]
-    [InlineData("dateTime", "2024-03-05T13:45:30.123+10:00")]
-    [InlineData("time", "13:45:30.123")]
-    public void GivenIgnixaDateTimeOffsetValue_WhenReadThroughTypedElementAdapter_ThenTranslatesAtTheTypesOwnPrecision(string instanceType, string expected)
+    [InlineData("date", "2024-03-05", typeof(P.Date))]
+    [InlineData("dateTime", "2024-03-05T13:45:30.123+10:00", typeof(P.DateTime))]
+    [InlineData("time", "13:45:30.123", typeof(P.Time))]
+    public void GivenIgnixaDateTimeOffsetValue_WhenReadThroughTypedElementAdapter_ThenTranslatesAtTheTypesOwnPrecision(string instanceType, string expectedText, Type expectedType)
     {
         // IElement.Value permits DateTimeOffset as well as the wire string. Each FHIR type has to
         // land at its own precision: date drops the time and offset, time drops the offset, and
-        // only dateTime keeps both.
+        // only dateTime keeps both. The type is asserted as well as the text, because rendering
+        // the wire string and calling it done would satisfy the text alone - and that is precisely
+        // the pass-through this translation exists to replace.
 
         // Arrange
         var element = new StubElement
@@ -196,7 +201,8 @@ public class FirelyPrimitiveValueContractTests
         var value = new TypedElementAdapter(element).Value;
 
         // Assert
-        Assert.Equal(expected, value?.ToString());
+        Assert.IsType(expectedType, value);
+        Assert.Equal(expectedText, value?.ToString());
     }
 
     [Fact]
@@ -220,6 +226,45 @@ public class FirelyPrimitiveValueContractTests
         Assert.DoesNotContain("+", dateTime.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain("Z", dateTime.ToString(), StringComparison.Ordinal);
         Assert.StartsWith("2024-03-05T13:45:30", dateTime.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("007", 7L)]
+    [InlineData("+12", 12L)]
+    [InlineData("-0", 0L)]
+    public void GivenIgnixaInteger64WithNonCanonicalDigits_WhenReadThroughTypedElementAdapter_ThenParsesAndCanonicalises(string text, long expected)
+    {
+        // Pins a known, accepted consequence rather than desired behaviour. FHIR's integer64
+        // grammar is [0]|[-+]?[1-9][0-9]*, so "007" is invalid - but long.TryParse accepts it and
+        // canonicalises it to 7, erasing the invalid literal at this boundary. That matches how
+        // SchemaAwareElement already parses the narrower integer types, so the shim is consistent
+        // with the native path; catching it belongs in the validator, which reads the raw text.
+
+        // Arrange
+        var element = new StubElement { InstanceType = "integer64", Value = text };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(expected, Assert.IsType<long>(value));
+    }
+
+    [Fact]
+    public void GivenTranslatedTypeCarryingAnUnexpectedClrType_WhenReadThroughTypedElementAdapter_ThenPassesThroughUnchanged()
+    {
+        // Covers the per-helper fallthrough arms: the instanceType is one we translate, but the
+        // value is not a shape that type can be built from. Passing it through unchanged keeps
+        // this a translation rather than a coercion.
+
+        // Arrange
+        var element = new StubElement { InstanceType = "date", Value = 42 };
+
+        // Act
+        var value = new TypedElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(42, value);
     }
 
     [Fact]
@@ -285,6 +330,25 @@ public class FirelyPrimitiveValueContractTests
         Assert.Equal(true, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "boolean", Value = true }).Value);
         Assert.Equal(42, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "integer", Value = 42 }).Value);
         Assert.Equal(1.5m, new IgnixaElementAdapter(new StubTypedElement { InstanceType = "decimal", Value = 1.5m }).Value);
+    }
+
+    [Fact]
+    public void GivenFirelyInteger64_WhenReadThroughIgnixaElementAdapter_ThenStaysALongRatherThanBecomingAString()
+    {
+        // Pins the deliberate asymmetry: integer64 is translated in the Ignixa -> Firely direction
+        // only. Ignixa's evaluator treats long as a first-class numeric alongside int and decimal
+        // (FhirPathEvaluator.cs:1074-1075, :1317-1318), so "fixing" the asymmetry by stringifying
+        // here would silently downgrade numeric comparison to lexical - making 9 > 10 true.
+        // Without this test that change passes the whole suite.
+
+        // Arrange
+        var element = new StubTypedElement { InstanceType = "integer64", Value = 9007199254740993L };
+
+        // Act
+        var value = new IgnixaElementAdapter(element).Value;
+
+        // Assert
+        Assert.Equal(9007199254740993L, Assert.IsType<long>(value));
     }
 
     [Fact]
@@ -363,6 +427,7 @@ public class FirelyPrimitiveValueContractTests
         var backToIgnixa = new IgnixaElementAdapter(new StubTypedElement { InstanceType = instanceType, Value = firelyValue }).Value;
 
         // Assert
+        Assert.IsNotType<string>(firelyValue);
         Assert.Equal(expected, Assert.IsType<string>(backToIgnixa));
     }
 
@@ -448,6 +513,24 @@ public class FirelyPrimitiveValueContractTests
         // Arrange
         var element = new CountingStubElement { InstanceType = "dateTime", Value = null };
         var adapter = new TypedElementAdapter(element);
+
+        // Act
+        _ = adapter.Value;
+        _ = adapter.Value;
+
+        // Assert
+        Assert.Equal(1, element.ValueReadCount);
+    }
+
+    [Fact]
+    public void GivenNullValue_WhenReadRepeatedlyThroughIgnixaElementAdapter_ThenStillTranslatesOnlyOnce()
+    {
+        // The same guard as above, asserted independently: each adapter carries its own flag, so
+        // the null-sentinel bug is independently reintroducible in this one.
+
+        // Arrange
+        var element = new CountingStubTypedElement { InstanceType = "date", Value = null };
+        var adapter = new IgnixaElementAdapter(element);
 
         // Act
         _ = adapter.Value;


### PR DESCRIPTION
## Purpose

The two SDKs disagree on how a primitive value is represented:

| FHIR type | Firely `ITypedElement.Value` | Ignixa `IElement.Value` |
|---|---|---|
| `date` | `P.Date` | `string` (wire format) |
| `dateTime` / `instant` | `P.DateTime` | `string` (wire format) |
| `time` | `P.Time` | `string` (wire format) |
| `integer64` | `long` | `string` |
| `boolean`, `integer` family, `decimal`, string-backed types | — agree — | — agree — |

Both `IgnixaElementAdapter` and `TypedElementAdapter` passed `Value` straight through, so each handed the receiving engine a type it does not recognise.

That is not merely untidy. `FhirPathEvaluator`'s comparison helpers (`CompareDateTimeEquality`, `CompareDateTimesWithPrecision`) narrow their operands through a `string` / `DateTime` / `DateTimeOffset` switch that falls through to `null` for anything else. A Firely `P.DateTime` arriving via `IgnixaElementAdapter` therefore makes **every date comparison yield an empty collection instead of a boolean** — silently, and in a position where FHIRPath's empty-propagation carries it all the way out without an error. `GetFhirPathTypeName` misreports the same values as `"string"`.

This is on the critical path for [microsoft/fhir-server](https://github.com/microsoft/fhir-server)'s migration to the Ignixa FHIRPath engine, where the engine runs over Firely-backed POCOs and every temporal value crosses this boundary.

## Scope of change

- New internal `FirelyPrimitiveValues` helper with the two translation directions.
- `TypedElementAdapter.Value` translates Ignixa → Firely (keyed off `InstanceType`, since Ignixa carries temporals as strings).
- `IgnixaElementAdapter.Value` translates Firely → Ignixa (keyed off runtime type).
- `Ignixa.Extensions.FirelySdk5.csproj` links the new file.

Deliberately narrow: only the types where the two SDKs actually disagree are touched. Everything else passes through by reference.

## Risks

- **Behaviour change for existing consumers of these adapters.** In-repo the blast radius is contained — `Ignixa.Extensions.Tests` is the only project referencing them — but any downstream code that had compensated for the old pass-through (e.g. calling `.ToString()` on a `P.DateTime` itself) will now receive the translated value. That compensation is exactly what this change makes unnecessary.
- **Precision.** Temporals round-trip through `ToString()`, which preserves the originally-parsed string, so a year-only `dateTime` stays year-only rather than being widened. Covered by a round-trip test.
- **Malformed input.** An unparseable value is surfaced as its raw text rather than throwing, matching how Firely's own `PocoElementNode.ToITypedElementValue` degrades — navigation over a bad resource stays possible. Covered by a test.
- **Known remaining gap:** `P.Quantity`, `P.Ratio`, `P.Code`, and `P.Concept` are still passed through untranslated. I found no evidence they arise from resource primitive data (they come from `Any.TryParseToAny` on FHIRPath system types), so translating them speculatively felt worse than leaving them documented. Worth revisiting if a concrete case appears.

## Tests run

New `FirelyPrimitiveValueContractTests` (24 cases), including an end-to-end regression that evaluates `birthDate > @1980-01-01` through `FhirPathEvaluator` over a Firely-backed element and asserts a boolean rather than empty.

Verified the tests actually pin the behaviour: **12 of the 24 fail against the unmodified adapters**, including the end-to-end one.

- `dotnet test test/Ignixa.Extensions.Tests` — 113/113 passing on both `net9.0` and `net10.0`
- `dotnet build src/Core/Extensions/Ignixa.Extensions.FirelySdk5` — clean on both TFMs against Firely 5.13.1, confirming the shared source still compiles for SDK 5.x consumers (fhir-server is on 5.11.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
